### PR TITLE
Change npm publication name to "spine-web-client"

### DIFF
--- a/client-js-proto/package.json
+++ b/client-js-proto/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "spine-js-client-proto",
+  "name": "spine-web-client-proto",
   "version": "$PACKAGE_VERSION",
   "license": "Apache-2.0",
   "description": "Protobuf types defined and used by the Spine client library.",

--- a/client-js/build.gradle
+++ b/client-js/build.gradle
@@ -53,7 +53,7 @@ apply from: "$rootDir/scripts/js.gradle"
 
 task linkClientProto {
     doLast {
-        npm 'link', 'spine-js-client-proto'
+        npm 'link', 'spine-web-client-proto'
     }
 
     dependsOn ':client-js-proto:link'

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "spine-js-client",
+  "name": "spine-web-client",
   "version": "$PACKAGE_VERSION",
   "license": "Apache-2.0",
   "description": "JS implementation of the Spine client.",
@@ -14,7 +14,7 @@
     "base64-js": "^1.3.0",
     "firebase": "^4.12.1",
     "isomorphic-fetch": "^2.2.1",
-    "spine-js-client-proto": "$PACKAGE_VERSION",
+    "spine-web-client-proto": "$PACKAGE_VERSION",
     "uuid": "^3.2.1"
   },
   "devDependencies": {

--- a/client-js/src/client/actor-request-factory.js
+++ b/client-js/src/client/actor-request-factory.js
@@ -22,18 +22,18 @@
 
 import uuid from 'uuid';
 
-import {Timestamp} from 'spine-js-client-proto/google/protobuf/timestamp_pb';
-import {Query, QueryId} from 'spine-js-client-proto/spine/client/query_pb';
+import {Timestamp} from 'spine-web-client-proto/google/protobuf/timestamp_pb';
+import {Query, QueryId} from 'spine-web-client-proto/spine/client/query_pb';
 import {
   EntityFilters,
   EntityId,
   EntityIdFilter,
   Target
-} from 'spine-js-client-proto/spine/client/entities_pb';
-import {ActorContext} from 'spine-js-client-proto/spine/core/actor_context_pb';
-import {Command, CommandContext, CommandId} from 'spine-js-client-proto/spine/core/command_pb';
-import {UserId} from 'spine-js-client-proto/spine/core/user_id_pb';
-import {ZoneId, ZoneOffset} from 'spine-js-client-proto/spine/time/time_pb';
+} from 'spine-web-client-proto/spine/client/entities_pb';
+import {ActorContext} from 'spine-web-client-proto/spine/core/actor_context_pb';
+import {Command, CommandContext, CommandId} from 'spine-web-client-proto/spine/core/command_pb';
+import {UserId} from 'spine-web-client-proto/spine/core/user_id_pb';
+import {ZoneId, ZoneOffset} from 'spine-web-client-proto/spine/time/time_pb';
 import {TypedMessage, TypeUrl} from './typed-message';
 
 

--- a/client-js/src/client/http-endpoint.js
+++ b/client-js/src/client/http-endpoint.js
@@ -19,7 +19,7 @@
  */
 
 import {TypedMessage, TypeUrl} from './typed-message';
-import {WebQuery} from 'spine-js-client-proto/spine/web/web_query_pb';
+import {WebQuery} from 'spine-web-client-proto/spine/web/web_query_pb';
 
 /**
  * The type URL representing the spine.client.Query.

--- a/client-js/src/client/typed-message.js
+++ b/client-js/src/client/typed-message.js
@@ -21,7 +21,7 @@
 "use strict";
 
 import base64 from 'base64-js';
-import {Any} from 'spine-js-client-proto/google/protobuf/any_pb';
+import {Any} from 'spine-web-client-proto/google/protobuf/any_pb';
 
 /**
  * A URL of a Protobuf type.


### PR DESCRIPTION
This PR changes the name of the npm publications to `spine-web-client` and `spine-web-client-proto` to better manifest the packages place in Spine ecosystem.