### PR TITLE
Introduce a Protobuf message for the query response

### DIFF
--- a/client-js-proto/build.gradle
+++ b/client-js-proto/build.gradle
@@ -22,6 +22,7 @@ apply plugin: 'com.google.protobuf'
 
 dependencies {
     protobuf project(':web')
+    protobuf project(':firebase-web')
     protobuf group: 'io.spine', name: 'spine-client', version: spineVersion, classifier: 'proto'
 
     testProtobuf project(':web-tests')

--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@ ext {
     spineBaseVersion = '0.10.66-SNAPSHOT'
 
     // Publish artifacts of this project with the same version number as Base.
-    versionToPublish = spineBaseVersion
+    versionToPublish = '0.10.67-SNAPSHOT'
 
     firebaseVersion = '5.9.0'
     servletApiVersion = '4.0.0'

--- a/firebase-web/build.gradle
+++ b/firebase-web/build.gradle
@@ -18,6 +18,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+configurations {
+    // Avoid collisions of Java classes defined both in `protobuf-lite` and `protobuf-java`
+    runtime.exclude group: "com.google.protobuf", module: "protobuf-lite"
+    testRuntime.exclude group: "com.google.protobuf", module: "protobuf-lite"
+}
+
+apply plugin: spineProtobufPluginId
+
 dependencies {
     api project(':web')
     api ("com.google.firebase:firebase-admin:$firebaseVersion") {
@@ -25,4 +33,30 @@ dependencies {
     }
 
     implementation "io.spine:spine-client:$spineVersion"
+}
+
+modelCompiler {
+    generateValidatingBuilders = true
+}
+
+task compileProtoToJs {
+    description = "Compiles Protobuf sources into JavaScript."
+}
+
+protobuf {
+    protoc {
+        artifact = deps.build.protoc
+    }
+    generateProtoTasks {
+        all().each { final task ->
+            task.builtins {
+                // For information on JavaScript code generation please see
+                // https://github.com/google/protobuf/blob/master/js/README.md
+                js {
+                    option "import_style=commonjs"
+                }
+            }
+            compileProtoToJs.dependsOn task
+        }
+    }
 }

--- a/firebase-web/src/main/java/io/spine/web/firebase/FirebaseDatabasePath.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/FirebaseDatabasePath.java
@@ -62,15 +62,15 @@ final class FirebaseDatabasePath {
      * @return new {@code FirebaseDatabasePath}
      */
     static FirebaseDatabasePath allocateForQuery(Query query) {
-        final String path = constructPath(query);
+        String path = constructPath(query);
         return new FirebaseDatabasePath(path);
     }
 
     private static String constructPath(Query query) {
-        final String tenantId = tenantIdAsString(query);
-        final String actor = actorAsString(query);
-        final String queryId = queryIdAsString(query);
-        final Collection<String> pathElements = newArrayList();
+        String tenantId = tenantIdAsString(query);
+        String actor = actorAsString(query);
+        String queryId = queryIdAsString(query);
+        Collection<String> pathElements = newArrayList();
         if (!tenantId.isEmpty()) {
             pathElements.add(escaped(tenantId));
         }
@@ -80,15 +80,15 @@ final class FirebaseDatabasePath {
         if (!queryId.isEmpty()) {
             pathElements.add(escaped(queryId));
         }
-        final String path = Joiner.on(PATH_DELIMITER)
+        String path = Joiner.on(PATH_DELIMITER)
                                   .join(pathElements);
         return path;
     }
 
     @SuppressWarnings("UnnecessaryDefault")
     private static String tenantIdAsString(Query query) {
-        final TenantId tenantId = query.getContext().getTenantId();
-        final TenantId.KindCase kind = tenantId.getKindCase();
+        TenantId tenantId = query.getContext().getTenantId();
+        TenantId.KindCase kind = tenantId.getKindCase();
         switch (kind) {
             case EMAIL:
                 return tenantId.getEmail().getValue();
@@ -103,14 +103,14 @@ final class FirebaseDatabasePath {
     }
 
     private static String actorAsString(Query query) {
-        final UserId actor = query.getContext().getActor();
-        final String result = actor.getValue();
+        UserId actor = query.getContext().getActor();
+        String result = actor.getValue();
         return result;
     }
 
     private static String queryIdAsString(Query query) {
-        final QueryId queryId = query.getId();
-        final String result = queryId.getValue();
+        QueryId queryId = query.getId();
+        String result = queryId.getValue();
         return result;
     }
 

--- a/firebase-web/src/main/java/io/spine/web/firebase/FirebaseQueryBridge.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/FirebaseQueryBridge.java
@@ -87,7 +87,7 @@ public final class FirebaseQueryBridge implements QueryBridge {
             record.storeTo(database);
         }
 
-        final QueryProcessingResult result = 
+        QueryProcessingResult result =
                 new FirebaseQueryProcessingResult(record.path(), record.getCount());
         return result;
     }

--- a/firebase-web/src/main/java/io/spine/web/firebase/FirebaseQueryProcessingResult.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/FirebaseQueryProcessingResult.java
@@ -26,7 +26,7 @@ import javax.servlet.ServletResponse;
 import java.io.IOException;
 
 import static com.google.common.net.MediaType.JSON_UTF_8;
-import static java.lang.String.format;
+import static io.spine.json.Json.toCompactJson;
 
 /**
  * A result of a query processed by a {@link FirebaseQueryBridge}.
@@ -53,9 +53,11 @@ final class FirebaseQueryProcessingResult implements QueryProcessingResult {
      */
     @Override
     public void writeTo(ServletResponse response) throws IOException {
-        final String databaseUrl = path.toString();
-        response.getWriter().append(format("{\"path\": \"%s\", \"count\": %s}",
-                                           databaseUrl, count));
+        FirebaseQueryResponse queryResponse = FirebaseQueryResponseVBuilder.newBuilder()
+                                                                           .setPath(path.toString())
+                                                                           .setCount(count)
+                                                                           .build();
+        response.getWriter().append(toCompactJson(queryResponse));
         response.setContentType(JSON_MIME_TYPE);
     }
 }

--- a/firebase-web/src/main/proto/spine/web/firebase/firebase_query_response.proto
+++ b/firebase-web/src/main/proto/spine/web/firebase/firebase_query_response.proto
@@ -1,0 +1,40 @@
+//
+// Copyright 2018, TeamDev. All rights reserved.
+//
+// Redistribution and use in source and/or binary forms, with or without
+// modification, must retain the above copyright notice and the following
+// disclaimer.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+syntax = "proto3";
+
+package spine.web.firebase;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_package = "io.spine.web.firebase";
+option java_multiple_files = true;
+option java_outer_classname = "FirebaseQueryResponseProto";
+
+// A response to the query with results being posted to Firebase.
+//
+message FirebaseQueryResponse {
+
+    // A datapase path to the requested data.
+    string path = 1 [(required) = true];
+
+    // A number of records.
+    int64 count = 2;
+}

--- a/firebase-web/src/test/java/io/spine/web/firebase/FirebaseDatabasePathTest.java
+++ b/firebase-web/src/test/java/io/spine/web/firebase/FirebaseDatabasePathTest.java
@@ -28,8 +28,11 @@ import com.google.protobuf.Timestamp;
 import io.spine.client.Query;
 import io.spine.client.QueryFactory;
 import io.spine.core.TenantId;
+import io.spine.core.TenantIdVBuilder;
 import io.spine.net.EmailAddress;
+import io.spine.net.EmailAddressVBuilder;
 import io.spine.net.InternetDomain;
+import io.spine.net.InternetDomainVBuilder;
 import io.spine.testing.client.TestActorRequestFactory;
 import io.spine.time.ZoneOffsets;
 import org.junit.jupiter.api.DisplayName;
@@ -60,11 +63,11 @@ class FirebaseDatabasePathTest {
     @Test
     @DisplayName("construct self for a Query")
     void testConstruct() {
-        final Query firstQuery = queryFactory.all(Empty.class);
-        final Query secondQuery = queryFactory.all(Timestamp.class);
+        Query firstQuery = queryFactory.all(Empty.class);
+        Query secondQuery = queryFactory.all(Timestamp.class);
 
-        final FirebaseDatabasePath firstPath = FirebaseDatabasePath.allocateForQuery(firstQuery);
-        final FirebaseDatabasePath secondPath = FirebaseDatabasePath.allocateForQuery(secondQuery);
+        FirebaseDatabasePath firstPath = FirebaseDatabasePath.allocateForQuery(firstQuery);
+        FirebaseDatabasePath secondPath = FirebaseDatabasePath.allocateForQuery(secondQuery);
 
         assertNotNull(firstPath);
         assertNotNull(secondPath);
@@ -74,28 +77,30 @@ class FirebaseDatabasePathTest {
     @Test
     @DisplayName("be tenant-aware")
     void testTenantAware() {
-        final TenantId domainTenant = TenantId.newBuilder()
-                                              .setDomain(InternetDomain.newBuilder()
-                                                                       .setValue("spine.io"))
-                                              .build();
-        final TenantId emailTenant = TenantId.newBuilder()
-                                             .setEmail(EmailAddress.newBuilder()
-                                                                   .setValue("john@doe.org"))
-                                             .build();
-        final TenantId firstValueTenant = TenantId.newBuilder()
-                                                  .setValue("first tenant")
-                                                  .build();
-        final TenantId secondValueTenant = TenantId.newBuilder()
-                                                   .setValue("second tenant")
-                                                   .build();
-        final List<String> paths = Stream.of(domainTenant,
-                                             emailTenant,
-                                             firstValueTenant,
-                                             secondValueTenant)
-                                         .map(FirebaseDatabasePathTest::tenantAwareQuery)
-                                         .map(FirebaseDatabasePath::allocateForQuery)
-                                         .map(FirebaseDatabasePath::toString)
-                                         .collect(toList());
+        InternetDomain domain = InternetDomainVBuilder.newBuilder()
+                                                      .setValue("spine.io")
+                                                      .build();
+        TenantId domainTenant = TenantIdVBuilder.newBuilder()
+                                                .setDomain(domain)
+                                                .build();
+        EmailAddress email = EmailAddressVBuilder.newBuilder()
+                                                 .setValue("john@doe.org")
+                                                 .build();
+        TenantId emailTenant = TenantIdVBuilder.newBuilder()
+                                               .setEmail(email)
+                                               .build();
+        TenantId firstValueTenant = TenantIdVBuilder.newBuilder()
+                                                    .setValue("first tenant")
+                                                    .build();
+        TenantId secondValueTenant = TenantIdVBuilder.newBuilder()
+                                                     .setValue("second tenant")
+                                                     .build();
+        List<String> paths = Stream.of(domainTenant, emailTenant, firstValueTenant,
+                                       secondValueTenant)
+                                   .map(FirebaseDatabasePathTest::tenantAwareQuery)
+                                   .map(FirebaseDatabasePath::allocateForQuery)
+                                   .map(FirebaseDatabasePath::toString)
+                                   .collect(toList());
         new EqualsTester()
                 .addEqualityGroup(paths.get(0))
                 .addEqualityGroup(paths.get(1))
@@ -107,10 +112,10 @@ class FirebaseDatabasePathTest {
     @Test
     @DisplayName("construct into a valid path")
     void testEscaped() {
-        final TestActorRequestFactory requestFactory =
+        TestActorRequestFactory requestFactory =
                 TestActorRequestFactory.newInstance("a.aa#@)?$0[abb-ab", ZoneOffsets.getDefault(), systemDefault());
-        final Query query = requestFactory.query().all(Any.class);
-        final String path = FirebaseDatabasePath.allocateForQuery(query).toString();
+        Query query = requestFactory.query().all(Any.class);
+        String path = FirebaseDatabasePath.allocateForQuery(query).toString();
         assertFalse(path.contains("#"));
         assertFalse(path.contains("."));
         assertFalse(path.contains("["));
@@ -124,18 +129,18 @@ class FirebaseDatabasePathTest {
     @Test
     @DisplayName("generate a database reference")
     void testReference() {
-        final Query query = queryFactory.all(Empty.class);
-        final FirebaseDatabase database = mock(FirebaseDatabase.class);
+        Query query = queryFactory.all(Empty.class);
+        FirebaseDatabase database = mock(FirebaseDatabase.class);
 
-        final FirebaseDatabasePath path = FirebaseDatabasePath.allocateForQuery(query);
+        FirebaseDatabasePath path = FirebaseDatabasePath.allocateForQuery(query);
         path.reference(database);
         verify(database).getReference(eq(path.toString()));
     }
 
     private static Query tenantAwareQuery(TenantId tenantId) {
-        final TestActorRequestFactory requestFactory =
+        TestActorRequestFactory requestFactory =
                 TestActorRequestFactory.newInstance(FirebaseDatabasePathTest.class, tenantId);
-        final Query query = requestFactory.query().all(Any.class);
+        Query query = requestFactory.query().all(Any.class);
         return query;
     }
 }

--- a/firebase-web/src/test/java/io/spine/web/firebase/FirebaseQueryBridgeTest.java
+++ b/firebase-web/src/test/java/io/spine/web/firebase/FirebaseQueryBridgeTest.java
@@ -82,13 +82,13 @@ class FirebaseQueryBridgeTest {
     @Test
     @DisplayName("produce a database path for the given query results")
     void testMediate() {
-        final TestQueryService queryService = new TestQueryService();
-        final FirebaseQueryBridge bridge = FirebaseQueryBridge.newBuilder()
-                                                              .setQueryService(queryService)
-                                                              .setDatabase(firebaseDatabase)
-                                                              .build();
-        final Query query = queryFactory.all(Empty.class);
-        final QueryProcessingResult result = bridge.send(nonTransactionalQuery(query));
+        TestQueryService queryService = new TestQueryService();
+        FirebaseQueryBridge bridge = FirebaseQueryBridge.newBuilder()
+                                                        .setQueryService(queryService)
+                                                        .setDatabase(firebaseDatabase)
+                                                        .build();
+        Query query = queryFactory.all(Empty.class);
+        QueryProcessingResult result = bridge.send(nonTransactionalQuery(query));
 
         assertThat(result, instanceOf(FirebaseQueryProcessingResult.class));
     }
@@ -98,13 +98,13 @@ class FirebaseQueryBridgeTest {
     void testWriteData() {
         futureWillComeFromChild();
 
-        final Message dataElement = Time.getCurrentTime();
-        final TestQueryService queryService = new TestQueryService(dataElement);
-        final FirebaseQueryBridge bridge = FirebaseQueryBridge.newBuilder()
+        Message dataElement = Time.getCurrentTime();
+        TestQueryService queryService = new TestQueryService(dataElement);
+        FirebaseQueryBridge bridge = FirebaseQueryBridge.newBuilder()
                                                               .setQueryService(queryService)
                                                               .setDatabase(firebaseDatabase)
                                                               .build();
-        final Query query = queryFactory.all(Timestamp.class);
+        Query query = queryFactory.all(Timestamp.class);
         //noinspection ResultOfMethodCallIgnored
         bridge.send(nonTransactionalQuery(query));
 
@@ -119,16 +119,16 @@ class FirebaseQueryBridgeTest {
     void testIgnoreErrors() throws InterruptedException, ExecutionException, TimeoutException {
         futureWillNotComeFromChild();
 
-        final Message dataElement = Time.getCurrentTime();
-        final TestQueryService queryService = new TestQueryService(dataElement);
-        final long awaitSeconds = 1L;
-        final FirebaseQueryBridge bridge =
+        Message dataElement = Time.getCurrentTime();
+        TestQueryService queryService = new TestQueryService(dataElement);
+        long awaitSeconds = 1L;
+        FirebaseQueryBridge bridge =
                 FirebaseQueryBridge.newBuilder()
                                    .setQueryService(queryService)
                                    .setDatabase(firebaseDatabase)
                                    .setWriteAwaitSeconds(awaitSeconds)
                                    .build();
-        final Query query = queryFactory.all(Timestamp.class);
+        Query query = queryFactory.all(Timestamp.class);
         bridge.send(nonTransactionalQuery(query));
     }
 

--- a/firebase-web/src/test/java/io/spine/web/firebase/FirebaseQueryProcessingResultTest.java
+++ b/firebase-web/src/test/java/io/spine/web/firebase/FirebaseQueryProcessingResultTest.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
-import static java.lang.String.format;
+import static io.spine.json.Json.fromJson;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -52,29 +52,37 @@ class FirebaseQueryProcessingResultTest {
 
     @BeforeEach
     void setUp() {
-        final Query query = queryFactory.all(Any.class);
+        Query query = queryFactory.all(Any.class);
         databasePath = FirebaseDatabasePath.allocateForQuery(query);
     }
 
     @Test
     @DisplayName("write DB path to servlet response")
     void testWritePath() throws IOException {
-        final ServletResponse response = mock(ServletResponse.class);
-        final StringWriter stringWriter = new StringWriter();
-        final PrintWriter writer = new PrintWriter(stringWriter);
+        ServletResponse response = mock(ServletResponse.class);
+        StringWriter stringWriter = new StringWriter();
+        PrintWriter writer = new PrintWriter(stringWriter);
         when(response.getWriter()).thenReturn(writer);
 
         int count = 2;
-        final FirebaseQueryProcessingResult queryResult = 
+        FirebaseQueryProcessingResult queryResult =
                 new FirebaseQueryProcessingResult(databasePath, count);
         queryResult.writeTo(response);
         verify(response).getWriter();
 
-        String expected = queryProcessingResult(databasePath, count);
-        assertEquals(expected, stringWriter.toString());
+        FirebaseQueryResponse expected = toQueryResponse(databasePath, count);
+        FirebaseQueryResponse actual = fromJson(stringWriter.toString(),
+                                                FirebaseQueryResponse.class);
+
+        assertEquals(expected, actual);
     }
 
-    private static String queryProcessingResult(FirebaseDatabasePath databasePath, int count) {
-        return format("{\"path\": \"%s\", \"count\": %s}", databasePath.toString(), count);
+    private static FirebaseQueryResponse toQueryResponse(FirebaseDatabasePath path, long count) {
+        FirebaseQueryResponse response =
+                FirebaseQueryResponseVBuilder.newBuilder()
+                                             .setPath(path.toString())
+                                             .setCount(count)
+                                             .build();
+        return response;
     }
 }

--- a/firebase-web/src/test/java/io/spine/web/firebase/given/FirebaseQueryBridgeTestEnv.java
+++ b/firebase-web/src/test/java/io/spine/web/firebase/given/FirebaseQueryBridgeTestEnv.java
@@ -22,6 +22,7 @@ package io.spine.web.firebase.given;
 
 import io.spine.client.Query;
 import io.spine.web.WebQuery;
+import io.spine.web.WebQueryVBuilder;
 
 /**
  * @author Mykhailo Drachuk
@@ -36,16 +37,16 @@ public class FirebaseQueryBridgeTestEnv {
     }
 
     public static WebQuery transactionalQuery(Query query) {
-        return WebQuery.newBuilder()
-                       .setQuery(query)
-                       .setDeliveredTransactionally(true)
-                       .build();
+        return WebQueryVBuilder.newBuilder()
+                               .setQuery(query)
+                               .setDeliveredTransactionally(true)
+                               .build();
     }
 
     public static WebQuery nonTransactionalQuery(Query query) {
-        return WebQuery.newBuilder()
-                       .setQuery(query)
-                       .setDeliveredTransactionally(false)
-                       .build();
+        return WebQueryVBuilder.newBuilder()
+                               .setQuery(query)
+                               .setDeliveredTransactionally(false)
+                               .build();
     }
 }

--- a/firebase-web/src/test/java/io/spine/web/firebase/given/FirebaseQueryMediatorTestEnv.java
+++ b/firebase-web/src/test/java/io/spine/web/firebase/given/FirebaseQueryMediatorTestEnv.java
@@ -26,9 +26,11 @@ import com.google.protobuf.Message;
 import io.grpc.stub.StreamObserver;
 import io.spine.client.Query;
 import io.spine.client.QueryResponse;
+import io.spine.client.QueryResponseVBuilder;
 import io.spine.client.grpc.QueryServiceGrpc;
 import io.spine.protobuf.AnyPacker;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -64,8 +66,7 @@ public final class FirebaseQueryMediatorTestEnv {
      */
     public static <T> ApiFuture<T> timeoutFuture()
             throws InterruptedException, ExecutionException, TimeoutException {
-        @SuppressWarnings("unchecked")
-        final ApiFuture<T> future = mock(ApiFuture.class);
+        @SuppressWarnings("unchecked") ApiFuture<T> future = mock(ApiFuture.class);
 
         when(future.get(anyLong(), any(TimeUnit.class)))
                 .thenThrow(new TimeoutException("FirebaseQueryMediatorTestEnv.timeoutFuture()"));
@@ -85,10 +86,11 @@ public final class FirebaseQueryMediatorTestEnv {
 
         @Override
         public void read(Query request, StreamObserver<QueryResponse> responseObserver) {
-            final QueryResponse queryResponse = QueryResponse.newBuilder()
-                                                             .setResponse(ok())
-                                                             .addAllMessages(response)
-                                                             .build();
+            QueryResponse queryResponse =
+                    QueryResponseVBuilder.newBuilder()
+                                         .setResponse(ok())
+                                         .addAllMessages(new ArrayList<>(response))
+                                         .build();
             responseObserver.onNext(queryResponse);
             responseObserver.onCompleted();
         }

--- a/integration-tests/web-tests/src/main/java/io/spine/web/test/Application.java
+++ b/integration-tests/web-tests/src/main/java/io/spine/web/test/Application.java
@@ -43,12 +43,12 @@ final class Application {
 
     static Application create(BoundedContext boundedContext) {
         checkNotNull(boundedContext);
-        final CommandService commandService = CommandService.newBuilder()
-                                                            .add(boundedContext)
-                                                            .build();
-        final QueryService queryService = QueryService.newBuilder()
+        CommandService commandService = CommandService.newBuilder()
                                                       .add(boundedContext)
                                                       .build();
+        QueryService queryService = QueryService.newBuilder()
+                                                .add(boundedContext)
+                                                .build();
         return new Application(commandService, queryService);
     }
 

--- a/integration-tests/web-tests/src/main/java/io/spine/web/test/FirebaseClient.java
+++ b/integration-tests/web-tests/src/main/java/io/spine/web/test/FirebaseClient.java
@@ -39,12 +39,12 @@ final class FirebaseClient {
 
     static {
         try {
-            final InputStream in = FirebaseClient.class.getClassLoader()
+            InputStream in = FirebaseClient.class.getClassLoader()
                                                        .getResourceAsStream("spine-dev.json");
-            final GoogleCredentials credentials;
+            GoogleCredentials credentials;
 
             credentials = GoogleCredentials.fromStream(in);
-            final FirebaseOptions options = new FirebaseOptions.Builder()
+            FirebaseOptions options = new FirebaseOptions.Builder()
                     .setCredentials(credentials)
                     .setDatabaseUrl("https://spine-dev.firebaseio.com/")
                     .build();

--- a/integration-tests/web-tests/src/main/java/io/spine/web/test/Server.java
+++ b/integration-tests/web-tests/src/main/java/io/spine/web/test/Server.java
@@ -49,15 +49,15 @@ final class Server {
     }
 
     private static Application createApplication() {
-        final String name = "Test Bounded Context";
-        final StorageFactory storageFactory = newInstance(newName(name), false);
-        final BoundedContext boundedContext =
+        String name = "Test Bounded Context";
+        StorageFactory storageFactory = newInstance(newName(name), false);
+        BoundedContext boundedContext =
                 BoundedContext.newBuilder()
                               .setName(name)
                               .setStorageFactorySupplier(() -> storageFactory)
                               .build();
         boundedContext.register(new TaskRepository());
-        final Application app = Application.create(boundedContext);
+        Application app = Application.create(boundedContext);
         return app;
     }
 }

--- a/integration-tests/web-tests/src/main/java/io/spine/web/test/TaskAggregate.java
+++ b/integration-tests/web-tests/src/main/java/io/spine/web/test/TaskAggregate.java
@@ -37,11 +37,11 @@ public class TaskAggregate extends Aggregate<TaskId, Task, TaskVBuilder> {
 
     @Assign
     TaskCreated handle(CreateTask command) {
-        return TaskCreated.newBuilder()
-                          .setId(command.getId())
-                          .setName(command.getName())
-                          .setDescription(command.getDescription())
-                          .build();
+        return TaskCreatedVBuilder.newBuilder()
+                                  .setId(command.getId())
+                                  .setName(command.getName())
+                                  .setDescription(command.getDescription())
+                                  .build();
     }
 
     @Apply

--- a/web/src/main/java/io/spine/web/CommandServlet.java
+++ b/web/src/main/java/io/spine/web/CommandServlet.java
@@ -60,21 +60,21 @@ public abstract class CommandServlet extends NonSerializableServlet {
     @Override
     protected void doPost(HttpServletRequest req, HttpServletResponse resp)
             throws IOException {
-        final Optional<Command> parsed = HttpMessages.parse(req, Command.class);
+        Optional<Command> parsed = HttpMessages.parse(req, Command.class);
         if (!parsed.isPresent()) {
             resp.sendError(SC_BAD_REQUEST);
         } else {
-            final Command command = parsed.get();
-            final FutureObserver<Ack> ack = FutureObserver.withDefault(Ack.getDefaultInstance());
+            Command command = parsed.get();
+            FutureObserver<Ack> ack = FutureObserver.withDefault(Ack.getDefaultInstance());
             commandService.post(command, ack);
-            final Ack result = ack.toFuture().join();
+            Ack result = ack.toFuture().join();
             writeToResponse(result, resp);
         }
     }
 
     private static void writeToResponse(Ack ack, HttpServletResponse response)
             throws IOException {
-        final String json = Json.toCompactJson(ack);
+        String json = Json.toCompactJson(ack);
         response.getWriter().append(json);
         response.setContentType(MIME_TYPE);
     }

--- a/web/src/main/java/io/spine/web/parser/Base64MessageParser.java
+++ b/web/src/main/java/io/spine/web/parser/Base64MessageParser.java
@@ -53,11 +53,11 @@ final class Base64MessageParser<M extends Message> implements MessageParser<M> {
      */
     @Override
     public Optional<M> parse(String raw) {
-        final byte[] bytes = Base64.getDecoder().decode(raw);
-        final Message.Builder builder = Messages.builderFor(type);
+        byte[] bytes = Base64.getDecoder().decode(raw);
+        Message.Builder builder = Messages.builderFor(type);
         try {
             @SuppressWarnings("unchecked") // Logically checked.
-            final M message = (M) builder.mergeFrom(bytes)
+            M message = (M) builder.mergeFrom(bytes)
                                          .build();
             return Optional.of(message);
         } catch (InvalidProtocolBufferException | ClassCastException e) {

--- a/web/src/main/java/io/spine/web/parser/HttpMessages.java
+++ b/web/src/main/java/io/spine/web/parser/HttpMessages.java
@@ -74,17 +74,17 @@ public final class HttpMessages {
     public static <M extends Message> Optional<M> parse(HttpServletRequest request, Class<M> type)
             throws IOException {
         checkNotNull(request, type);
-        final Optional<MessageFormat> format = MessageFormat.formatOf(request);
-        final String requestBody = body(request);
-        final Optional<M> message = format.map(messageFormat -> messageFormat.parserFor(type))
+        Optional<MessageFormat> format = MessageFormat.formatOf(request);
+        String requestBody = body(request);
+        Optional<M> message = format.map(messageFormat -> messageFormat.parserFor(type))
                                           .flatMap(parser -> parser.parse(requestBody));
         return message;
     }
 
     private static String body(ServletRequest request) throws IOException {
-        final String result = request.getReader()
-                                     .lines()
-                                     .collect(joining(" "));
+        String result = request.getReader()
+                               .lines()
+                               .collect(joining(" "));
         return result;
     }
 }

--- a/web/src/main/java/io/spine/web/parser/JsonMessageParser.java
+++ b/web/src/main/java/io/spine/web/parser/JsonMessageParser.java
@@ -56,9 +56,9 @@ final class JsonMessageParser<M extends Message> implements MessageParser<M> {
      */
     @Override
     public Optional<M> parse(String raw) {
-        final String json = cleanUp(raw);
+        String json = cleanUp(raw);
         try {
-            final M message = Json.fromJson(json, type);
+            M message = Json.fromJson(json, type);
             return Optional.of(message);
         } catch (IllegalArgumentException e) {
             log().error("Unable to parse message of type {} from JSON: `{}`",
@@ -68,8 +68,8 @@ final class JsonMessageParser<M extends Message> implements MessageParser<M> {
     }
 
     private static String cleanUp(String jsonFromRequest) {
-        final String json = EscapeSymbol.unEscapeAll(jsonFromRequest);
-        final String unQuoted = unQuote(json);
+        String json = EscapeSymbol.unEscapeAll(jsonFromRequest);
+        String unQuoted = unQuote(json);
         return unQuoted;
     }
 
@@ -82,7 +82,7 @@ final class JsonMessageParser<M extends Message> implements MessageParser<M> {
         if (json.endsWith("\"")) {
             endIndex = json.length() - 1;
         }
-        final String result = json.substring(beginIndex, endIndex);
+        String result = json.substring(beginIndex, endIndex);
         return result;
     }
 
@@ -108,8 +108,8 @@ final class JsonMessageParser<M extends Message> implements MessageParser<M> {
         }
 
         private String unEscape(String escaped) {
-            final Matcher matcher = escapedPattern.matcher(escaped);
-            final String unescaped = matcher.replaceAll(raw);
+            Matcher matcher = escapedPattern.matcher(escaped);
+            String unescaped = matcher.replaceAll(raw);
             return unescaped;
         }
 

--- a/web/src/main/java/io/spine/web/parser/MessageFormat.java
+++ b/web/src/main/java/io/spine/web/parser/MessageFormat.java
@@ -86,8 +86,8 @@ enum MessageFormat {
      *         the request does not justify the described format
      */
     static Optional<MessageFormat> formatOf(HttpServletRequest request) {
-        final String formatHeader = request.getHeader(CONTENT_TYPE);
-        final Optional<MessageFormat> matchedFormat =
+        String formatHeader = request.getHeader(CONTENT_TYPE);
+        Optional<MessageFormat> matchedFormat =
                 Stream.of(values())
                       .filter(format -> format.matches(formatHeader))
                       .findFirst();
@@ -95,7 +95,7 @@ enum MessageFormat {
     }
 
     protected boolean matches(@Nullable String requestContentType) {
-        final boolean result = contentType.equalsIgnoreCase(requestContentType);
+        boolean result = contentType.equalsIgnoreCase(requestContentType);
         return result;
     }
 

--- a/web/src/main/java/io/spine/web/queryservice/Local.java
+++ b/web/src/main/java/io/spine/web/queryservice/Local.java
@@ -44,7 +44,7 @@ final class Local implements AsyncQueryService {
 
     @Override
     public CompletableFuture<QueryResponse> execute(Query query) {
-        final FutureObserver<QueryResponse> observer =
+        FutureObserver<QueryResponse> observer =
                 FutureObserver.withDefault(QueryResponse.getDefaultInstance());
         service.read(query, observer);
         return observer.toFuture();

--- a/web/src/main/java/io/spine/web/queryservice/Remote.java
+++ b/web/src/main/java/io/spine/web/queryservice/Remote.java
@@ -45,7 +45,7 @@ final class Remote implements AsyncQueryService {
 
     @Override
     public CompletableFuture<QueryResponse> execute(Query query) {
-        final CompletableFuture<QueryResponse> result = supplyAsync(() -> service.read(query));
+        CompletableFuture<QueryResponse> result = supplyAsync(() -> service.read(query));
         return result;
     }
 

--- a/web/src/main/proto/spine/web/web_query.proto
+++ b/web/src/main/proto/spine/web/web_query.proto
@@ -30,9 +30,9 @@ option java_outer_classname = "WebProto";
 
 import "spine/client/query.proto";
 
-// A query received from Spines JS client.
+// A query received from HTTP client.
 // 
-// Complements the Query sent to Spine specifying one of two query strategies:
+// Complements the `Query` sent to Spine specifying one of two query strategies:
 // <ol>
 //    <li>A non-transactional supplying items to the destination one at a time.
 //    <li>A transactional strategy supplying items to the destination in one batch.  

--- a/web/src/main/proto/spine/web/web_query.proto
+++ b/web/src/main/proto/spine/web/web_query.proto
@@ -44,5 +44,5 @@ message WebQuery {
     spine.client.Query query = 1 [(required) = true];
 
     // Specifies if the client wants the result to be pushed in a single transaction.
-    bool delivered_transactionally = 2 [(required) = true];
+    bool delivered_transactionally = 2;
 }

--- a/web/src/test/java/io/spine/web/CommandServletTest.java
+++ b/web/src/test/java/io/spine/web/CommandServletTest.java
@@ -57,19 +57,19 @@ class CommandServletTest {
     @Test
     @DisplayName("fail to serialize")
     void testSerialize() throws IOException {
-        final CommandServlet servlet = new TestCommandServlet();
-        final ObjectOutputStream stream = new ObjectOutputStream(new ByteArrayOutputStream());
+        CommandServlet servlet = new TestCommandServlet();
+        ObjectOutputStream stream = new ObjectOutputStream(new ByteArrayOutputStream());
         assertThrows(UnsupportedOperationException.class, () -> stream.writeObject(servlet));
     }
 
     @Test
     @DisplayName("handle command POST requests")
     void testHandle() throws IOException {
-        final CommandServlet servlet = new TestCommandServlet();
-        final StringWriter response = new StringWriter();
-        final Command command = commandFactory.create(Time.getCurrentTime());
+        CommandServlet servlet = new TestCommandServlet();
+        StringWriter response = new StringWriter();
+        Command command = commandFactory.create(Time.getCurrentTime());
         servlet.doPost(request(command), response(response));
-        final Ack ack = Json.fromJson(response.toString(), Ack.class);
+        Ack ack = Json.fromJson(response.toString(), Ack.class);
         assertEquals(OK, ack.getStatus().getStatusCase());
         assertEquals(command.getId(), AnyPacker.unpack(ack.getMessageId()));
     }
@@ -77,8 +77,8 @@ class CommandServletTest {
     @Test
     @DisplayName("respond 400 to an invalid command")
     void testInvalidCommand() throws IOException {
-        final CommandServlet servlet = new TestCommandServlet();
-        final HttpServletResponse response = response(new StringWriter());
+        CommandServlet servlet = new TestCommandServlet();
+        HttpServletResponse response = response(new StringWriter());
         servlet.doPost(request(Time.getCurrentTime()), response);
         verify(response).sendError(400);
     }

--- a/web/src/test/java/io/spine/web/FutureObserverTest.java
+++ b/web/src/test/java/io/spine/web/FutureObserverTest.java
@@ -41,8 +41,8 @@ class FutureObserverTest {
     @Test
     @DisplayName("instantiate self")
     void testCreateDefault() {
-        final FutureObserver<String> observer = FutureObserver.create();
-        final String value = "hello";
+        FutureObserver<String> observer = FutureObserver.create();
+        String value = "hello";
         observer.onNext(value);
         assertEquals(value, observer.toFuture().join());
         observer.onCompleted();
@@ -52,7 +52,7 @@ class FutureObserverTest {
     @Test
     @DisplayName("complete with null by default")
     void testDefaultNull() {
-        final FutureObserver<String> observer = FutureObserver.create();
+        FutureObserver<String> observer = FutureObserver.create();
         observer.onCompleted();
         assertNull(observer.toFuture().join());
     }
@@ -60,8 +60,8 @@ class FutureObserverTest {
     @Test
     @DisplayName("complete with given default value")
     void testDefaultValue() {
-        final String defaultValue = "Aquaman";
-        final FutureObserver<String> observer = FutureObserver.withDefault(defaultValue);
+        String defaultValue = "Aquaman";
+        FutureObserver<String> observer = FutureObserver.withDefault(defaultValue);
         observer.onCompleted();
         assertEquals(defaultValue, observer.toFuture().join());
     }
@@ -69,7 +69,7 @@ class FutureObserverTest {
     @Test
     @DisplayName("fail to override value")
     void testFailToOverride() {
-        final FutureObserver<String> observer = FutureObserver.create();
+        FutureObserver<String> observer = FutureObserver.create();
         observer.onNext("first");
         assertThrows(IllegalStateException.class, () -> observer.onNext("second"));
     }
@@ -77,14 +77,14 @@ class FutureObserverTest {
     @Test
     @DisplayName("override value with error if onError() called")
     void testOverrideWithError() {
-        final FutureObserver<String> observer = FutureObserver.create();
-        final String value = "Titanic";
+        FutureObserver<String> observer = FutureObserver.create();
+        String value = "Titanic";
         observer.onNext(value);
         assertEquals(value, observer.toFuture().join());
         observer.onError(new IcebergCollisionException());
-        final Throwable thrown = assertThrows(CompletionException.class,
+        Throwable thrown = assertThrows(CompletionException.class,
                                               () -> observer.toFuture().join());
-        final Throwable rootCause = getRootCause(thrown);
+        Throwable rootCause = getRootCause(thrown);
         assertThat(rootCause, instanceOf(IcebergCollisionException.class));
     }
 

--- a/web/src/test/java/io/spine/web/QueryServletTest.java
+++ b/web/src/test/java/io/spine/web/QueryServletTest.java
@@ -56,8 +56,8 @@ class QueryServletTest {
     @Test
     @DisplayName("throw UnsupportedOperationException when trying to serialize")
     void testFailToSerialize() throws IOException {
-        final QueryServlet servlet = new TestQueryServlet();
-        final ObjectOutputStream stream = new ObjectOutputStream(new ByteArrayOutputStream());
+        QueryServlet servlet = new TestQueryServlet();
+        ObjectOutputStream stream = new ObjectOutputStream(new ByteArrayOutputStream());
         assertThrows(UnsupportedOperationException.class, () -> stream.writeObject(servlet));
         stream.close();
     }
@@ -65,28 +65,28 @@ class QueryServletTest {
     @Test
     @DisplayName("handle query POST requests")
     void testHandle() throws IOException {
-        final Timestamp expectedData = Time.getCurrentTime();
-        final QueryServlet servlet = new TestQueryServlet(expectedData);
-        final StringWriter response = new StringWriter();
-        final Query query = queryFactory.all(Timestamp.class);
+        Timestamp expectedData = Time.getCurrentTime();
+        QueryServlet servlet = new TestQueryServlet(expectedData);
+        StringWriter response = new StringWriter();
+        Query query = queryFactory.all(Timestamp.class);
         HttpServletRequest request = request(newTransactionalQuery(query));
         servlet.doPost(request, response(response));
-        final Timestamp actualData = Json.fromJson(response.toString(), Timestamp.class);
+        Timestamp actualData = Json.fromJson(response.toString(), Timestamp.class);
         assertEquals(expectedData, actualData);
     }
 
     private static WebQuery newTransactionalQuery(Query query) {
-        return WebQuery.newBuilder()
-                       .setQuery(query)
-                       .setDeliveredTransactionally(false)
-                       .build();
+        return WebQueryVBuilder.newBuilder()
+                               .setQuery(query)
+                               .setDeliveredTransactionally(false)
+                               .build();
     }
 
     @Test
     @DisplayName("respond 400 to an invalid query")
     void testInvalidCommand() throws IOException {
-        final QueryServlet servlet = new TestQueryServlet();
-        final HttpServletResponse response = response(new StringWriter());
+        QueryServlet servlet = new TestQueryServlet();
+        HttpServletResponse response = response(new StringWriter());
         servlet.doPost(request(Time.getCurrentTime()), response);
         verify(response).sendError(400);
     }

--- a/web/src/test/java/io/spine/web/given/CommandServletTestEnv.java
+++ b/web/src/test/java/io/spine/web/given/CommandServletTestEnv.java
@@ -22,12 +22,14 @@ package io.spine.web.given;
 
 import io.grpc.stub.StreamObserver;
 import io.spine.core.Ack;
+import io.spine.core.AckVBuilder;
 import io.spine.core.Command;
 import io.spine.protobuf.AnyPacker;
 import io.spine.server.CommandService;
 import io.spine.web.CommandServlet;
 
 import static io.spine.core.Responses.statusOk;
+import static io.spine.protobuf.AnyPacker.pack;
 import static io.spine.testing.Tests.nullRef;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -46,14 +48,14 @@ public final class CommandServletTestEnv {
 
     @SuppressWarnings("unchecked") // Mocking generics.
     public static CommandService positiveCommandService() {
-        final CommandService commandService = mock(CommandService.class);
+        CommandService commandService = mock(CommandService.class);
         doAnswer(invocation -> {
-            final StreamObserver<Ack> observer = invocation.getArgument(1);
-            final Command command = invocation.getArgument(0);
-            observer.onNext(Ack.newBuilder()
-                               .setMessageId(AnyPacker.pack(command.getId()))
-                               .setStatus(statusOk())
-                               .build());
+            StreamObserver<Ack> observer = invocation.getArgument(1);
+            Command command = invocation.getArgument(0);
+            observer.onNext(AckVBuilder.newBuilder()
+                                       .setMessageId(pack(command.getId()))
+                                       .setStatus(statusOk())
+                                       .build());
             observer.onCompleted();
             return nullRef();
         }).when(commandService).post(any(Command.class), any(StreamObserver.class));

--- a/web/src/test/java/io/spine/web/given/Servlets.java
+++ b/web/src/test/java/io/spine/web/given/Servlets.java
@@ -49,14 +49,14 @@ public final class Servlets {
     }
 
     public static HttpServletRequest request(Message contents) throws IOException {
-        final HttpServletRequest request = mock(HttpServletRequest.class);
-        final String content = Json.toJson(contents);
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        String content = Json.toJson(contents);
         when(request.getReader()).thenReturn(new BufferedReader(new StringReader(content)));
         return request;
     }
 
     public static HttpServletResponse response(StringWriter writer) throws IOException {
-        final HttpServletResponse response = mock(HttpServletResponse.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
         when(response.getWriter()).thenReturn(new PrintWriter(writer));
         return response;
     }

--- a/web/src/test/java/io/spine/web/queryservice/AsyncQueryServiceTest.java
+++ b/web/src/test/java/io/spine/web/queryservice/AsyncQueryServiceTest.java
@@ -67,11 +67,11 @@ class AsyncQueryServiceTest {
         @Test
         @DisplayName(EXIST_TEST_NAME)
         void testLocal() {
-            final QueryService queryService = mockQueryService();
-            final AsyncQueryService proxy = AsyncQueryService.local(queryService);
+            QueryService queryService = mockQueryService();
+            AsyncQueryService proxy = AsyncQueryService.local(queryService);
             assertNotNull(proxy);
 
-            final Query query = Query.getDefaultInstance();
+            Query query = Query.getDefaultInstance();
             CompletableFuture<QueryResponse> future = proxy.execute(query);
             assertNotNull(future);
 
@@ -81,7 +81,7 @@ class AsyncQueryServiceTest {
         @Test
         @DisplayName(TO_STRING_TEST_NAME)
         void testToString() {
-            final String representation = AsyncQueryService.local(mockQueryService())
+            String representation = AsyncQueryService.local(mockQueryService())
                                                            .toString();
             assertTrue(representation.contains(AsyncQueryService.class.getSimpleName()));
             // Same each time.
@@ -90,7 +90,7 @@ class AsyncQueryServiceTest {
         }
 
         private QueryService mockQueryService() {
-            final QueryService queryService = mock(QueryService.class);
+            QueryService queryService = mock(QueryService.class);
             return queryService;
         }
     }
@@ -106,7 +106,7 @@ class AsyncQueryServiceTest {
         void setUp() throws IOException {
             queryService = mock(QueryService.class);
             doAnswer(invocation -> {
-                final StreamObserver<QueryResponse> observer = invocation.getArgument(1);
+                StreamObserver<QueryResponse> observer = invocation.getArgument(1);
                 observer.onNext(QueryResponse.getDefaultInstance());
                 observer.onCompleted();
                 return nullRef();
@@ -126,10 +126,10 @@ class AsyncQueryServiceTest {
         @Test
         @DisplayName(EXIST_TEST_NAME)
         void testRemote() {
-            final AsyncQueryService proxy = AsyncQueryService.remote(remoteQueryService());
+            AsyncQueryService proxy = AsyncQueryService.remote(remoteQueryService());
             assertNotNull(proxy);
 
-            final Query query = Query.getDefaultInstance();
+            Query query = Query.getDefaultInstance();
             proxy.execute(query).join();
 
             verify(queryService).read(eq(query), any());
@@ -138,7 +138,7 @@ class AsyncQueryServiceTest {
         @Test
         @DisplayName(TO_STRING_TEST_NAME)
         void testToString() {
-            final String representation = AsyncQueryService.remote(remoteQueryService())
+            String representation = AsyncQueryService.remote(remoteQueryService())
                                                            .toString();
             assertTrue(representation.contains(AsyncQueryService.class.getSimpleName()));
             // Same each time.
@@ -147,11 +147,11 @@ class AsyncQueryServiceTest {
         }
 
         private QueryServiceBlockingStub remoteQueryService() {
-            final Channel channel = forAddress("127.0.0.1", TEST_GRPC_PORT)
+            Channel channel = forAddress("127.0.0.1", TEST_GRPC_PORT)
                     .usePlaintext(true)
                     .directExecutor()
                     .build();
-            final QueryServiceBlockingStub result = QueryServiceGrpc.newBlockingStub(channel);
+            QueryServiceBlockingStub result = QueryServiceGrpc.newBlockingStub(channel);
             return result;
         }
     }


### PR DESCRIPTION
In this PR we:
- bump module version to `0.10.67-SNAPSHOT`;
- introduce new `FirebaseQueryResponse` message;
- redocument `WebQuery` to be for more general `HTTP` clients, not `Spine JS client`;
- fix unit tests accordingly;
- remove unnecessary `final`s;
- replaces all `Builder`s with `VBuilder`s.