### PR TITLE
Bump Spine version to 0.10.78-SNAPSHOT

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -18,14 +18,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-final def SPINE_VERSION = '0.10.77-SNAPSHOT'
+final def SPINE_VERSION = '0.10.78-SNAPSHOT'
 
 ext {
     spineVersion = SPINE_VERSION
     spineBaseVersion = '0.10.66-SNAPSHOT'
 
-    // Publish artifacts of this project with the same version number as Base.
-    versionToPublish = '0.10.67-SNAPSHOT'
+    versionToPublish = SPINE_VERSION;
 
     firebaseVersion = '5.9.0'
     servletApiVersion = '4.0.0'

--- a/scripts/js.gradle
+++ b/scripts/js.gradle
@@ -96,7 +96,7 @@ protobuf {
  */
 String filterPackageDescriptor(final String line) {
     final Map<String, String> replacements = [
-            '\\$PACKAGE_VERSION'         : ext.spineVersion,
+            '\\$PACKAGE_VERSION'         : ext.versionToPublish,
             '\\$PACKAGE_PROTOBUF_VERSION': '^3.6.0',
             '\\$PACKAGE_TEST'            : 'mocha --require babel-polyfill --require babel-register --recursive --exit --full-trace ./test'
     ]


### PR DESCRIPTION
This PR bumps Spine version and fixes the fact that `spineVersion` Gradle variable was used as the version to publish instead of `versionToPublish`.