### PR TITLE
Implement new fetch strategy and notify the client about completed fetchAll

### DIFF
--- a/client-js/src/client/firebase-client.js
+++ b/client-js/src/client/firebase-client.js
@@ -25,29 +25,39 @@
  */
 export class FirebaseClient {
 
-    /**
-     * Creates a new FirebaseClient.
-     *
-     * @param firebaseApp an initialized Firebase app
-     */
-    constructor(firebaseApp) {
-        this._firebaseApp = firebaseApp;
-    }
+  /**
+   * Creates a new FirebaseClient.
+   *
+   * @param firebaseApp an initialized Firebase app
+   */
+  constructor(firebaseApp) {
+    this._firebaseApp = firebaseApp;
+  }
 
-    /**
-     * Subscribes to the child_added events of of the node under the given path.
-     *
-     * Each child's value is parsed as a JSON and dispatched to the given callback
-     *
-     * @param path         the path to the watched node
-     * @param dataCallback the child value callback
-     */
-    subscribeTo(path, dataCallback) {
-        let dbRef = this._firebaseApp.database().ref(path);
-        dbRef.on("child_added", data => {
-            let msgJson = data.val();
-            let message = JSON.parse(msgJson);
-            dataCallback(message);
-        });
-    }
+  /**
+   * Subscribes to the child_added events of of the node under the given path.
+   *
+   * Each child's value is parsed as a JSON and dispatched to the given callback
+   *
+   * @param path         the path to the watched node
+   * @param dataCallback the child value callback
+   */
+  onChildAdded(path, dataCallback) {
+    const dbRef = this._firebaseApp.database().ref(path);
+    dbRef.on("child_added", response => {
+      const msgJson = response.val();
+      const message = JSON.parse(msgJson);
+      dataCallback(message);
+    });
+  }
+
+  getValue(path, dataCallback) {
+    const dbRef = this._firebaseApp.database().ref(path);
+    dbRef.once("value", response => {
+      const data = response.val(); // an Object mapping Firebase ids to objects is returned
+      const objectStrings = Object.values(data);
+      const items = objectStrings.map(item => JSON.parse(item));
+      dataCallback(items);
+    });
+  }
 }

--- a/client-js/src/client/observable.js
+++ b/client-js/src/client/observable.js
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2018, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ * @callback nextCallback
+ * @param {*} data
+ */
+
+/**
+ * @callback errorCallback
+ * @param {Object} error
+ */
+
+/**
+ * @callback completeCallback
+ */
+
+/**
+ * @callback observableInput
+ * @param {Observer} observer
+ */
+
+/**
+ * An abstract Observer class.
+ *
+ * It is passed new values from the Observable to its {@code #next(value)} method,
+ * errors to {@code #error(err)} method and a notification about Observable completion to its
+ * {@code complete()} method.
+ *
+ * This class defines an interface for documentation and code completion. In real code use
+ * a Javascript Object instead:
+ * <code>
+ *   observable.subscribe({
+ *     next(value) {...},
+ *     error(err) {...},
+ *     complete() {...} 
+ *   })
+ * </code>
+ *
+ */
+class Observer {
+  // noinspection JSMethodCanBeStatic
+  /**
+   * Invoked by the Observable when it retrieves a new value.
+   *
+   * @param value {*}
+   */
+  next(value) {
+    throw new Error("Unimplemented by an abstract Observer");
+  }
+
+  // noinspection JSMethodCanBeStatic
+  /**
+   * Invoked by the Observable an error occures while processing its values.
+   *
+   * @param err {Error}
+   */
+  error(err) {
+    throw new Error("Unimplemented by an abstract Observer");
+  }
+
+  // noinspection JSMethodCanBeStatic
+  /**
+   * Invoked by the Observable when its complete.
+   */
+  complete() {
+    throw new Error("Unimplemented by an abstract Observer");
+  }
+}
+
+/**
+ * An implementation of Observable pattern.
+ *
+ * An Observable represents a set of values over some period of time.
+ *
+ * An Observable accepts a single subscriber, supplying each new observed value to its
+ * {@code next(item)} method.
+ *
+ * When all of the possible values are observed an Observable call Observers
+ * {@code complete()} method.
+ *
+ * If an error occurres while processing any Observable value it calls the Observers
+ * {@code error(err)} method.
+ */
+export class Observable {
+
+  /**
+   * @param subscribe {observableInput}
+   */
+  constructor(subscribe) {
+    this._subscribe = subscribe;
+    this._subscriber = null;
+  }
+
+  /**
+   * Subscribes a provided Observable to observe new values.
+   *
+   * @param next {nextCallback}
+   * @param error? {errorCallback}
+   * @param complete? {completeCallback}
+   * @return {Subscription}
+   */
+  subscribe({next = undefined, error = undefined, complete = undefined}) {
+    if (this._subscriber) {
+      throw new Error("This observable already has a subscriber.")
+    }
+
+    this._subscriber = Subscriber.fromObservable(next, error, complete);
+
+    try {
+      this._subscribe({
+        next: data => this._subscriber.next(data),
+        error: err => this._subscriber.error(err),
+        complete: () => this._subscriber.complete(),
+      });
+    } catch (err) {
+      this._subscriber.error(err);
+    }
+
+    return new Subscription(() => {
+      this._subscriber.unsubscribe();
+    });
+  }
+}
+
+/**
+ * A no-operation function that accepts any arguments, return undefined and does nothing.
+ * @private
+ */
+function _noop() {
+  // Does nothing.
+}
+
+/**
+ * A subscription returned by the Observable allowing to unsubscribe the Observer from receiving
+ * new values.
+ */
+export class Subscription {
+
+  constructor(unsubscribe) {
+    this._unsubscribe = unsubscribe;
+  }
+
+  /**
+   * Unsubscribes the Observer from Observable stopping it from receiving new values.
+   */
+  unsubscribe() {
+    this._unsubscribe();
+  }
+}
+
+/**
+ * An Observable Subscriber sending off received values, errors and complete notifications to the
+ * observer.
+ */
+class Subscriber {
+
+  constructor(destination) {
+    this.destination = destination;
+  }
+
+  /**
+   * Sends off the next Observable value to the Observer, skipping it if the Observable was
+   * unsubscribed or the Observer was complete.
+   * @param value {*} a next value for the Observer
+   */
+  next(value) {
+    if (!this.isStopped) {
+      this.destination.next(value);
+    }
+  }
+
+  /**
+   * Sends off an error to the Observer, stopping it from receiving further values.
+   * @param err {Error} an error to be passed to the Observer
+   */
+  error(err) {
+    if (!this.isStopped) {
+      this.isStopped = true;
+      this.destination.error(err);
+      this.unsubscribe();
+    }
+  }
+
+  /**
+   * Sends off a complete notification to the Observer, stopping it from receiving further values.
+   */
+  complete() {
+    if (!this.isStopped) {
+      this.isStopped = true;
+      this.destination.complete();
+      this.unsubscribe();
+    }
+  }
+
+  /**
+   * Stops the Subscriber from sending new messages to the Observer.
+   */
+  unsubscribe() {
+    this.isStopped = true;
+  }
+
+  /**
+   * Creates a new Subscriber from a provided Observer, supplying it with default next, error
+   * and complete method implementations.
+   *
+   * {@code next} and {@code complete} use no-op as a default, while the {@code error} is logging
+   * the values to the console.
+   *
+   * @param next
+   * @param error
+   * @param complete
+   * @return {Subscriber}
+   */
+  static fromObservable(next, error, complete) {
+    let _next = next;
+    if (_next === undefined) {
+      _next = _noop;
+    }
+    let _error = error;
+    if (_error === undefined) {
+      _error = _consoleErrorHandler;
+    }
+    let _complete = complete;
+    if (_complete === undefined) {
+      _complete = _noop;
+    }
+
+    const observer = {next: _next, error: _error, complete: _complete};
+
+    return new Subscriber(observer);
+  }
+}
+
+/**
+ * A default error handler used by Observable, logging the error to console.
+ * @private
+ */
+function _consoleErrorHandler(error) {
+  console.error(error);
+}

--- a/client-js/test/client/client-test.js
+++ b/client-js/test/client/client-test.js
@@ -52,9 +52,9 @@ describe("Client should", function () {
         assert.equal(data.name, command.message.getName());
         assert.equal(data.description, command.message.getDescription());
         done();
-      }, done);
+      }, fail(done));
 
-    }, fail, fail);
+    }, fail(done), fail(done));
   });
 
   it("fetch all the existing entities of given type one by one", done => {
@@ -63,19 +63,23 @@ describe("Client should", function () {
 
     backendClient.sendCommand(command, function () {
 
+      let itemFound = false;
       const type = new TypeUrl("type.spine.io/spine.web.test.Task");
+
       backendClient.fetchAll({ofType: type}).oneByOne().subscribe({
         next(data) {
           // Ordering is not guaranteed by fetch and 
           // the list of entities cannot be cleaned for tests,
           // thus at least one of entities should match the target one.
-          if (data.id.value === productId.getValue()) {
-            done();
-          }
+          itemFound = data.id.value === productId.getValue() || itemFound;
+        },
+        error: fail(done),
+        complete() {
+          done();
         }
       });
 
-    }, fail, fail);
+    }, fail(done), fail(done));
   });
 
   it("fetch all the existing entities of given type at once", done => {
@@ -90,9 +94,9 @@ describe("Client should", function () {
           const targetObject = data.find(item => item.id.value === productId.getValue());
           assert.ok(targetObject);
           done();
-        });
+        }, fail(done));
 
-    }, fail, fail);
+    }, fail(done), fail(done));
   });
 });
 
@@ -135,4 +139,10 @@ function newRequestFactory() {
   return new ActorRequestFactory("web-test-actor");
 }
 
-const fail = () => assert.ok(false);
+function fail(done) {
+  return error => {
+    console.error(error);
+    assert.ok(false);
+    done();
+  };
+}

--- a/client-js/test/client/client-test.js
+++ b/client-js/test/client/client-test.js
@@ -135,4 +135,4 @@ function newRequestFactory() {
   return new ActorRequestFactory("web-test-actor");
 }
 
-const fail = () => assert.notOk(true);
+const fail = () => assert.ok(false);

--- a/client-js/test/client/observable-test.js
+++ b/client-js/test/client/observable-test.js
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2018, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// noinspection NodeJsCodingAssistanceForCoreModules
+import assert from "assert";
+
+import {Observable} from "../../src/client/observable";
+
+const MILLISECONDS = 1;
+const SECONDS = 1000 * MILLISECONDS;
+
+describe("Observable should", function () {
+
+  this.timeout(5 * SECONDS);
+
+  it("send next values to the observer", done => {
+    const observable = new Observable(observer => {
+      observer.next(1);
+      observer.next(2);
+      setTimeout(() => {
+        observer.next(3);
+        observer.complete();
+      });
+    });
+
+    const retrievedValues = [];
+    observable.subscribe({
+      next(value) {
+        retrievedValues.push(value);
+      },
+      complete() {
+        assert.equal(retrievedValues.length, 3);
+        assert.equal(retrievedValues[0], 1);
+        assert.equal(retrievedValues[1], 2);
+        assert.equal(retrievedValues[2], 3);
+        done();
+      }
+    })
+  });
+
+  it("send an error to the observer", done => {
+    const expectedError = new Error("An observable error.");
+    const observable = new Observable(observer => {
+      observer.next(1);
+      setTimeout(() => {
+        observer.next(2);
+      });
+      throw expectedError;
+    });
+
+    const retrievedValues = [];
+    observable.subscribe({
+      next(value) {
+        retrievedValues.push(value);
+      },
+      error(error) {
+        assert.ok(retrievedValues.length === 1);
+        assert.ok(retrievedValues[0] === 1);
+        assert.ok(error === expectedError);
+        done();
+      }
+    })
+  });
+});

--- a/firebase-web/src/main/java/io/spine/web/firebase/FirebaseQueryBridge.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/FirebaseQueryBridge.java
@@ -121,12 +121,6 @@ public final class FirebaseQueryBridge implements QueryBridge {
         private Builder() {
         }
 
-        public Builder setQueryService(QueryServiceBlockingStub service) {
-            checkNotNull(service);
-            this.queryService = AsyncQueryService.remote(service);
-            return this;
-        }
-
         public Builder setQueryService(QueryServiceImplBase service) {
             checkNotNull(service);
             this.queryService = AsyncQueryService.local(service);

--- a/firebase-web/src/main/java/io/spine/web/firebase/FirebaseQueryBridge.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/FirebaseQueryBridge.java
@@ -88,7 +88,8 @@ public final class FirebaseQueryBridge implements QueryBridge {
             record.storeTo(database);
         }
 
-        final QueryProcessingResult result = new FirebaseQueryProcessingResult(record.path());
+        final QueryProcessingResult result = 
+                new FirebaseQueryProcessingResult(record.path(), record.getCount());
         return result;
     }
 

--- a/firebase-web/src/main/java/io/spine/web/firebase/FirebaseQueryBridge.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/FirebaseQueryBridge.java
@@ -127,7 +127,7 @@ public final class FirebaseQueryBridge implements QueryBridge {
             return this;
         }
 
-        public Builder serQueryService(QueryServiceImplBase service) {
+        public Builder setQueryService(QueryServiceImplBase service) {
             checkNotNull(service);
             this.queryService = AsyncQueryService.local(service);
             return this;

--- a/firebase-web/src/main/java/io/spine/web/firebase/FirebaseQueryProcessingResult.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/FirebaseQueryProcessingResult.java
@@ -25,6 +25,8 @@ import io.spine.web.QueryProcessingResult;
 import javax.servlet.ServletResponse;
 import java.io.IOException;
 
+import static java.lang.String.format;
+
 /**
  * A result of a query processed by a {@link FirebaseQueryBridge}.
  *
@@ -35,12 +37,15 @@ import java.io.IOException;
  */
 final class FirebaseQueryProcessingResult implements QueryProcessingResult {
 
-    private static final String MIME_TYPE = "text/plain";
+    @SuppressWarnings("DuplicateStringLiteralInspection") // The duplication is a coincidence.
+    private static final String MIME_TYPE = "application/json";
 
     private final FirebaseDatabasePath path;
+    private final long count;
 
-    FirebaseQueryProcessingResult(FirebaseDatabasePath path) {
+    FirebaseQueryProcessingResult(FirebaseDatabasePath path, long count) {
         this.path = path;
+        this.count = count;
     }
 
     /**
@@ -49,7 +54,8 @@ final class FirebaseQueryProcessingResult implements QueryProcessingResult {
     @Override
     public void writeTo(ServletResponse response) throws IOException {
         final String databaseUrl = path.toString();
-        response.getWriter().append(databaseUrl);
+        response.getWriter().append(format("{\"path\": \"%s\", \"count\": %s}",
+                                           databaseUrl, count));
         response.setContentType(MIME_TYPE);
     }
 

--- a/firebase-web/src/main/java/io/spine/web/firebase/FirebaseRecord.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/FirebaseRecord.java
@@ -97,7 +97,7 @@ final class FirebaseRecord {
      * <p>Suitable for big queries, spanning thousands and millions of items.
      */
     private void flushTo(DatabaseReference reference) {
-        queryResponse.thenAccept(
+        queryResponse.thenAcceptAsync(
                 response -> mapMessagesToJson(response).map(json -> addTo(reference, json))
                                                        .forEach(this::mute)
         );

--- a/firebase-web/src/test/java/io/spine/web/firebase/FirebaseQueryBridgeTest.java
+++ b/firebase-web/src/test/java/io/spine/web/firebase/FirebaseQueryBridgeTest.java
@@ -81,7 +81,7 @@ class FirebaseQueryBridgeTest {
     void testMediate() {
         final TestQueryService queryService = new TestQueryService();
         final FirebaseQueryBridge bridge = FirebaseQueryBridge.newBuilder()
-                                                              .serQueryService(queryService)
+                                                              .setQueryService(queryService)
                                                               .setDatabase(firebaseDatabase)
                                                               .build();
         final Query query = queryFactory.all(Empty.class);
@@ -98,7 +98,7 @@ class FirebaseQueryBridgeTest {
         final Message dataElement = Time.getCurrentTime();
         final TestQueryService queryService = new TestQueryService(dataElement);
         final FirebaseQueryBridge bridge = FirebaseQueryBridge.newBuilder()
-                                                              .serQueryService(queryService)
+                                                              .setQueryService(queryService)
                                                               .setDatabase(firebaseDatabase)
                                                               .build();
         final Query query = queryFactory.all(Timestamp.class);
@@ -121,7 +121,7 @@ class FirebaseQueryBridgeTest {
         final long awaitSeconds = 1L;
         final FirebaseQueryBridge bridge =
                 FirebaseQueryBridge.newBuilder()
-                                   .serQueryService(queryService)
+                                   .setQueryService(queryService)
                                    .setDatabase(firebaseDatabase)
                                    .setWriteAwaitSeconds(awaitSeconds)
                                    .build();
@@ -135,7 +135,7 @@ class FirebaseQueryBridgeTest {
     void testTransactionalQuery() {
         TestQueryService queryService = new TestQueryService(Empty.getDefaultInstance());
         FirebaseQueryBridge bridge = FirebaseQueryBridge.newBuilder()
-                                                        .serQueryService(queryService)
+                                                        .setQueryService(queryService)
                                                         .setDatabase(firebaseDatabase)
                                                         .build();
         bridge.send(transactionalQuery(queryFactory.all(Empty.class)));
@@ -150,7 +150,7 @@ class FirebaseQueryBridgeTest {
     void testNonTransactionalQuery() {
         TestQueryService queryService = new TestQueryService(Empty.getDefaultInstance());
         FirebaseQueryBridge bridge = FirebaseQueryBridge.newBuilder()
-                                                        .serQueryService(queryService)
+                                                        .setQueryService(queryService)
                                                         .setDatabase(firebaseDatabase)
                                                         .build();
         bridge.send(nonTransactionalQuery(queryFactory.all(Empty.class)));

--- a/firebase-web/src/test/java/io/spine/web/firebase/FirebaseQueryBridgeTest.java
+++ b/firebase-web/src/test/java/io/spine/web/firebase/FirebaseQueryBridgeTest.java
@@ -51,6 +51,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -62,6 +63,7 @@ class FirebaseQueryBridgeTest {
 
     private static final QueryFactory queryFactory =
             TestActorRequestFactory.newInstance(FirebaseQueryBridgeTest.class).query();
+    private static final int ONE_SECOND = 1000 /* ms */;
 
     private FirebaseDatabase firebaseDatabase;
     private DatabaseReference pathReference;
@@ -106,7 +108,7 @@ class FirebaseQueryBridgeTest {
 
         final String dbPath = result.toString();
         verify(firebaseDatabase).getReference(eq(dbPath));
-        verify(pathReference).push();
+        verify(pathReference, timeout(ONE_SECOND)).push();
         verify(childReference).setValueAsync(eq(Json.toCompactJson(dataElement)));
     }
 
@@ -155,7 +157,7 @@ class FirebaseQueryBridgeTest {
                                                         .build();
         bridge.send(nonTransactionalQuery(queryFactory.all(Empty.class)));
 
-        verify(childReference).setValueAsync(eq("{}"));
+        verify(childReference, timeout(ONE_SECOND)).setValueAsync(eq("{}"));
         verify(pathReference, never()).setValueAsync(any(Object.class));
     }
 

--- a/firebase-web/src/test/java/io/spine/web/firebase/FirebaseQueryProcessingResultTest.java
+++ b/firebase-web/src/test/java/io/spine/web/firebase/FirebaseQueryProcessingResultTest.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
+import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -63,17 +64,27 @@ class FirebaseQueryProcessingResultTest {
         final PrintWriter writer = new PrintWriter(stringWriter);
         when(response.getWriter()).thenReturn(writer);
 
-        final FirebaseQueryProcessingResult queryResult = new FirebaseQueryProcessingResult(databasePath);
+        int count = 2;
+        final FirebaseQueryProcessingResult queryResult = 
+                new FirebaseQueryProcessingResult(databasePath, count);
         queryResult.writeTo(response);
         verify(response).getWriter();
 
-        assertEquals(databasePath.toString(), stringWriter.toString());
+        String expected = queryProcessingResult(databasePath, count);
+        assertEquals(expected, stringWriter.toString());
     }
 
     @Test
     @DisplayName("provide a comprehensible string representation")
     void test_toString() {
-        final FirebaseQueryProcessingResult queryResult = new FirebaseQueryProcessingResult(databasePath);
-        assertEquals(databasePath.toString(), queryResult.toString());
+        int count = 0;
+        final FirebaseQueryProcessingResult queryResult = 
+                new FirebaseQueryProcessingResult(databasePath, count);
+        String expected = queryProcessingResult(databasePath, count);
+        assertEquals(expected, queryResult.toString());
+    }
+
+    private static String queryProcessingResult(FirebaseDatabasePath databasePath, int count) {
+        return format("{\"path\": \"%s\", \"count\": %s}", databasePath.toString(), count);
     }
 }

--- a/integration-tests/web-tests/src/main/java/io/spine/web/test/TestQueryServlet.java
+++ b/integration-tests/web-tests/src/main/java/io/spine/web/test/TestQueryServlet.java
@@ -36,7 +36,7 @@ public class TestQueryServlet extends FirebaseQueryServlet {
 
     public TestQueryServlet() {
         super(FirebaseQueryBridge.newBuilder()
-                                 .serQueryService(Server.application().getQueryService())
+                                 .setQueryService(Server.application().getQueryService())
                                  .setDatabase(FirebaseClient.database())
                                  .build());
     }

--- a/web/src/main/java/io/spine/web/WebQuery.java
+++ b/web/src/main/java/io/spine/web/WebQuery.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.web;
+
+import io.spine.client.Query;
+
+/**
+ * A query received from Spines JS client.
+ *
+ * <p>Complements the {@link Query Query} sent to Spine specifying one of two query strategies:
+ * <ol>
+ *    <li>A non-transactional supplying items to destination one at a time.
+ *    <li>A transactional strategy supplying items to destination in one batch.  
+ * </ol>
+ *
+ * @author Mykhailo Drachuk
+ */
+public class WebQuery {
+
+    private final Query query;
+    private final boolean isDeliveredTransactionally;
+
+    private WebQuery(Query query, boolean transactional) {
+        this.query = query;
+        this.isDeliveredTransactionally = transactional;
+    }
+
+    /**
+     * @return a query to be sent to Spine
+     */
+    public Query getQuery() {
+        return query;
+    }
+
+    /**
+     * Specifies if the {@code Query} results should be delivered to client transactionally
+     * (in a single batch).
+     *
+     * @return {@code true} if the query results should be delivered in one batch,
+     *         {@code false} otherwise.
+     */
+    public boolean isDeliveredTransactionally() {
+        return isDeliveredTransactionally;
+    }
+
+    /**
+     * Builds a new {@code WebQuery} that should be delivered to client in a single batch.
+     *
+     * @param query the {@code Query} to be executed
+     * @return a new {@link WebQuery WebQuery} instance
+     */
+    public static WebQuery transactionalQuery(Query query) {
+        return new WebQuery(query, true);
+    }
+
+    /**
+     * Builds a new {@code WebQuery} results from which can be sent to a client one by one.
+     *
+     * @param query the {@code Query} to be executed
+     * @return a new {@link WebQuery WebQuery} instance
+     */
+    public static WebQuery nonTransactionalQuery(Query query) {
+        return new WebQuery(query, false);
+    }
+}

--- a/web/src/test/java/io/spine/web/QueryServletTest.java
+++ b/web/src/test/java/io/spine/web/QueryServletTest.java
@@ -20,6 +20,7 @@
 
 package io.spine.web;
 
+import com.google.protobuf.Empty;
 import com.google.protobuf.Timestamp;
 import io.spine.base.Time;
 import io.spine.client.Query;
@@ -29,18 +30,27 @@ import io.spine.testing.client.TestActorRequestFactory;
 import io.spine.web.given.QueryServletTestEnv.TestQueryServlet;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.io.StringWriter;
 
+import static io.spine.web.given.QueryServletTestEnv.TRANSACTIONAL_PARAMETER;
 import static io.spine.web.given.Servlets.request;
 import static io.spine.web.given.Servlets.response;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Dmytro Dashenkov
@@ -70,6 +80,63 @@ class QueryServletTest {
         servlet.doPost(request(query), response(response));
         final Timestamp actualData = Json.fromJson(response.toString(), Timestamp.class);
         assertEquals(expectedData, actualData);
+    }
+
+    @Test
+    @DisplayName("mark query as transactional if query parameter is true")
+    void testTransactionalParameterTrue() throws IOException {
+        QueryBridge bridge = mock(QueryBridge.class);
+
+        QueryServlet servlet = new TestQueryServlet(bridge);
+
+        HttpServletRequest request = request(queryFactory.all(Empty.class));
+        when(request.getParameter(TRANSACTIONAL_PARAMETER)).thenReturn("true");
+
+        when(bridge.send(any(WebQuery.class))).thenReturn(mock(QueryProcessingResult.class));
+        servlet.doPost(request, response(new StringWriter()));
+
+        ArgumentCaptor<WebQuery> captor = forClass(WebQuery.class);
+        verify(bridge).send(captor.capture());
+        assertTrue(captor.getValue()
+                         .isDeliveredTransactionally());
+    }
+
+    @Test
+    @DisplayName("mark query as non-transactional if query parameter is false")
+    void testTransactionalParameterFalse() throws IOException {
+        QueryBridge bridge = mock(QueryBridge.class);
+
+        QueryServlet servlet = new TestQueryServlet(bridge);
+
+        HttpServletRequest request = request(queryFactory.all(Empty.class));
+        when(request.getParameter(TRANSACTIONAL_PARAMETER)).thenReturn("false");
+
+        when(bridge.send(any(WebQuery.class))).thenReturn(mock(QueryProcessingResult.class));
+        servlet.doPost(request, response(new StringWriter()));
+
+        ArgumentCaptor<WebQuery> captor = forClass(WebQuery.class);
+        verify(bridge).send(captor.capture());
+        assertFalse(captor.getValue()
+                          .isDeliveredTransactionally());
+    }
+
+    @Test
+    @DisplayName("mark query as non-transactional by default")
+    void testTransactionalParameterFalseByDefault() throws IOException {
+        QueryBridge bridge = mock(QueryBridge.class);
+
+        QueryServlet servlet = new TestQueryServlet(bridge);
+
+        HttpServletRequest request = request(queryFactory.all(Empty.class));
+        when(request.getParameter(TRANSACTIONAL_PARAMETER)).thenReturn(null);
+
+        when(bridge.send(any(WebQuery.class))).thenReturn(mock(QueryProcessingResult.class));
+        servlet.doPost(request, response(new StringWriter()));
+
+        ArgumentCaptor<WebQuery> captor = forClass(WebQuery.class);
+        verify(bridge).send(captor.capture());
+        assertFalse(captor.getValue()
+                          .isDeliveredTransactionally());
     }
 
     @Test

--- a/web/src/test/java/io/spine/web/WebQueryTest.java
+++ b/web/src/test/java/io/spine/web/WebQueryTest.java
@@ -21,30 +21,32 @@
 package io.spine.web;
 
 import io.spine.client.Query;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static io.spine.web.WebQuery.nonTransactionalQuery;
+import static io.spine.web.WebQuery.transactionalQuery;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * An {@linkplain io.spine.client.Query entity query} bridge.
- *
- * <p>Connects the {@link io.spine.server.QueryService QueryService} with a query response
- * processor. Typically, the query response processor is the channel which sends the query response
- * to the client.
- *
- * <p>No constrains are applied to the contents of the query. Neither any guaranties are made for
- * the query result. Refer to the concrete implementations to find out the details of their
- * behaviour.
- *
- * @author Dmytro Dashenkov
+ * @author Mykhailo Drachuk
  */
-public interface QueryBridge {
+@DisplayName("WebQuery should")
+class WebQueryTest {
 
-    /**
-     * Sends the given {@link Query} to the {@link io.spine.server.QueryService QueryService} and
-     * dispatches the query response to the query response processor.
-     *
-     * <p>Returns the result of query processing.
-     *
-     * @param query the query to send
-     * @return the query result
-     */
-    QueryProcessingResult send(WebQuery query);
+    @Test
+    @DisplayName("contain false transactional delivery value using nonTransactionalQuery static factory method")
+    void testNonTransactionalFactory() {
+        WebQuery query = nonTransactionalQuery(Query.getDefaultInstance());
+        assertFalse(query.isDeliveredTransactionally());
+    }
+
+    @Test
+    @DisplayName("contain true transactional delivery value using transactionalQuery static factory method ")
+    void testTransactionalFactory() {
+        WebQuery query = transactionalQuery(Query.getDefaultInstance());
+        assertTrue(query.isDeliveredTransactionally());
+    }
+
 }

--- a/web/src/test/java/io/spine/web/given/QueryServletTestEnv.java
+++ b/web/src/test/java/io/spine/web/given/QueryServletTestEnv.java
@@ -22,11 +22,11 @@ package io.spine.web.given;
 
 import com.google.protobuf.Empty;
 import com.google.protobuf.Message;
-import io.spine.client.Query;
 import io.spine.json.Json;
 import io.spine.web.QueryBridge;
 import io.spine.web.QueryProcessingResult;
 import io.spine.web.QueryServlet;
+import io.spine.web.WebQuery;
 
 import javax.annotation.Nonnull;
 import javax.servlet.ServletResponse;
@@ -37,6 +37,16 @@ import java.io.IOException;
  */
 public final class QueryServletTestEnv {
 
+    // This duplication verifies that the parameter was not changed in production code by accident.
+    @SuppressWarnings("DuplicateStringLiteralInspection") 
+    public static final String TRANSACTIONAL_PARAMETER = "transactional";
+
+    /**
+     * A private constructor stopping this utility class from instantiation.
+     */
+    private QueryServletTestEnv() {
+    }
+
     @SuppressWarnings("serial")
     public static final class TestQueryServlet extends QueryServlet {
 
@@ -45,7 +55,11 @@ public final class QueryServletTestEnv {
         }
 
         public TestQueryServlet(Message expectedMessage) {
-            super(new TestQueryBridge(expectedMessage));
+            this(new TestQueryBridge(expectedMessage));
+        }
+
+        public TestQueryServlet(QueryBridge bridge) {
+            super(bridge);
         }
     }
 
@@ -58,7 +72,7 @@ public final class QueryServletTestEnv {
         }
 
         @Override
-        public QueryProcessingResult send(@Nonnull Query query) {
+        public QueryProcessingResult send(@Nonnull WebQuery query) {
             return new TestQueryProcessingResult(response);
         }
     }
@@ -73,7 +87,8 @@ public final class QueryServletTestEnv {
 
         @Override
         public void writeTo(@Nonnull ServletResponse response) throws IOException {
-            response.getWriter().append(Json.toJson(message));
+            response.getWriter()
+                    .append(Json.toJson(message));
         }
     }
 }


### PR DESCRIPTION
This PR addresses an issue https://github.com/SpineEventEngine/web/issues/2. The new client API looks as follows:
```
// Fetch items one-by-one using an Observable.
// Suitable for big collections.
fetchAll({ofType: taskType}).oneByOne().subscribe({
  next(value) { ... },
  error(error) { ... },
  complete() { ... }
})
```
and
```
// Fetch all items at once using a Promise.
fetchAll({ofType: taskType}).atOnce().then(data => { ... })
```