### PR TITLE
Set a proper Spine group

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,7 @@ allprojects {
 
     // Use the same version numbering for the Spine Base library.
     version = versionToPublish
+    group = 'io.spine'
 }
 
 subprojects {

--- a/ext.gradle
+++ b/ext.gradle
@@ -18,11 +18,11 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-final def SPINE_VERSION = '0.10.75-SNAPSHOT'
+final def SPINE_VERSION = '0.10.77-SNAPSHOT'
 
 ext {
     spineVersion = SPINE_VERSION
-    spineBaseVersion = '0.10.63-SNAPSHOT'
+    spineBaseVersion = '0.10.66-SNAPSHOT'
 
     // Publish artifacts of this project with the same version number as Base.
     versionToPublish = spineBaseVersion


### PR DESCRIPTION
Previously, a Spine group was mistakenly removed from the build. As a consequence two `web` versions ended up having an improper group in Maven. 

This PR fixes the issue and bumps the Spine version.