### PR TITLE
Full-fledged JS Query Builder

### DIFF
--- a/client-js/src/client/actor-request-factory.js
+++ b/client-js/src/client/actor-request-factory.js
@@ -437,7 +437,7 @@ class QueryBuilder {
    *
    * @param {![]} items an array of objects that are expected to be of the provided type
    * @param {!Object} cls a class each item is required to be instance of
-   * @param {!String} message
+   * @param {!String} message an error message thrown on type mismatch
    * @private
    */
   static _checkAllOfType(items, cls, message = 'Unexpected parameter type.') {
@@ -452,6 +452,11 @@ class QueryBuilder {
     }
   }
 
+  /**
+   * @param {![]} items an array of objects that are expected to be strings
+   * @param {!String} message an error message thrown on type mismatch
+   * @private
+   */
   static _checkAllAreStrings(items, message) {
     items.forEach(item => {
       if (typeof item !== 'string' && !(item instanceof String)) {
@@ -460,6 +465,11 @@ class QueryBuilder {
     });
   }
 
+  /**
+   * @param {![]} items an array of objects that are expected to be numbers
+   * @param {!String} message an error message thrown on type mismatch
+   * @private
+   */
   static _checkAllAreNumbers(items, message) {
     items.forEach(item => {
       if (typeof item !== 'number' && !(item instanceof Number)) {
@@ -468,6 +478,11 @@ class QueryBuilder {
     });
   }
 
+  /**
+   * @param {![]} items an array of objects that are expected to be booleans
+   * @param {!String} message an error message thrown on type mismatch
+   * @private
+   */
   static _checkAllAreBooleans(items, message) {
     items.forEach(item => {
       if (typeof item !== 'boolean' && !(item instanceof Boolean)) {
@@ -476,6 +491,12 @@ class QueryBuilder {
     });
   }
 
+  /**
+   * @param {!Object} cls a class tyo check items against
+   * @param {![]} items an array of objects that are expected to instances of class
+   * @param {!String} message an error message thrown on type mismatch
+   * @private
+   */
   static _checkAllOfClass(cls, items, message) {
     items.forEach(item => {
       if (!(item instanceof cls)) {

--- a/client-js/src/client/actor-request-factory.js
+++ b/client-js/src/client/actor-request-factory.js
@@ -223,7 +223,7 @@ class QueryBuilder {
    *
    * Makes the query return only the entities identified by the provided IDs.
    *
-   * @param {!TypedMessage[]} ids an array with identifiers of entities to query
+   * @param {!TypedMessage[]|Number[]|String[]} ids an array with identifiers of entities to query
    * @return {QueryBuilder} the current builder instance
    * @throws if this method is executed more than once
    * @throws if the provided IDs are not an instance of `Array`
@@ -239,8 +239,17 @@ class QueryBuilder {
     if (!ids.length) {
       return this;
     }
-    QueryBuilder._checkAllOfType(ids, TypedMessage, 'Each provided ID must be a TypedMessage.');
-    this._ids = ids.slice();
+    const invalidTypeMessage = 'Each provided ID must be a string, number or a TypedMessage.';
+    if (ids[0] instanceof Number || typeof ids[0] === 'number') {
+      QueryBuilder._checkAllOfType(ids, Number, invalidTypeMessage);
+      this._ids = ids.map(TypedMessage.int64);
+    } else if (ids[0] instanceof String || typeof ids[0] === 'string') {
+      QueryBuilder._checkAllOfType(ids, String, invalidTypeMessage);
+      this._ids = ids.map(TypedMessage.string);
+    } else {
+      QueryBuilder._checkAllOfType(ids, TypedMessage, invalidTypeMessage);
+      this._ids = ids.slice();
+    }
     return this;
   }
 

--- a/client-js/src/client/actor-request-factory.js
+++ b/client-js/src/client/actor-request-factory.js
@@ -544,7 +544,7 @@ class QueryFactory {
    * @return {Query}
    */
   forTarget(target, fieldMask) {
-    return this._newQuery(target, fieldMask)
+    return this._newQuery(target, fieldMask);
   }
 
   /**

--- a/client-js/src/client/actor-request-factory.js
+++ b/client-js/src/client/actor-request-factory.js
@@ -63,7 +63,7 @@ export class ColumnFilters {
    * @return {ColumnFilter} a new column filter
    */
   static eq(columnName, value) {
-    return ColumnFilters.with(columnName, ColumnFilters.Operator.EQUAL, value);
+    return ColumnFilters.with(columnName, ColumnFilter.Operator.EQUAL, value);
   }
 
   /**
@@ -75,7 +75,7 @@ export class ColumnFilters {
    * @return {ColumnFilter} a new column filter
    */
   static lt(columnName, value) {
-    return ColumnFilters.with(columnName, ColumnFilters.Operator.LESS_THAN, value);
+    return ColumnFilters.with(columnName, ColumnFilter.Operator.LESS_THAN, value);
   }
 
   /**
@@ -87,7 +87,7 @@ export class ColumnFilters {
    * @return {ColumnFilter} a new column filter
    */
   static gt(columnName, value) {
-    return ColumnFilters.with(columnName, ColumnFilters.Operator.GREATER_THAN, value);
+    return ColumnFilters.with(columnName, ColumnFilter.Operator.GREATER_THAN, value);
   }
 
   /**
@@ -100,7 +100,7 @@ export class ColumnFilters {
    * @return {ColumnFilter} a new column filter
    */
   static le(columnName, value) {
-    return ColumnFilters.with(columnName, ColumnFilters.Operator.LESS_OR_EQUAL, value);
+    return ColumnFilters.with(columnName, ColumnFilter.Operator.LESS_OR_EQUAL, value);
   }
 
   /**
@@ -113,7 +113,7 @@ export class ColumnFilters {
    * @return {ColumnFilter} a new column filter
    */
   static ge(columnName, value) {
-    return ColumnFilters.with(columnName, ColumnFilters.Operator.GREATER_OR_EQUAL, value);
+    return ColumnFilters.with(columnName, ColumnFilter.Operator.GREATER_OR_EQUAL, value);
   }
 
   /**

--- a/client-js/src/client/actor-request-factory.js
+++ b/client-js/src/client/actor-request-factory.js
@@ -88,7 +88,7 @@ class Targets {
    * Instantiation not allowed and will throw an error.
    */
   constructor() {
-    throw 'Tried instantiating a utility class.';
+    throw new Error('Tried instantiating a utility class.');
   }
 
   /**
@@ -223,7 +223,7 @@ class QueryBuilder {
    */
   byIds(ids) {
     if (this._ids !== null) {
-      throw 'Can not set query ID more than once for QueryBuilder.';
+      throw new Error('Can not set query ID more than once for QueryBuilder.');
     }
     this._ids = ids.slice();
     return this;
@@ -247,7 +247,7 @@ class QueryBuilder {
    */
   where(predicates) {
     if (this._columns !== null) {
-      throw 'Can not set filters more than once for QueryBuilder.';
+      throw new Error('Can not set filters more than once for QueryBuilder.');
     }
     if (predicates[0] instanceof ColumnFilter) {
       QueryBuilder._checkAllOfType(predicates, ColumnFilter, INVALID_FILTER_TYPE);
@@ -275,8 +275,8 @@ class QueryBuilder {
    * @see FieldMask
    */
   withMask(fieldNames) {
-    if (typeof this._fieldMask !== 'undefined') {
-      throw 'Can not set field mask more than once for QueryBuilder.';
+    if (this._fieldMask != null) {
+      throw new Error('Can not set field mask more than once for QueryBuilder.');
     }
     if (!fieldNames.length) {
       return this;
@@ -308,7 +308,7 @@ class QueryBuilder {
   static _checkAllOfType(items, cls, message = 'Unexpected parameter type.') {
     items.forEach(item => {
       if (!(item instanceof cls)) {
-        throw message;
+        throw new Error(message);
       }
     });
   }

--- a/client-js/src/client/actor-request-factory.js
+++ b/client-js/src/client/actor-request-factory.js
@@ -42,28 +42,129 @@ import {Type, TypedMessage} from './typed-message';
 import {AnyPacker} from './any-packer';
 
 
-class ColumnFilters {
+/**
+ * A factory for `ColumnFilter` and `CompositeColumnFilter` instances.
+ */
+export class ColumnFilters {
+
   /**
-   * @param {ColumnFilter[]} filters
-   * @return {CompositeColumnFilter}
+   * Instantiation not allowed and will throw an error.
+   */
+  constructor() {
+    throw new Error('Tried instantiating a utility class.');
+  }
+
+  /**
+   * Creates a new filter for the value of named column to be equal to the provided value.
+   *
+   * @param {!String} columnName a string name of the entity column
+   * @param {TypedMessage} value a value to compare the column value to
+   *
+   * @return {ColumnFilter} a new column filter
+   */
+  static eq(columnName, value) {
+    return ColumnFilters.with(columnName, ColumnFilters.Operator.EQUAL, value);
+  }
+
+  /**
+   * Creates a new filter for the value of named column to be less than the provided value.
+   *
+   * @param {!String} columnName a string name of the entity column
+   * @param {TypedMessage} value a value to compare the column value to
+   *
+   * @return {ColumnFilter} a new column filter
+   */
+  static lt(columnName, value) {
+    return ColumnFilters.with(columnName, ColumnFilters.Operator.LESS_THAN, value);
+  }
+
+  /**
+   * Creates a new filter for the value of named column to be greater than the provided value.
+   *
+   * @param {!String} columnName a string name of the entity column
+   * @param {TypedMessage} value a value to compare the column value to
+   *
+   * @return {ColumnFilter} a new column filter
+   */
+  static gt(columnName, value) {
+    return ColumnFilters.with(columnName, ColumnFilters.Operator.GREATER_THAN, value);
+  }
+
+  /**
+   * Creates a new filter for the value of named column to be less or equal compared to
+   * the provided value.
+   *
+   * @param {!String} columnName a string name of the entity column
+   * @param {TypedMessage} value a value to compare the column value to
+   *
+   * @return {ColumnFilter} a new column filter
+   */
+  static le(columnName, value) {
+    return ColumnFilters.with(columnName, ColumnFilters.Operator.LESS_OR_EQUAL, value);
+  }
+
+  /**
+   * Creates a new filter for the value of named column to be greater or equal compared to
+   * the provided value.
+   *
+   * @param {!String} columnName a string name of the entity column
+   * @param {TypedMessage} value a value to compare the column value to
+   *
+   * @return {ColumnFilter} a new column filter
+   */
+  static ge(columnName, value) {
+    return ColumnFilters.with(columnName, ColumnFilters.Operator.GREATER_OR_EQUAL, value);
+  }
+
+  /**
+   * Creates a filter for a column by name to match the provided value according to an operator.
+   *
+   * @param {!String} columnName a string name of the entity column
+   * @param {!ColumnFilter.Operator} operator an operator to check column value to filter
+   * @param {TypedMessage} value a value to compare the column value to
+   *
+   * @return {ColumnFilter} a new column filter
+   */
+  static with(columnName, operator, value) {
+    const wrappedValue = AnyPacker().packTyped(value);
+    const filter = new ColumnFilter();
+    filter.setColumnName(columnName);
+    filter.setValue(wrappedValue);
+    filter.setOperator(operator);
+    return filter;
+  }
+
+  /**
+   * Creates a new composite filter which matches entities that fit every provided filter.
+   *
+   * @param {ColumnFilter[]} filters an array of column filters
+   *
+   * @return {CompositeColumnFilter} a new composite filter with `ALL` operator
    */
   static all(filters) {
     return ColumnFilters.compose(filters, CompositeColumnFilter.CompositeOperator.ALL);
   }
 
   /**
-   * @param {ColumnFilter[]} filters
-   * @return {CompositeColumnFilter}
+   * Creates a new composite filter which matches entities that fit at least one
+   * of the provided filters.
+   *
+   * @param {ColumnFilter[]} filters an array of column filters
+   *
+   * @return {CompositeColumnFilter} a new composite filter with `EITHER` operator
    */
   static either(filters) {
     return ColumnFilters.compose(filters, CompositeColumnFilter.CompositeOperator.EITHER);
   }
 
   /**
+   * Creates a new composite filter which matches entities according to an array of filters with a
+   * specified logical operator.
    *
-   * @param {ColumnFilter[]} filters
-   * @param {CompositeColumnFilter.CompositeOperator} operator
-   * @return {CompositeColumnFilter}
+   * @param {ColumnFilter[]} filters an array of column filters
+   * @param {CompositeColumnFilter.CompositeOperator} operator a logical operator for `filters`
+   *
+   * @return {CompositeColumnFilter} a new composite filter
    */
   static compose(filters, operator) {
     const compositeFilter = new CompositeColumnFilter();

--- a/client-js/src/client/actor-request-factory.js
+++ b/client-js/src/client/actor-request-factory.js
@@ -126,7 +126,7 @@ export class ColumnFilters {
    * @return {ColumnFilter} a new column filter
    */
   static with(columnName, operator, value) {
-    const wrappedValue = AnyPacker().packTyped(value);
+    const wrappedValue = AnyPacker.packTyped(value);
     const filter = new ColumnFilter();
     filter.setColumnName(columnName);
     filter.setValue(wrappedValue);

--- a/client-js/src/client/actor-request-factory.js
+++ b/client-js/src/client/actor-request-factory.js
@@ -323,6 +323,11 @@ class QueryBuilder {
    * Sets an ID predicate of the `Query#getTarget()`.
    *
    * Makes the query return only the entities identified by the provided IDs.
+   * 
+   * Supported ID types are string, number, and `TypedMessage`. To use other primitive types
+   * wrap them in type message using Protobuf primitive wrappers (e.g. StringValue, BytesValue).
+   * 
+   * If number IDs are passed they are assumed to be of `int64` Protobuf type. 
    *
    * @param {!TypedMessage[]|Number[]|String[]} ids an array with identifiers of entities to query
    * @return {QueryBuilder} the current builder instance

--- a/client-js/src/client/actor-request-factory.js
+++ b/client-js/src/client/actor-request-factory.js
@@ -58,7 +58,7 @@ export class ColumnFilters {
    * Creates a new filter for the value of named column to be equal to the provided value.
    *
    * @param {!String} columnName a string name of the entity column
-   * @param {TypedMessage} value a value to compare the column value to
+   * @param {!TypedMessage} value a value to compare the column value to
    *
    * @return {ColumnFilter} a new column filter
    */
@@ -70,7 +70,7 @@ export class ColumnFilters {
    * Creates a new filter for the value of named column to be less than the provided value.
    *
    * @param {!String} columnName a string name of the entity column
-   * @param {TypedMessage} value a value to compare the column value to
+   * @param {!TypedMessage} value a value to compare the column value to
    *
    * @return {ColumnFilter} a new column filter
    */
@@ -82,7 +82,7 @@ export class ColumnFilters {
    * Creates a new filter for the value of named column to be greater than the provided value.
    *
    * @param {!String} columnName a string name of the entity column
-   * @param {TypedMessage} value a value to compare the column value to
+   * @param {!TypedMessage} value a value to compare the column value to
    *
    * @return {ColumnFilter} a new column filter
    */
@@ -95,7 +95,7 @@ export class ColumnFilters {
    * the provided value.
    *
    * @param {!String} columnName a string name of the entity column
-   * @param {TypedMessage} value a value to compare the column value to
+   * @param {!TypedMessage} value a value to compare the column value to
    *
    * @return {ColumnFilter} a new column filter
    */
@@ -108,7 +108,7 @@ export class ColumnFilters {
    * the provided value.
    *
    * @param {!String} columnName a string name of the entity column
-   * @param {TypedMessage} value a value to compare the column value to
+   * @param {!TypedMessage} value a value to compare the column value to
    *
    * @return {ColumnFilter} a new column filter
    */
@@ -121,7 +121,7 @@ export class ColumnFilters {
    *
    * @param {!String} columnName a string name of the entity column
    * @param {!ColumnFilter.Operator} operator an operator to check column value to filter
-   * @param {TypedMessage} value a value to compare the column value to
+   * @param {!TypedMessage} value a value to compare the column value to
    *
    * @return {ColumnFilter} a new column filter
    */
@@ -137,7 +137,7 @@ export class ColumnFilters {
   /**
    * Creates a new composite filter which matches entities that fit every provided filter.
    *
-   * @param {ColumnFilter[]} filters an array of column filters
+   * @param {!ColumnFilter[]} filters an array of column filters
    *
    * @return {CompositeColumnFilter} a new composite filter with `ALL` operator
    */
@@ -149,7 +149,7 @@ export class ColumnFilters {
    * Creates a new composite filter which matches entities that fit at least one
    * of the provided filters.
    *
-   * @param {ColumnFilter[]} filters an array of column filters
+   * @param {!ColumnFilter[]} filters an array of column filters
    *
    * @return {CompositeColumnFilter} a new composite filter with `EITHER` operator
    */
@@ -161,8 +161,8 @@ export class ColumnFilters {
    * Creates a new composite filter which matches entities according to an array of filters with a
    * specified logical operator.
    *
-   * @param {ColumnFilter[]} filters an array of column filters
-   * @param {CompositeColumnFilter.CompositeOperator} operator a logical operator for `filters`
+   * @param {!ColumnFilter[]} filters an array of column filters
+   * @param {!CompositeColumnFilter.CompositeOperator} operator a logical operator for `filters`
    *
    * @return {CompositeColumnFilter} a new composite filter
    */
@@ -228,7 +228,7 @@ class Targets {
    */
   static _all(type) {
     const target = new Target();
-    target.setType(type.url().value);
+    target.setType(type.url().value());
     target.setIncludeAll(true);
     return target;
   }
@@ -243,7 +243,7 @@ class Targets {
    */
   static _filtered(type, filters) {
     const target = new Target();
-    target.setType(type.url().value);
+    target.setType(type.url().value());
     target.setFilters(filters);
     return target;
   }

--- a/client-js/src/client/any-packer.js
+++ b/client-js/src/client/any-packer.js
@@ -121,7 +121,7 @@ class Unpack {
    * @return {Message} a protobuf message wrapped in `Any` deserialized using the provided type
    */
   as(type) {
-    return this._any.unpack(type.class().deserializeBinary, type.url().typeName);
+    return this._any.unpack(type.class().deserializeBinary, type.url().name());
   }
 }
 
@@ -271,7 +271,7 @@ class Pack {
     const typeUrl = type.url();
     const result = new Any();
     const bytes = message.serializeBinary();
-    result.pack(bytes, typeUrl.typeName, typeUrl.typeUrlPrefix);
+    result.pack(bytes, typeUrl.name(), typeUrl.prefix());
     return result;
   }
 }

--- a/client-js/src/client/any-packer.js
+++ b/client-js/src/client/any-packer.js
@@ -320,7 +320,7 @@ export class AnyPacker {
    * @return {Unpack} an unpacker for the provided `Any` instance
    */
   static unpack(any) {
-    return new Unpack(any)
+    return new Unpack(any);
   }
 
   /**
@@ -351,7 +351,7 @@ export class AnyPacker {
    */
   static packTyped(message) {
     if (!(message instanceof TypedMessage)) {
-      throw new Error('Only TypedMessage instance can be packed using AnyPacker#packTyped().')
+      throw new Error('Only TypedMessage instance can be packed using AnyPacker#packTyped().');
     }
     return new Pack(message.message).as(message.type);
   }

--- a/client-js/src/client/any-packer.js
+++ b/client-js/src/client/any-packer.js
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2018, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+import {Type, TypedMessage} from './typed-message';
+import {
+  Int32Value,
+  Int64Value,
+  StringValue
+} from 'spine-web-client-proto/google/protobuf/wrappers_pb';
+import {Any} from 'spine-web-client-proto/google/protobuf/any_pb';
+
+
+class Unpack {
+  /**
+   * @param {Any} any
+   */
+  constructor(any) {
+    /**
+     * @type {Any}
+     * @private
+     */
+    this._any = any;
+  }
+
+  /**
+   * @return {String}
+   */
+  asString() {
+    return this.as(Type.STRING).getValue();
+  }
+
+  /**
+   * @return {Number}
+   */
+  asInt32() {
+    return this.as(Type.INT32).getValue();
+  }
+
+  /**
+   * @return {Number}
+   */
+  asInt64() {
+    return this.as(TYPE.INT64).getValue();
+  }
+
+  /**
+   * @param {Type} type
+   * @return {Message}
+   */
+  as(type) {
+    return this._any.unpack(type.class().deserializeBinary, type.url().typeName);
+  }
+}
+
+class Pack {
+  /**
+   * @param {*} value
+   */
+  constructor(value) {
+    this._value = value;
+  }
+
+  /**
+   * @return {String}
+   */
+  asString() {
+    return Pack._primitive(this._value, Type.STRING);
+  }
+
+  /**
+   * @return {String}
+   */
+  asInt32() {
+    return Pack._primitive(this._value, Type.INT32);
+  }
+
+  /**
+   * @return {String}
+   */
+  asInt64() {
+    return Pack._primitive(this._value, Type.INT64);
+  }
+
+  /**
+   * @param {Type} type
+   * @return {Any}
+   */
+  as(type) {
+    return Pack._message(this._value, type);
+  }
+
+  /**
+   * @param {Type} type
+   * @private
+   */
+  _wrapPrimitive(type) {
+    const wrapper = type.class();
+    return wrapper([this._value]);
+  }
+
+  static _primitive(value, type) {
+    const wrapper = type.class();
+    const message = wrapper([value]);
+    return Pack._message(message, type);
+  }
+
+  static _message(message, type) {
+    const typeUrl = type.url();
+    const result = new Any();
+    const bytes = message.serializeBinary();
+    result.pack(bytes, typeUrl.typeName, typeUrl.typeUrlPrefix);
+    return result;
+  }
+}
+
+
+export class AnyPacker {
+  static string(value) {
+    const result = new StringValue();
+    result.setValue(value);
+    return result;
+  }
+
+  /**
+   * @param {!Any} any
+   * @return {Unpack}
+   */
+  static unpack(any) {
+    return new Unpack(any)
+  }
+
+  /**
+   * @param {!Message|string|number} message
+   * @return {Pack}
+   */
+  static pack(message) {
+    return new Pack(message);
+  }
+
+  /**
+   * @param {!TypedMessage} value
+   * @return {Any}
+   */
+  static packTyped(value) {
+    return new Pack(value.message).as(value.type);
+  }
+}

--- a/client-js/src/client/any-packer.js
+++ b/client-js/src/client/any-packer.js
@@ -129,13 +129,7 @@ class Pack {
   }
 }
 
-
 export class AnyPacker {
-  static string(value) {
-    const result = new StringValue();
-    result.setValue(value);
-    return result;
-  }
 
   /**
    * @param {!Any} any

--- a/client-js/src/client/any-packer.js
+++ b/client-js/src/client/any-packer.js
@@ -56,7 +56,7 @@ class Unpack {
    * @return {Number}
    */
   asInt64() {
-    return this.as(TYPE.INT64).getValue();
+    return this.as(Type.INT64).getValue();
   }
 
   /**

--- a/client-js/src/client/any-packer.js
+++ b/client-js/src/client/any-packer.js
@@ -26,9 +26,12 @@ import {
 import {Any} from 'spine-web-client-proto/google/protobuf/any_pb';
 
 
+/**
+ * An packer of string, number, boolean, and message values from Protobuf `Any`.
+ */
 class Unpack {
   /**
-   * @param {Any} any
+   * @param {Any} any a Protobuf `Any` value to be unpacked to message or primitive
    */
   constructor(any) {
     /**
@@ -39,6 +42,8 @@ class Unpack {
   }
 
   /**
+   * Unpacks a Protobuf `Any` assuming it contains a string value.
+   *
    * @return {String}
    */
   asString() {
@@ -46,6 +51,8 @@ class Unpack {
   }
 
   /**
+   * Unpacks a Protobuf `Any` assuming it contains an int32 value.
+   *
    * @return {Number}
    */
   asInt32() {
@@ -53,6 +60,17 @@ class Unpack {
   }
 
   /**
+   * Unpacks a Protobuf `Any` assuming it contains an unsigned int32 value.
+   *
+   * @return {Number}
+   */
+  asUInt32() {
+    return this.as(Type.UINT32).getValue();
+  }
+
+  /**
+   * Unpacks a Protobuf `Any` assuming it contains an int64 value.
+   *
    * @return {Number}
    */
   asInt64() {
@@ -60,14 +78,56 @@ class Unpack {
   }
 
   /**
-   * @param {Type} type
-   * @return {Message}
+   * Unpacks a Protobuf `Any` assuming it contains an unsigned int64 value.
+   *
+   * @return {Number}
+   */
+  asUInt64() {
+    return this.as(Type.UINT64).getValue();
+  }
+
+  /**
+   * Unpacks a Protobuf `Any` assuming it contains a boolean value.
+   *
+   * @return {boolean}
+   */
+  asBool() {
+    return this.as(Type.BOOL).getValue();
+  }
+
+  /**
+   * Unpacks a Protobuf `Any` assuming it contains a double value.
+   *
+   * @return {number}
+   */
+  asDouble() {
+    return this.as(Type.DOUBLE).getValue();
+  }
+
+  /**
+   * Unpacks a Protobuf `Any` assuming it contains a float value.
+   *
+   * @return {number}
+   */
+  asFloat() {
+    return this.as(Type.FLOAT).getValue();
+  }
+
+  /**
+   * Unpacks a Protobuf `Any` assuming it a message of the provided type.
+   *
+   * @param {!Type} type a type used to deserialize `Any` encompassed in this unpacker
+   *
+   * @return {Message} a protobuf message wrapped in `Any` deserialized using the provided type
    */
   as(type) {
     return this._any.unpack(type.class().deserializeBinary, type.url().typeName);
   }
 }
 
+/**
+ * A packer of string, number, boolean, and message values to Protobuf `Any`.
+ */
 class Pack {
   /**
    * @param {*} value
@@ -77,49 +137,136 @@ class Pack {
   }
 
   /**
-   * @return {String}
+   * Packs the encompassed value assuming its of a string type.
+   *
+   * @return {Any} a new any instance with this packers value
    */
   asString() {
-    return Pack._primitive(this._value, Type.STRING);
+    return Pack._primitive(this._value.toString(), Type.STRING);
   }
 
   /**
-   * @return {String}
+   * Packs the encompassed value assuming its of an int32 type.
+   *
+   * @return {Any} a new any instance with this packers value
    */
   asInt32() {
-    return Pack._primitive(this._value, Type.INT32);
+    const value = Number(this._value);
+    if (isNaN(value)) {
+      throw new Error('The value could not be coerced to a number');
+    }
+    return Pack._primitive(Math.floor(value.valueOf()), Type.INT32);
   }
 
   /**
-   * @return {String}
+   * Packs the encompassed value assuming its of an unsigned int32 type.
+   *
+   * @return {Any} a new any instance with this packers value
+   */
+  asUInt32() {
+    const value = Number(this._value);
+    if (isNaN(value)) {
+      throw new Error('The value could not be coerced to a number');
+    }
+    return Pack._primitive(Math.floor(value.valueOf()), Type.UINT32);
+  }
+
+  /**
+   * Packs the encompassed value assuming its of an int64 type.
+   *
+   * @return {Any} a new any instance with this packers value
    */
   asInt64() {
-    return Pack._primitive(this._value, Type.INT64);
+    const value = Number(this._value);
+    if (isNaN(value)) {
+      throw new Error('The value could not be coerced to a number');
+    }
+    return Pack._primitive(Math.floor(value.valueOf()), Type.INT64);
   }
 
   /**
-   * @param {Type} type
-   * @return {Any}
+   * Packs the encompassed value assuming its of an unsigned int64 type.
+   *
+   * @return {Any} a new any instance with this packers value
+   */
+  asUInt64() {
+    const value = Number(this._value);
+    if (isNaN(value)) {
+      throw new Error('The value could not be coerced to a number');
+    }
+    return Pack._primitive(Math.floor(value.valueOf()), Type.UINT64);
+  }
+
+  /**
+   * Packs the encompassed value assuming its of a float type.
+   *
+   * @return {Any} a new any instance with this packers value
+   */
+  asFloat() {
+    const value = Number(this._value);
+    if (isNaN(value)) {
+      throw new Error('The value could not be coerced to a number');
+    }
+    return Pack._primitive(value.valueOf(), Type.FLOAT);
+  }
+
+  /**
+   * Packs the encompassed value assuming its of a double type.
+   *
+   * @return {Any} a new any instance with this packers value
+   */
+  asDouble() {
+    const value = Number(this._value);
+    if (isNaN(value)) {
+      throw new Error('The value could not be coerced to a number');
+    }
+    return Pack._primitive(value.valueOf(), Type.DOUBLE);
+  }
+
+  /**
+   * Packs the encompassed value assuming its of a boolean type.
+   *
+   * @return {Any} a new any instance with this packers value
+   */
+  asBool() {
+    return Pack._primitive(!!this._value, Type.BOOL);
+  }
+
+  /**
+   * @param {!Type} type a type to pack the value encompassed in this packer to
+   *
+   * @return {Any} a new any instance with this packers value
    */
   as(type) {
     return Pack._message(this._value, type);
   }
 
   /**
-   * @param {Type} type
+   * Packs a primitive (number, string, boolean) value to Protobuf `Any`.
+   *
+   * @param {!number|string|boolean} value a primitive value to pack
+   * @param {!Type} type definition of the type to wrap the value
+   *
+   * @return {Any} a new `Any`
+   *
    * @private
    */
-  _wrapPrimitive(type) {
-    const wrapper = type.class();
-    return wrapper([this._value]);
-  }
-
   static _primitive(value, type) {
     const wrapper = type.class();
     const message = wrapper([value]);
     return Pack._message(message, type);
   }
 
+  /**
+   * Packs a Protobuf message to Protobuf `Any`.
+   *
+   * @param {!Message} message a message to be packed into `Any`
+   * @param {!Type} type definition of the Message type
+   *
+   * @return {Any} a new `Any`
+   *
+   * @private
+   */
   static _message(message, type) {
     const typeUrl = type.url();
     const result = new Any();
@@ -129,29 +276,83 @@ class Pack {
   }
 }
 
+/**
+ * Utilities for packing messages into {@link Any} and unpacking them.
+ *
+ * @example
+ * // Packing `TypedMessage` instance:
+ * const task = new Task(message, TASK_TYPE);
+ * const anyWithTask = AnyPacker.packTyped(task);
+ *
+ * @example
+ * // Packing Protobuf messages:
+ * const anyWithTask = AnyPacker.pack(message).as(TASK_TYPE);
+ * const task = AnyPacker.unpack(anyWithTask).as(TASK_TYPE);
+ *
+ * @example
+ * // Packing strings:
+ * const anyWithString = AnyPacker.pack('Presents get packed too!').asString();
+ * console.log(AnyPacker.unpack(anyWithString).asString());
+ * // Out: Presents get packed too!
+ */
 export class AnyPacker {
 
   /**
-   * @param {!Any} any
-   * @return {Unpack}
+   * Instantiation not allowed and will throw an error.
+   */
+  constructor() {
+    throw new Error('Tried instantiating a utility class.');
+  }
+
+  /**
+   * Creates a new packer for the provided `Any` instance.
+   *
+   * @example
+   * // Unpacking messages:
+   * AnyPacker.unpack(anyWithTask).as(TASK_TYPE);
+   *
+   * @example
+   * // Unpacking primitive values:
+   * AnyPacker.pack('Presents get packed too!').asString();
+   *
+   * @param {!Any} any a Protobuf `Any` message to unpack
+   *
+   * @return {Unpack} an unpacker for the provided `Any` instance
    */
   static unpack(any) {
     return new Unpack(any)
   }
 
   /**
-   * @param {!Message|string|number} message
+   * Creates a new packer for the provided value.
+   *
+   * @example
+   * // Packing primitive values:
+   * AnyPacker.pack('Presents get packed too!').asString();
+   *
+   * @example
+   * // Packing Protobuf messages:
+   * const anyWithTask = AnyPacker.pack(message).as(TASK_TYPE);
+   *
+   * @param {!*} value a value of
+   *
    * @return {Pack}
    */
-  static pack(message) {
-    return new Pack(message);
+  static pack(value) {
+    return new Pack(value);
   }
 
   /**
-   * @param {!TypedMessage} value
-   * @return {Any}
+   * Packs a `TypedMessage` into a Protobuf `Any`.
+   *
+   * @param {!TypedMessage} message a message to be packed
+   *
+   * @return {Any} a new Any with provided typed message inside
    */
-  static packTyped(value) {
-    return new Pack(value.message).as(value.type);
+  static packTyped(message) {
+    if (!(message instanceof TypedMessage)) {
+      throw new Error('Only TypedMessage instance can be packed using AnyPacker#packTyped().')
+    }
+    return new Pack(message.message).as(message.type);
   }
 }

--- a/client-js/src/client/any-packer.js
+++ b/client-js/src/client/any-packer.js
@@ -253,7 +253,7 @@ class Pack {
    */
   static _primitive(value, type) {
     const wrapper = type.class();
-    const message = wrapper([value]);
+    const message = new wrapper([value]);
     return Pack._message(message, type);
   }
 

--- a/client-js/src/client/backend-client.js
+++ b/client-js/src/client/backend-client.js
@@ -170,7 +170,7 @@ export class BackendClient {
    * @template <T>
    */
   fetchById(type, id, dataCallback, errorCallback) {
-    const query = this._requestFactory.query().select(type).byId(id).build();
+    const query = this._requestFactory.query().select(type).byIds([id]).build();
 
     const observer = {next: dataCallback};
     if (errorCallback) {

--- a/client-js/src/client/backend-client.js
+++ b/client-js/src/client/backend-client.js
@@ -70,7 +70,7 @@ class Fetch {
    * @abstract
    */
   oneByOne() {
-    throw 'Not implemented in abstract base.';
+    throw new Error('Not implemented in abstract base.');
   }
 
   /**
@@ -85,7 +85,7 @@ class Fetch {
    * @abstract
    */
   atOnce() {
-    throw 'Not implemented in abstract base.';
+    throw new Error('Not implemented in abstract base.');
   }
 }
 
@@ -223,7 +223,7 @@ export class BackendClient {
    */
   subscribeToEntities({ofType: typeUrl, byIds: ids, byId: id}) {
     if (typeof ids !== 'undefined' && typeof id !== 'undefined') {
-      throw "You can specify only one of ids or id as a parameter to subscribeToEntities";
+      throw new Error('You can specify only one of ids or id as a parameter to subscribeToEntities');
     }
     if (typeof id !== 'undefined') {
       ids = [id];
@@ -269,7 +269,7 @@ export class BackendClient {
    * @abstract
    */
   _fetchOf(query) {
-    throw 'Not implemented in abstract base.';
+    throw new Error('Not implemented in abstract base.');
   }
 
   /**
@@ -281,7 +281,7 @@ export class BackendClient {
    * @abstract
    */
   _subscribeToTopic(topic) {
-    throw 'Not implemented in abstract base.';
+    throw new Error('Not implemented in abstract base.');
   }
 }
 

--- a/client-js/src/client/backend-client.js
+++ b/client-js/src/client/backend-client.js
@@ -21,16 +21,16 @@
 "use strict";
 
 import {Observable, Subscription} from './observable';
-import {TypedMessage, TypeUrl} from './typed-message';
+import {TypedMessage} from './typed-message';
 import {EndpointError, HttpEndpoint, QUERY_STRATEGY} from './http-endpoint';
 import {HttpClient} from './http-client';
 import {FirebaseClient} from './firebase-client';
 import {ActorRequestFactory} from './actor-request-factory';
-import {FirebaseSubscriptionService} from "./firebase-subscription-service";
+import {FirebaseSubscriptionService} from './firebase-subscription-service';
 import {
   Subscription as SpineSubscription,
   SubscriptionId
-} from "spine-web-client-proto/spine/client/subscription_pb";
+} from 'spine-web-client-proto/spine/client/subscription_pb';
 
 /**
  * An abstract Fetch that can fetch the data of a provided query in one of two ways
@@ -146,21 +146,21 @@ export class BackendClient {
    * // Fetch all entities of a developer-defined Task type at once using a Promise.
    * fetchAll({ofType: taskType}).atOnce().then(tasks => { ... })
    *
-   * @param {!TypeUrl<T>} ofType a type of the entities to be queried
+   * @param {!Type<T>} ofType a type of the entities to be queried
    * @return {BackendClient.Fetch<T>} a fetch object allowing to specify additional remote
    *                                call parameters and executed the query.
    *
    * @template <T>
    */
-  fetchAll({ofType: typeUrl}) {
-    const query = this._requestFactory.query().select(typeUrl).build();
+  fetchAll({ofType: type}) {
+    const query = this._requestFactory.query().select(type).build();
     return this._fetchOf(query);
   }
 
   /**
    * Fetches a single entity of the given type.
    *
-   * @param {!TypeUrl<T>} type a type URL of the target entity
+   * @param {!Type<T>} type a type URL of the target entity
    * @param {!TypedMessage} id an ID of the target entity
    * @param {!consumerCallback<Object>} dataCallback
    *        a callback receiving a single data item as a JS object
@@ -215,13 +215,13 @@ export class BackendClient {
    *
    * The entities that already exist will be initially passed to the `itemAdded` observer. 
    *
-   * @param {!TypeUrl} ofType a type URL of entities to observe changes
+   * @param {!Type} ofType a type URL of entities to observe changes
    * @param {?TypedMessage[]} byIds an array of ids of entities to observe changes
    * @param {?TypedMessage} byId an id of a single entity to observe changes
    * @return {Promise<EntitySubscriptionObject>} a promise of means to observe the changes 
    *                                             and unsubscribe from the updated 
    */
-  subscribeToEntities({ofType: typeUrl, byIds: ids, byId: id}) {
+  subscribeToEntities({ofType: type, byIds: ids, byId: id}) {
     if (typeof ids !== 'undefined' && typeof id !== 'undefined') {
       throw new Error('You can specify only one of ids or id as a parameter to subscribeToEntities');
     }
@@ -230,9 +230,9 @@ export class BackendClient {
     }
     let topic;
     if (ids) {
-      topic = this._requestFactory.topic().someOf(typeUrl, ids);
+      topic = this._requestFactory.topic().someOf(type, ids);
     } else {
-      topic = this._requestFactory.topic().allOf(typeUrl);
+      topic = this._requestFactory.topic().allOf(type);
     }
     return this._subscribeToTopic(topic);
   }

--- a/client-js/src/client/firebase-subscription-service.js
+++ b/client-js/src/client/firebase-subscription-service.js
@@ -51,7 +51,7 @@ export class FirebaseSubscriptionService {
    */
   add(subscription) {
     if (this._isRegistered(subscription)) {
-      throw "This subscription is already registered in subscription service";
+      throw new Error('This subscription is already registered in subscription service');
     }
     this._subscriptions.push(subscription);
   }
@@ -61,7 +61,7 @@ export class FirebaseSubscriptionService {
    */
   run() {
     if (this._interval) {
-      throw "The FirebaseSubscriptionService is already running";
+      throw new Error('The FirebaseSubscriptionService is already running');
     }
     this._interval = setInterval(() => {
       this._keepUpSubscriptions();
@@ -86,7 +86,7 @@ export class FirebaseSubscriptionService {
    */
   stop() {
     if (!this._interval) {
-      throw "The FirebaseSubscriptionService was stopped when it was not running";
+      throw new Error('The FirebaseSubscriptionService was stopped when it was not running');
     }
     clearInterval(this._interval);
     this._subscriptions.forEach(subscription => {

--- a/client-js/src/client/http-endpoint.js
+++ b/client-js/src/client/http-endpoint.js
@@ -18,16 +18,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import {TypedMessage, TypeUrl} from './typed-message';
+import {Type, TypedMessage} from './typed-message';
 import {WebQuery} from 'spine-web-client-proto/spine/web/web_query_pb';
-
-/**
- * The type URL representing the spine.client.Query.
- *
- * @type {TypeUrl}
- */
-const WEB_QUERY_MESSAGE_TYPE = new TypeUrl('type.spine.io/spine.web.WebQuery');
-const SUBSCRIPTION_MESSAGE_TYPE = new TypeUrl('type.spine.io/spine.client.Subscription');
 
 /**
  * An error which occurred when sending off a request to Spine server endpoint.
@@ -109,7 +101,7 @@ class Endpoint {
    */
   query(query, strategy) {
     const webQuery = Endpoint._newWebQuery({of: query, delivered: strategy});
-    const typedQuery = new TypedMessage(webQuery, WEB_QUERY_MESSAGE_TYPE);
+    const typedQuery = new TypedMessage(webQuery, Type.WEB_QUERY);
     return this._performQuery(typedQuery);
   }
 
@@ -121,7 +113,7 @@ class Endpoint {
    *                           an error occurs
    */
   subscribeTo(topic) {
-    const typedTopic = new TypedMessage(topic, new TypeUrl('type.spine.io/spine.client.Topic'));
+    const typedTopic = new TypedMessage(topic, Type.TOPIC);
     return this._subscribeTo(typedTopic);
   }
 
@@ -133,7 +125,7 @@ class Endpoint {
    *                           an error occurs
    */
   keepUpSubscription(subscription) {
-    const typedSubscription = new TypedMessage(subscription, SUBSCRIPTION_MESSAGE_TYPE);
+    const typedSubscription = new TypedMessage(subscription, Type.SUBSCRIPTION);
     return this._keepUp(typedSubscription);
   }
 
@@ -147,7 +139,7 @@ class Endpoint {
    *                           an error occurs
    */
   cancelSubscription(subscription) {
-    const typedSubscription = new TypedMessage(subscription, SUBSCRIPTION_MESSAGE_TYPE);
+    const typedSubscription = new TypedMessage(subscription, Type.SUBSCRIPTION);
     return this._cancel(typedSubscription);
   }
 
@@ -281,8 +273,8 @@ export class HttpEndpoint extends Endpoint {
   /**
    * Sends off a request to create a subscription for a topic.
    *
-   * @param {!TypedMessage<spine.client.Subscription>} subscription a subscription that is prevented 
- *                                                                  from being closed by server
+   * @param {!TypedMessage<spine.client.Subscription>} subscription a subscription that is prevented
+   *                                                                  from being closed by server
    * @return {Promise<Response>} a promise of a successful server response JSON data, rejected if
    *                             the client response is not 2xx
    * @protected

--- a/client-js/src/client/http-endpoint.js
+++ b/client-js/src/client/http-endpoint.js
@@ -173,7 +173,7 @@ class Endpoint {
    * @abstract
    */
   _executeCommand(command) {
-    throw 'Not implemented in abstract base.';
+    throw new Error('Not implemented in abstract base.');
   }
 
   /**
@@ -184,7 +184,7 @@ class Endpoint {
    * @abstract
    */
   _performQuery(query) {
-    throw 'Not implemented in abstract base.';
+    throw new Error('Not implemented in abstract base.');
   }
 
   /**
@@ -195,7 +195,7 @@ class Endpoint {
    * @abstract
    */
   _subscribeTo(topic) {
-    throw 'Not implemented in abstract base.';
+    throw new Error('Not implemented in abstract base.');
   }
 
   /**
@@ -206,7 +206,7 @@ class Endpoint {
    * @abstract
    */
   _keepUp(subscription) {
-    throw 'Not implemented in abstract base.';
+    throw new Error('Not implemented in abstract base.');
   }
 
   /**
@@ -217,7 +217,7 @@ class Endpoint {
    * @abstract
    */
   _cancel(subscription) {
-    throw 'Not implemented in abstract base.';
+    throw new Error('Not implemented in abstract base.');
   }
 }
 

--- a/client-js/src/client/index.js
+++ b/client-js/src/client/index.js
@@ -18,7 +18,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import {TypedMessage, TypeUrl} from './typed-message';
+import {Type, TypedMessage, TypeUrl} from './typed-message';
 import {ActorRequestFactory} from './actor-request-factory';
 import {FirebaseClient} from './firebase-client';
 import {HttpClient} from './http-client';
@@ -37,5 +37,6 @@ export const client = {
   FirebaseClient,
   ActorRequestFactory,
   TypeUrl,
-  TypedMessage
+  TypedMessage,
+  Type,
 };

--- a/client-js/src/client/observable.js
+++ b/client-js/src/client/observable.js
@@ -101,7 +101,7 @@ export class Subscription {
    */
   unsubscribe() {
     if (this.closed) {
-      throw "Tried to unsubscribe from closed subscription";
+      throw new Error('Tried to unsubscribe from closed subscription');
     }
     this._unsubscribe();
     this._tearDownCallbacks.forEach(callback => callback());

--- a/client-js/src/client/typed-message.js
+++ b/client-js/src/client/typed-message.js
@@ -58,9 +58,30 @@ export class TypeUrl {
    */
   constructor(value) {
     const urlParts = value.split('/');
-    this.typeUrlPrefix = urlParts[0];
-    this.typeName = urlParts[1];
-    this.value = value;
+    this._value = value;
+    this._prefix = urlParts[0];
+    this._name = urlParts[1];
+  }
+
+  /**
+   * @return {string} part of the type URL before `/` specifying a namespace
+   */
+  prefix() {
+    return this._prefix;
+  }
+
+  /**
+   * @return {string} part of the type URL after `/` specifying the type name
+   */
+  name() {
+    return this._name;
+  }
+
+  /**
+   * @return {!string} full type URL value formatted as `<prefix>/<name>` string
+   */
+  value() {
+    return this._value;
   }
 }
 

--- a/client-js/src/client/typed-message.js
+++ b/client-js/src/client/typed-message.js
@@ -64,44 +64,71 @@ export class TypeUrl {
   }
 }
 
+/**
+ * A type of the Protobuf message represented by its JavaScript class and type URL.
+ *
+ * @template <T>
+ */
 export class Type {
+
   /**
-   * @param {Object} cls
-   * @param {TypeUrl} typeUrl
+   * @param {!Class<T>} cls a class of the `Message` type is for
+   * @param {!TypeUrl<T>} typeUrl a type URL of the `Message` type is for
    */
   constructor(cls, typeUrl) {
     this._cls = cls;
     this._typeUrl = typeUrl;
   }
 
+  /**
+   * @return {!TypeUrl<T>} a type URL of a defined type
+   */
   url() {
     return this._typeUrl;
   }
 
+  /**
+   * @return {!Class<T>} a JS class of a defined type
+   */
   class() {
     return this._cls;
+  }
+
+  /**
+   * A static factory for creating Type instances from `Message` class and type URL.
+   *
+   * @param {!Class<T>} cls a class of the `Message` type is for
+   * @param {!string|TypeUrl<T>} typeUrl a type URL of the `Message` type is for
+   *
+   * @return {Type<T>} new Type instance
+   */
+  static of(cls, typeUrl) {
+    if (!(typeUrl instanceof TypeUrl)) {
+      typeUrl = new TypeUrl(typeUrl);
+    }
+    return new Type(cls, typeUrl);
   }
 }
 
 // PRIMITIVE WRAPPERS
-Type.STRING = new Type(StringValue, new TypeUrl('type.googleapis.com/proto.google.protobuf.StringValue'));
-Type.INT32 = new Type(Int32Value, new TypeUrl('type.googleapis.com/proto.google.protobuf.Int32Value'));
-Type.UINT32 = new Type(UInt32Value, new TypeUrl('type.googleapis.com/proto.google.protobuf.Int32Value'));
-Type.INT64 = new Type(Int64Value, new TypeUrl('type.googleapis.com/proto.google.protobuf.Int64Value'));
-Type.UINT64 = new Type(UInt64Value, new TypeUrl('type.googleapis.com/proto.google.protobuf.Int64Value'));
-Type.BOOL = new Type(BoolValue, new TypeUrl('type.googleapis.com/proto.google.protobuf.BoolValue'));
-Type.DOUBLE = new Type(DoubleValue, new TypeUrl('type.googleapis.com/proto.google.protobuf.DoubleValue'));
-Type.FLOAT = new Type(FloatValue, new TypeUrl('type.googleapis.com/proto.google.protobuf.FloatValue'));
+Type.STRING = Type.of(StringValue, 'type.googleapis.com/proto.google.protobuf.StringValue');
+Type.INT32 = Type.of(Int32Value, 'type.googleapis.com/proto.google.protobuf.Int32Value');
+Type.UINT32 = Type.of(UInt32Value, 'type.googleapis.com/proto.google.protobuf.Int32Value');
+Type.INT64 = Type.of(Int64Value, 'type.googleapis.com/proto.google.protobuf.Int64Value');
+Type.UINT64 = Type.of(UInt64Value, 'type.googleapis.com/proto.google.protobuf.Int64Value');
+Type.BOOL = Type.of(BoolValue, 'type.googleapis.com/proto.google.protobuf.BoolValue');
+Type.DOUBLE = Type.of(DoubleValue, 'type.googleapis.com/proto.google.protobuf.DoubleValue');
+Type.FLOAT = Type.of(FloatValue, 'type.googleapis.com/proto.google.protobuf.FloatValue');
 
 // SPINE WEB
-Type.WEB_QUERY = new Type(WebQuery, new TypeUrl('type.spine.io/spine.web.WebQuery'));
+Type.WEB_QUERY = Type.of(WebQuery, 'type.spine.io/spine.web.WebQuery');
 
 // SPINE CLIENT
-Type.SUBSCRIPTION = new Type(Subscription, new TypeUrl('type.spine.io/spine.client.Subscription'));
-Type.TOPIC = new Type(Topic, new TypeUrl('type.spine.io/spine.client.Topic'));
+Type.SUBSCRIPTION = Type.of(Subscription, 'type.spine.io/spine.client.Subscription');
+Type.TOPIC = Type.of(Topic, 'type.spine.io/spine.client.Topic');
 
 // SPINE CORE
-Type.COMMAND = new Type(Command, new TypeUrl('type.spine.io/spine.core.Command'));
+Type.COMMAND = Type.of(Command, 'type.spine.io/spine.core.Command');
 
 /**
  * A Protobuf message with a {@link TypeUrl}.

--- a/client-js/src/client/typed-message.js
+++ b/client-js/src/client/typed-message.js
@@ -23,9 +23,14 @@
 import base64 from 'base64-js';
 import {Any} from 'spine-web-client-proto/google/protobuf/any_pb';
 import {
+  BoolValue,
+  DoubleValue,
+  FloatValue,
   Int32Value,
   Int64Value,
-  StringValue
+  StringValue,
+  UInt32Value,
+  UInt64Value,
 } from 'spine-web-client-proto/google/protobuf/wrappers_pb';
 import {WebQuery} from 'spine-web-client-proto/spine/web/web_query_pb';
 import {Subscription, Topic} from 'spine-web-client-proto/spine/client/subscription_pb';
@@ -81,7 +86,12 @@ export class Type {
 // PRIMITIVE WRAPPERS
 Type.STRING = new Type(StringValue, new TypeUrl('type.googleapis.com/proto.google.protobuf.StringValue'));
 Type.INT32 = new Type(Int32Value, new TypeUrl('type.googleapis.com/proto.google.protobuf.Int32Value'));
+Type.UINT32 = new Type(UInt32Value, new TypeUrl('type.googleapis.com/proto.google.protobuf.Int32Value'));
 Type.INT64 = new Type(Int64Value, new TypeUrl('type.googleapis.com/proto.google.protobuf.Int64Value'));
+Type.UINT64 = new Type(UInt64Value, new TypeUrl('type.googleapis.com/proto.google.protobuf.Int64Value'));
+Type.BOOL = new Type(BoolValue, new TypeUrl('type.googleapis.com/proto.google.protobuf.BoolValue'));
+Type.DOUBLE = new Type(DoubleValue, new TypeUrl('type.googleapis.com/proto.google.protobuf.DoubleValue'));
+Type.FLOAT = new Type(FloatValue, new TypeUrl('type.googleapis.com/proto.google.protobuf.FloatValue'));
 
 // SPINE WEB
 Type.WEB_QUERY = new Type(WebQuery, new TypeUrl('type.spine.io/spine.web.WebQuery'));
@@ -113,7 +123,7 @@ export class TypedMessage {
     this.message = message;
     this.type = type;
   }
-  
+
   /**
    * Converts this message into a Base64-encoded byte string.
    *
@@ -122,5 +132,99 @@ export class TypedMessage {
   toBase64() {
     const bytes = this.message.serializeBinary();
     return base64.fromByteArray(bytes);
+  }
+
+  /**
+   * Creates a new `TypedMessage` wrapping a string.
+   *
+   * @param {!String} value a string value for `TypedMessage`
+   * @return {TypedMessage<StringValue>} a new `TypedMessage` instance with provided value
+   */
+  static string(value) {
+    return new TypedMessage(new StringValue([value.toString()]), Type.STRING);
+  }
+
+  /**
+   * Creates a new `TypedMessage` with a 32-bit integer value.
+   *
+   * The number gets floored if the provided value contains a floating point.
+   *
+   * @param {!number|Number} value a number value for `TypedMessage`
+   * @return {TypedMessage<Int32Value>} a new `TypedMessage` instance with provided value
+   */
+  static int32(value) {
+    const message = new Int32Value([Math.floor(value.valueOf())]);
+    return new TypedMessage(message, Type.INT64);
+  }
+
+  /**
+   * Creates a new `TypedMessage` with an unsigned 32-bit integer value.
+   *
+   * The number gets floored if the provided value contains a floating point.
+   *
+   * @param {!number|Number} value a number value for `TypedMessage`
+   * @return {TypedMessage<UInt32Value>} a new `TypedMessage` instance with provided value
+   */
+  static uint32(value) {
+    const message = new UInt32Value([Math.floor(value.valueOf())]);
+    return new TypedMessage(message, Type.UINT64);
+  }
+
+  /**
+   * Creates a new `TypedMessage` with a 64-bit integer value.
+   *
+   * The number gets floored if the provided value contains a floating point.
+   *
+   * @param {!number|Number} value a number value for `TypedMessage`
+   * @return {TypedMessage<Int64Value>} a new `TypedMessage` instance with provided value
+   */
+  static int64(value) {
+    const message = new Int64Value([Math.floor(value.valueOf())]);
+    return new TypedMessage(message, Type.INT64);
+  }
+
+  /**
+   * Creates a new `TypedMessage` with an unsigned 64-bit integer value.
+   *
+   * The number gets floored if the provided value contains a floating point.
+   *
+   * @param {!number|Number} value a number value for `TypedMessage`
+   * @return {TypedMessage<UInt64Value>} a new `TypedMessage` instance with provided value
+   */
+  static uint64(value) {
+    const message = new UInt64Value([Math.floor(value.valueOf())]);
+    return new TypedMessage(message, Type.UINT64);
+  }
+
+  /**
+   * Creates a new `TypedMessage` with a float value.
+   *
+   * @param {!number|Number} value a number value for `TypedMessage`
+   * @return {TypedMessage<FloatValue>} a new `TypedMessage` instance with provided value
+   */
+  static float(value) {
+    const message = new FloatValue([value.valueOf()]);
+    return new TypedMessage(message, Type.FLOAT);
+  }
+
+  /**
+   * Creates a new `TypedMessage` with a double value.
+   *
+   * @param {!number|Number} value a number value for `TypedMessage`
+   * @return {TypedMessage<DoubleValue>} a new `TypedMessage` instance with provided value
+   */
+  static double(value) {
+    const message = new DoubleValue([value.valueOf()]);
+    return new TypedMessage(message, Type.DOUBLE);
+  }
+
+  /**
+   * Creates a new `TypedMessage` with a boolean value.
+   *
+   * @param {!boolean|Boolean} value `true` or `false` value for the `TypedMessage`
+   * @return {TypedMessage<BoolValue>} a new `TypedMessage` instance with provided value
+   */
+  static bool(value) {
+    return new TypedMessage(new BoolValue([value]), Type.BOOL);
   }
 }

--- a/client-js/src/client/typed-message.js
+++ b/client-js/src/client/typed-message.js
@@ -22,6 +22,15 @@
 
 import base64 from 'base64-js';
 import {Any} from 'spine-web-client-proto/google/protobuf/any_pb';
+import {
+  Int32Value,
+  Int64Value,
+  StringValue
+} from 'spine-web-client-proto/google/protobuf/wrappers_pb';
+import {WebQuery} from 'spine-web-client-proto/spine/web/web_query_pb';
+import {Subscription, Topic} from 'spine-web-client-proto/spine/client/subscription_pb';
+import {Command} from 'spine-web-client-proto/spine/core/command_pb';
+
 
 /**
  * A URL of a Protobuf type.
@@ -50,6 +59,40 @@ export class TypeUrl {
   }
 }
 
+export class Type {
+  /**
+   * @param {Object} cls
+   * @param {TypeUrl} typeUrl
+   */
+  constructor(cls, typeUrl) {
+    this._cls = cls;
+    this._typeUrl = typeUrl;
+  }
+
+  url() {
+    return this._typeUrl;
+  }
+
+  class() {
+    return this._cls;
+  }
+}
+
+// PRIMITIVE WRAPPERS
+Type.STRING = new Type(StringValue, new TypeUrl('type.googleapis.com/proto.google.protobuf.StringValue'));
+Type.INT32 = new Type(Int32Value, new TypeUrl('type.googleapis.com/proto.google.protobuf.Int32Value'));
+Type.INT64 = new Type(Int64Value, new TypeUrl('type.googleapis.com/proto.google.protobuf.Int64Value'));
+
+// SPINE WEB
+Type.WEB_QUERY = new Type(WebQuery, new TypeUrl('type.spine.io/spine.web.WebQuery'));
+
+// SPINE CLIENT
+Type.SUBSCRIPTION = new Type(Subscription, new TypeUrl('type.spine.io/spine.client.Subscription'));
+Type.TOPIC = new Type(Topic, new TypeUrl('type.spine.io/spine.client.Topic'));
+
+// SPINE CORE
+Type.COMMAND = new Type(Command, new TypeUrl('type.spine.io/spine.core.Command'));
+
 /**
  * A Protobuf message with a {@link TypeUrl}.
  *
@@ -64,41 +107,20 @@ export class TypedMessage {
    * type URL.
    *
    * @param {!Message} message a Protobuf message
-   * @param {!TypeUrl<T>} typeUrl a Protobuf type of the message
+   * @param {!Type<T>} type a Protobuf type of the message
    */
-  constructor(message, typeUrl) {
+  constructor(message, type) {
     this.message = message;
-    this.type = typeUrl;
+    this.type = type;
   }
-
-  /**
-   * Converts this message into a byte array.
-   *
-   * @return an array of bytes representing the message
-   */
-  toBytes() {
-    return this.message.serializeBinary();
-  }
-
-  /**
-   * Converts this message into an {@link Any}.
-   *
-   * @return this message packed into an instance of Any
-   */
-  toAny() {
-    const result = new Any();
-    const bytes = this.toBytes();
-    result.pack(bytes, this.type.typeName, this.type.typeUrlPrefix);
-    return result;
-  }
-
+  
   /**
    * Converts this message into a Base64-encoded byte string.
    *
    * @return the string representing this message
    */
   toBase64() {
-    const bytes = this.toBytes();
+    const bytes = this.message.serializeBinary();
     return base64.fromByteArray(bytes);
   }
 }

--- a/client-js/test/client/any-packer-test.js
+++ b/client-js/test/client/any-packer-test.js
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2018, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import uuid from 'uuid';
+import assert from 'assert';
+
+import {AnyPacker} from "../../src/client/any-packer";
+import {Type, TypedMessage} from "../../src/client/typed-message";
+import {Task, TaskId} from "../../proto/test/js/spine/web/test/given/task_pb";
+import {Message} from 'google-protobuf';
+
+const MILLISECONDS = 1;
+const SECONDS = 1000 * MILLISECONDS;
+
+class Given {
+  constructor() {
+    throw new Error('A utility Given class cannot be instantiated.');
+  }
+
+  static newTask() {
+    const task = new Task();
+    task.setId(Given.newTaskId());
+    task.setName(uuid.v4());
+    return task;
+  }
+
+  static newTaskId() {
+    const taskId = new TaskId();
+    taskId.setValue(uuid.v4());
+    return taskId;
+  }
+
+  /**
+   * @param {string} actual
+   * @param {Type} expected
+   */
+  static assertTypeUrlForType(actual, expected) {
+    assert.equal(actual, expected.url().value());
+  }
+
+  /**
+   * @param {Message} actual
+   * @param {Message} expected
+   */
+  static assertMessagesEqual(actual, expected) {
+    assert.ok(Message.equals(actual, expected), 'Messages are expected to be identical.');
+  }
+}
+
+Given.TYPE = {
+  TASK_ID: Type.of(TaskId, 'type.spine.io/spine.web.test.given.TaskId'),
+  TASK: Type.of(Task, 'type.spine.io/spine.web.test.given.Task'),
+};
+
+describe('AnyPacker', function () {
+
+  this.timeout(5 * SECONDS);
+
+  it('packs messages', () => {
+    const task = Given.newTask();
+
+    const any = AnyPacker.pack(task).as(Given.TYPE.TASK);
+    assert.ok(any);
+    Given.assertTypeUrlForType(any.getTypeUrl(), Given.TYPE.TASK);
+
+    const message = AnyPacker.unpack(any).as(Given.TYPE.TASK);
+    Given.assertMessagesEqual(task, message);
+  });
+
+  it('packs a typed messages', () => {
+    const task = Given.newTask();
+    const typedTask = new TypedMessage(task, Given.TYPE.TASK);
+
+    const any = AnyPacker.packTyped(typedTask);
+    assert.ok(any);
+    Given.assertTypeUrlForType(any.getTypeUrl(), Given.TYPE.TASK);
+
+    const message = AnyPacker.unpack(any).as(Given.TYPE.TASK);
+    Given.assertMessagesEqual(task, message);
+  });
+
+  it('packs a string', () => {
+    const value = 'AnyPacker, I’m coming for you!';
+
+    const any = AnyPacker.pack(value).asString();
+    assert.ok(any);
+    Given.assertTypeUrlForType(any.getTypeUrl(), Type.STRING);
+
+    const actualValue = AnyPacker.unpack(any).asString();
+    assert.equal(actualValue, value);
+  });
+
+  it('packs an int32', () => {
+    const value = -33;
+
+    const any = AnyPacker.pack(value).asInt32();
+    assert.ok(any);
+    Given.assertTypeUrlForType(any.getTypeUrl(), Type.INT32);
+
+    const actualValue = AnyPacker.unpack(any).asInt32();
+    assert.equal(actualValue, value);
+  });
+
+  it('packs an int64', () => {
+    const value = -9223372036854775807;
+
+    const any = AnyPacker.pack(value).asInt64();
+    assert.ok(any);
+    Given.assertTypeUrlForType(any.getTypeUrl(), Type.INT64);
+
+    const actualValue = AnyPacker.unpack(any).asInt64();
+    assert.equal(actualValue, value);
+  });
+
+  it('packs an uint32', () => {
+    const value = 4294967295;
+
+    const any = AnyPacker.pack(value).asUInt32();
+    assert.ok(any);
+    Given.assertTypeUrlForType(any.getTypeUrl(), Type.UINT32);
+
+    const actualValue = AnyPacker.unpack(any).asUInt32();
+    assert.equal(actualValue, value);
+  });
+
+  it('packs an uint64', () => {
+    const value = Number.MAX_SAFE_INTEGER;
+
+    const any = AnyPacker.pack(value).asUInt64();
+    assert.ok(any);
+    Given.assertTypeUrlForType(any.getTypeUrl(), Type.UINT64);
+
+    const actualValue = AnyPacker.unpack(any).asUInt64();
+    assert.equal(actualValue, value);
+  });
+
+  it('packs a float', () => {
+    const value = 3.1235;
+    const stringValue = value.toString();
+
+    const any = AnyPacker.pack(value).asFloat();
+    assert.ok(any);
+    Given.assertTypeUrlForType(any.getTypeUrl(), Type.FLOAT);
+
+    const actualValue = AnyPacker.unpack(any).asFloat();
+    assert.ok(actualValue.toString().slice(0, stringValue.length), stringValue);
+  });
+
+  it('packs a double', () => {
+    const value = 3.33333733335;
+
+    const any = AnyPacker.pack(value).asDouble();
+    assert.ok(any);
+    Given.assertTypeUrlForType(any.getTypeUrl(), Type.DOUBLE);
+
+    const actualValue = AnyPacker.unpack(any).asDouble();
+    assert.equal(actualValue, value);
+  });
+
+  it('packs a boolean true value', () => {
+    const value = true;
+
+    const any = AnyPacker.pack(value).asBool();
+    assert.ok(any);
+    Given.assertTypeUrlForType(any.getTypeUrl(), Type.BOOL);
+
+    const actualValue = AnyPacker.unpack(any).asBool();
+    assert.ok(actualValue);
+  });
+
+  it('packs a boolean false value', () => {
+    const value = false;
+
+    const any = AnyPacker.pack(value).asBool();
+    assert.ok(any);
+    Given.assertTypeUrlForType(any.getTypeUrl(), Type.BOOL);
+
+    const actualValue = AnyPacker.unpack(any).asBool();
+    assert.ok(!actualValue);
+  });
+});

--- a/client-js/test/client/firebase-backend-test.js
+++ b/client-js/test/client/firebase-backend-test.js
@@ -48,26 +48,10 @@ function fail(done, message) {
 class Given {
 
   constructor() {
-    this.defaultTaskName = 'Get to Mount Doom';
-    this.defaultTaskDescription = 'There seems to be a bug with the rings that needs to be fixed';
-    this.TYPE = {
-      OF_ENTITY: {
-        TASK: new Type(Task, new TypeUrl('type.spine.io/spine.web.test.given.Task')),
-        PROJECT: new Type(Project, new TypeUrl('type.spine.io/spine.web.test.given.Project')),
-      },
-      OF_IDENTIFIER: {
-        TASK_ID: new Type(TaskId, new TypeUrl('type.spine.io/spine.web.test.given.TaskId')),
-      },
-      OF_COMMAND: {
-        CREATE_TASK: new Type(CreateTask, new TypeUrl('type.spine.io/spine.web.test.given.CreateTask')),
-        RENAME_TASK: new Type(RenameTask, new TypeUrl('type.spine.io/spine.web.test.given.RenameTask')),
-      },
-      MALFORMED: new Type(Object, new TypeUrl('types.spine.io/malformed')),
-    };
-    Given._deepFreeze(this);
+    throw new Error('A utility Given class cannot be instantiated.');
   }
 
-  backendClient() {
+  static backendClient() {
     return BackendClient.usingFirebase({
       atEndpoint: 'https://spine-dev.appspot.com',
       withFirebaseStorage: devFirebaseApp,
@@ -75,7 +59,15 @@ class Given {
     });
   }
 
-  createTaskCommand({withId: id, withPrefix: idPrefix, named: name, describedAs: description}) {
+  /**
+   * @param {?String} withId
+   * @param {?String} withPrefix
+   * @param {?String} named
+   * @param {?String} describedAs
+   *
+   * @return {TypedMessage<CreateTask>}
+   */
+  static createTaskCommand({withId: id, withPrefix: idPrefix, named: name, describedAs: description}) {
     const taskId = this._taskId({value: id, withPrefix: idPrefix});
 
     name = typeof name === 'undefined' ? this.defaultTaskName : name;
@@ -89,12 +81,15 @@ class Given {
     return new TypedMessage(command, this.TYPE.OF_COMMAND.CREATE_TASK);
   }
 
-  createTaskCommands({count, withPrefix: idPrefix, named: names}) {
-    if (!names || names.length !== count) {
-      throw new Error('Name count does not match the count of tasks to be created');
-    }
+  /**
+   * @param {!String[]} named
+   * @param {?String} withPrefix
+   *
+   * @return {TypedMessage<CreateTask>[]}
+   */
+  static createTaskCommands({named: names, withPrefix: idPrefix}) {
     const commands = [];
-    for (let i = 0; i < count; i++) {
+    for (let i = 0; i < names.length; i++) {
       const command = this.createTaskCommand({
         withPrefix: idPrefix,
         named: names[i]
@@ -104,7 +99,13 @@ class Given {
     return commands;
   }
 
-  renameTaskCommand({withId: id, to: newName}) {
+  /**
+   * @param {!String} withId
+   * @param {!String} to
+   *
+   * @return {TypedMessage<RenameTask>}
+   */
+  static renameTaskCommand({withId: id, to: newName}) {
     const taskId = this._taskId({value: id});
 
     const command = new RenameTask();
@@ -115,7 +116,14 @@ class Given {
 
   }
 
-  _taskId({value, withPrefix: prefix}) {
+  /**
+   * @param value
+   * @param withPrefix
+   *
+   * @return {TaskId}
+   * @private
+   */
+  static _taskId({value, withPrefix: prefix}) {
     if (typeof value === 'undefined') {
       value = uuid.v4();
     }
@@ -130,26 +138,29 @@ class Given {
   /**
    * A function that does nothing.
    */
-  noop() {
+  static noop() {
     // Do nothing.
-  }
-
-  static _deepFreeze(object) {
-
-    const propNames = Object.getOwnPropertyNames(object);
-
-    propNames.forEach((name) => {
-      const value = object[name];
-
-      object[name] = value && typeof value === "object" ? Given._deepFreeze(value) : value;
-    });
-
-    return Object.freeze(object);
   }
 }
 
-const given = new Given();
-const backendClient = given.backendClient();
+Given.defaultTaskName = 'Get to Mount Doom';
+Given.defaultTaskDescription = 'There seems to be a bug with the rings that needs to be fixed';
+Given.TYPE = {
+  OF_ENTITY: {
+    TASK: new Type(Task, new TypeUrl('type.spine.io/spine.web.test.given.Task')),
+    PROJECT: new Type(Project, new TypeUrl('type.spine.io/spine.web.test.given.Project')),
+  },
+  OF_IDENTIFIER: {
+    TASK_ID: new Type(TaskId, new TypeUrl('type.spine.io/spine.web.test.given.TaskId')),
+  },
+  OF_COMMAND: {
+    CREATE_TASK: new Type(CreateTask, new TypeUrl('type.spine.io/spine.web.test.given.CreateTask')),
+    RENAME_TASK: new Type(RenameTask, new TypeUrl('type.spine.io/spine.web.test.given.RenameTask')),
+  },
+  MALFORMED: new Type(Object, new TypeUrl('types.spine.io/malformed')),
+};
+
+const backendClient = Given.backendClient();
 
 describe('FirebaseBackendClient', function () {
 
@@ -158,7 +169,7 @@ describe('FirebaseBackendClient', function () {
 
   it('sends commands successfully', done => {
 
-    const command = given.createTaskCommand({
+    const command = Given.createTaskCommand({
       withIdPrefix: 'spine-web-test-send-command',
       named: 'Implement Spine Web JS client tests',
       describedAs: 'Spine Web need integration tests'
@@ -168,9 +179,9 @@ describe('FirebaseBackendClient', function () {
 
     backendClient.sendCommand(command, () => {
 
-      const typedId = new TypedMessage(taskId, given.TYPE.OF_IDENTIFIER.TASK_ID);
+      const typedId = new TypedMessage(taskId, Given.TYPE.OF_IDENTIFIER.TASK_ID);
 
-      backendClient.fetchById(given.TYPE.OF_ENTITY.TASK, typedId, data => {
+      backendClient.fetchById(Given.TYPE.OF_ENTITY.TASK, typedId, data => {
         assert.equal(data.id.value, taskId.getValue());
         assert.equal(data.name, command.message.getName());
         assert.equal(data.description, command.message.getDescription());
@@ -183,7 +194,7 @@ describe('FirebaseBackendClient', function () {
   });
 
   it('fails a malformed command', done => {
-    const command = given.createTaskCommand({withId: null});
+    const command = Given.createTaskCommand({withId: null});
 
     backendClient.sendCommand(
       command,
@@ -197,15 +208,15 @@ describe('FirebaseBackendClient', function () {
       fail(done, 'A command was rejected when an error was expected.'));
   });
 
-  it('fetches all the existing entities of given type one by one', done => {
-    const command = given.createTaskCommand({withPrefix: 'spine-web-test-one-by-one'});
+  it('fetches all the existing entities of Given type one by one', done => {
+    const command = Given.createTaskCommand({withPrefix: 'spine-web-test-one-by-one'});
     const taskId = command.message.getId();
 
     backendClient.sendCommand(command, () => {
 
       let itemFound = false;
 
-      backendClient.fetchAll({ofType: given.TYPE.OF_ENTITY.TASK}).oneByOne().subscribe({
+      backendClient.fetchAll({ofType: Given.TYPE.OF_ENTITY.TASK}).oneByOne().subscribe({
         next(data) {
           // Ordering is not guaranteed by fetch and 
           // the list of entities cannot be cleaned for tests,
@@ -222,13 +233,13 @@ describe('FirebaseBackendClient', function () {
     }, fail(done), fail(done));
   });
 
-  it('fetches all the existing entities of given type at once', done => {
-    const command = given.createTaskCommand({withPrefix: 'spine-web-test-at-once'});
+  it('fetches all the existing entities of Given type at once', done => {
+    const command = Given.createTaskCommand({withPrefix: 'spine-web-test-at-once'});
     const taskId = command.message.getId();
 
     backendClient.sendCommand(command, () => {
 
-      backendClient.fetchAll({ofType: given.TYPE.OF_ENTITY.TASK}).atOnce()
+      backendClient.fetchAll({ofType: Given.TYPE.OF_ENTITY.TASK}).atOnce()
         .then(data => {
           const targetObject = data.find(item => item.id.value === taskId.getValue());
           assert.ok(targetObject);
@@ -239,7 +250,7 @@ describe('FirebaseBackendClient', function () {
   });
 
   it('fetches an empty list for entity that does not get created at once', done => {
-    backendClient.fetchAll({ofType: given.TYPE.OF_ENTITY.PROJECT}).atOnce()
+    backendClient.fetchAll({ofType: Given.TYPE.OF_ENTITY.PROJECT}).atOnce()
       .then(data => {
         assert.ok(data.length === 0);
         done();
@@ -247,7 +258,7 @@ describe('FirebaseBackendClient', function () {
   });
 
   it('fetches an empty list for entity that does not get created one-by-one', done => {
-    backendClient.fetchAll({ofType: given.TYPE.OF_ENTITY.PROJECT}).oneByOne()
+    backendClient.fetchAll({ofType: Given.TYPE.OF_ENTITY.PROJECT}).oneByOne()
       .subscribe({
         next: fail(done),
         error: fail(done),
@@ -256,11 +267,11 @@ describe('FirebaseBackendClient', function () {
   });
 
   it('fails a malformed query', done => {
-    const command = given.createTaskCommand({withPrefix: 'spine-web-test-malformed-query'});
+    const command = Given.createTaskCommand({withPrefix: 'spine-web-test-malformed-query'});
 
     backendClient.sendCommand(command, () => {
 
-      backendClient.fetchAll({ofType: given.TYPE.MALFORMED}).atOnce()
+      backendClient.fetchAll({ofType: Given.TYPE.MALFORMED}).atOnce()
         .then(fail(done), error => {
           assert.ok(!error.isClient());
           assert.ok(error.isServer());
@@ -271,10 +282,11 @@ describe('FirebaseBackendClient', function () {
   });
 
   it('subscribes to new entities of type', done => {
-    const TASKS_TO_BE_CREATED = 3;
+    const names = ['Task #1', 'Task #2', 'Task #3'];
+    const tasksToBeCreated = names.length;
     let taskIds;
     let count = 0;
-    backendClient.subscribeToEntities({ofType: given.TYPE.OF_ENTITY.TASK})
+    backendClient.subscribeToEntities({ofType: Given.TYPE.OF_ENTITY.TASK})
       .then(({itemAdded, itemChanged, itemRemoved, unsubscribe}) => {
         itemAdded.subscribe({
           next: task => {
@@ -282,7 +294,7 @@ describe('FirebaseBackendClient', function () {
             console.log(`Retrieved task '${id}'`);
             if (taskIds.includes(id)) {
               count++;
-              if (count === TASKS_TO_BE_CREATED) {
+              if (count === tasksToBeCreated) {
                 unsubscribe();
                 done();
               }
@@ -298,14 +310,13 @@ describe('FirebaseBackendClient', function () {
       })
       .catch(fail(done));
 
-    const commands = given.createTaskCommands({
-      count: TASKS_TO_BE_CREATED,
+    const commands = Given.createTaskCommands({
       withPrefix: 'spine-web-test-subscribe',
-      named: ['Task #1', 'Task #2', 'Task #3']
+      named: names
     });
     taskIds = commands.map(command => command.message.getId().getValue());
     commands.forEach(command => {
-      backendClient.sendCommand(command, given.noop, fail(done), fail(done));
+      backendClient.sendCommand(command, Given.noop, fail(done), fail(done));
     });
   });
 
@@ -315,7 +326,7 @@ describe('FirebaseBackendClient', function () {
     let countChanged = 0;
     const initialTaskNames = ['Created task #1', 'Created task #2', 'Created task #3'];
 
-    backendClient.subscribeToEntities({ofType: given.TYPE.OF_ENTITY.TASK})
+    backendClient.subscribeToEntities({ofType: Given.TYPE.OF_ENTITY.TASK})
       .then(({itemAdded, itemChanged, itemRemoved, unsubscribe}) => {
         itemAdded.subscribe({
           next: item => {
@@ -351,7 +362,7 @@ describe('FirebaseBackendClient', function () {
       .catch(fail(done));
 
     // Create tasks.
-    const createCommands = given.createTaskCommands({
+    const createCommands = Given.createTaskCommands({
       count: TASKS_TO_BE_CHANGED,
       withPrefix: 'spine-web-test-subscribe',
       named: initialTaskNames
@@ -379,7 +390,7 @@ describe('FirebaseBackendClient', function () {
       // allow for added subscriptions to be updated first.
       setTimeout(() => {
         taskIds.forEach(taskId => {
-          const renameCommand = given.renameTaskCommand({
+          const renameCommand = Given.renameTaskCommand({
             withId: taskId,
             to: `Renamed '${taskId}'`
           });
@@ -400,11 +411,11 @@ describe('FirebaseBackendClient', function () {
     const expectedRenames = ['Renamed once', 'Renamed twice'];
 
     // Create tasks.
-    const createCommand = given.createTaskCommand({
+    const createCommand = Given.createTaskCommand({
       withPrefix: 'spine-web-test-subscribe',
       named: initialTaskName
     });
-    const taskId = new TypedMessage(createCommand.message.getId(), given.TYPE.OF_IDENTIFIER.TASK_ID);
+    const taskId = new TypedMessage(createCommand.message.getId(), Given.TYPE.OF_IDENTIFIER.TASK_ID);
     const taskIdValue = createCommand.message.getId().getValue();
 
     const promise = new Promise(resolve => {
@@ -420,7 +431,7 @@ describe('FirebaseBackendClient', function () {
     });
 
     let changesCount = 0;
-    backendClient.subscribeToEntities({ofType: given.TYPE.OF_ENTITY.TASK, byId: taskId})
+    backendClient.subscribeToEntities({ofType: Given.TYPE.OF_ENTITY.TASK, byId: taskId})
       .then(({itemAdded, itemChanged, itemRemoved, unsubscribe}) => {
         itemAdded.subscribe({
           next: item => {
@@ -463,7 +474,7 @@ describe('FirebaseBackendClient', function () {
       // Tasks are renamed with a timeout after to allow for changes to show up in subscriptions.
       return new Promise(resolve => {
         setTimeout(() => {
-          const renameCommand = given.renameTaskCommand({
+          const renameCommand = Given.renameTaskCommand({
             withId: taskIdValue,
             to: 'Renamed once'
           });
@@ -480,7 +491,7 @@ describe('FirebaseBackendClient', function () {
       });
     }).then(() => {
       setTimeout(() => {
-        const renameCommand = given.renameTaskCommand({
+        const renameCommand = Given.renameTaskCommand({
           withId: taskIdValue,
           to: 'Renamed twice'
         });
@@ -495,7 +506,7 @@ describe('FirebaseBackendClient', function () {
   });
 
   it('fails a malformed subscription', done => {
-    backendClient.subscribeToEntities({ofType: given.TYPE.MALFORMED})
+    backendClient.subscribeToEntities({ofType: Given.TYPE.MALFORMED})
       .then(() => {
         done(new Error('A malformed subscription should not yield results.'));
       })

--- a/client-js/test/client/firebase-backend-test.js
+++ b/client-js/test/client/firebase-backend-test.js
@@ -22,7 +22,7 @@ import assert from 'assert';
 import uuid from 'uuid';
 
 import {devFirebaseApp} from './test-firebase-app';
-import {Type, TypedMessage, TypeUrl} from '../../src/client/typed-message';
+import {Type, TypedMessage} from '../../src/client/typed-message';
 
 import {CreateTask, RenameTask} from '../../proto/test/js/spine/web/test/given/commands_pb';
 import {Task, TaskId} from '../../proto/test/js/spine/web/test/given/task_pb';
@@ -147,17 +147,17 @@ Given.defaultTaskName = 'Get to Mount Doom';
 Given.defaultTaskDescription = 'There seems to be a bug with the rings that needs to be fixed';
 Given.TYPE = {
   OF_ENTITY: {
-    TASK: new Type(Task, new TypeUrl('type.spine.io/spine.web.test.given.Task')),
-    PROJECT: new Type(Project, new TypeUrl('type.spine.io/spine.web.test.given.Project')),
+    TASK: Type.of(Task, 'type.spine.io/spine.web.test.given.Task'),
+    PROJECT: Type.of(Project, 'type.spine.io/spine.web.test.given.Project'),
   },
   OF_IDENTIFIER: {
-    TASK_ID: new Type(TaskId, new TypeUrl('type.spine.io/spine.web.test.given.TaskId')),
+    TASK_ID: Type.of(TaskId, 'type.spine.io/spine.web.test.given.TaskId'),
   },
   OF_COMMAND: {
-    CREATE_TASK: new Type(CreateTask, new TypeUrl('type.spine.io/spine.web.test.given.CreateTask')),
-    RENAME_TASK: new Type(RenameTask, new TypeUrl('type.spine.io/spine.web.test.given.RenameTask')),
+    CREATE_TASK: Type.of(CreateTask, 'type.spine.io/spine.web.test.given.CreateTask'),
+    RENAME_TASK: Type.of(RenameTask, 'type.spine.io/spine.web.test.given.RenameTask'),
   },
-  MALFORMED: new Type(Object, new TypeUrl('types.spine.io/malformed')),
+  MALFORMED: Type.of(Object, 'types.spine.io/malformed'),
 };
 
 const backendClient = Given.backendClient();

--- a/client-js/test/client/firebase-backend-test.js
+++ b/client-js/test/client/firebase-backend-test.js
@@ -22,11 +22,13 @@ import assert from 'assert';
 import uuid from 'uuid';
 
 import {devFirebaseApp} from './test-firebase-app';
-import {TypedMessage, TypeUrl} from '../../src/client/typed-message';
+import {Type, TypedMessage, TypeUrl} from '../../src/client/typed-message';
 
 import {CreateTask, RenameTask} from '../../proto/test/js/spine/web/test/given/commands_pb';
-import {TaskId} from '../../proto/test/js/spine/web/test/given/task_pb';
+import {Task, TaskId} from '../../proto/test/js/spine/web/test/given/task_pb';
+import {ColumnFilter, CompositeColumnFilter} from 'spine-web-client-proto/spine/client/entities_pb';
 import {Topic} from '../../proto/test/js/spine/client/subscription_pb';
+import {Project} from '../../proto/test/js/spine/web/test/given/project_pb';
 import {BackendClient} from '../../src/client/backend-client';
 
 const MILLISECONDS = 1;
@@ -50,17 +52,17 @@ class Given {
     this.defaultTaskDescription = 'There seems to be a bug with the rings that needs to be fixed';
     this.TYPE = {
       OF_ENTITY: {
-        TASK: new TypeUrl('type.spine.io/spine.web.test.given.Task'),
-        PROJECT: new TypeUrl('type.spine.io/spine.web.test.given.Project')
+        TASK: new Type(Task, new TypeUrl('type.spine.io/spine.web.test.given.Task')),
+        PROJECT: new Type(Project, new TypeUrl('type.spine.io/spine.web.test.given.Project')),
       },
       OF_IDENTIFIER: {
-        TASK_ID: new TypeUrl('type.spine.io/spine.web.test.given.TaskId'),
+        TASK_ID: new Type(TaskId, new TypeUrl('type.spine.io/spine.web.test.given.TaskId')),
       },
       OF_COMMAND: {
-        CREATE_TASK: new TypeUrl('type.spine.io/spine.web.test.given.CreateTask'),
-        RENAME_TASK: new TypeUrl('type.spine.io/spine.web.test.given.RenameTask'),
+        CREATE_TASK: new Type(CreateTask, new TypeUrl('type.spine.io/spine.web.test.given.CreateTask')),
+        RENAME_TASK: new Type(RenameTask, new TypeUrl('type.spine.io/spine.web.test.given.RenameTask')),
       },
-      MALFORMED: new TypeUrl('types.spine.io/malformed')
+      MALFORMED: new Type(Object, new TypeUrl('types.spine.io/malformed')),
     };
     Given._deepFreeze(this);
   }

--- a/client-js/test/client/firebase-backend-test.js
+++ b/client-js/test/client/firebase-backend-test.js
@@ -151,12 +151,12 @@ class Given {
 const given = new Given();
 const backendClient = given.backendClient();
 
-describe('Client should', function () {
+describe('FirebaseBackendClient', function () {
 
   // Big timeout due to remote calls during tests.
   this.timeout(2 * MINUTES);
 
-  it('send commands successfully', done => {
+  it('sends commands successfully', done => {
 
     const command = given.createTaskCommand({
       withIdPrefix: 'spine-web-test-send-command',
@@ -182,7 +182,7 @@ describe('Client should', function () {
     }, fail(done), fail(done));
   });
 
-  it('fail a malformed command', done => {
+  it('fails a malformed command', done => {
     const command = given.createTaskCommand({withId: null});
 
     backendClient.sendCommand(
@@ -197,7 +197,7 @@ describe('Client should', function () {
       fail(done, 'A command was rejected when an error was expected.'));
   });
 
-  it('fetch all the existing entities of given type one by one', done => {
+  it('fetches all the existing entities of given type one by one', done => {
     const command = given.createTaskCommand({withPrefix: 'spine-web-test-one-by-one'});
     const taskId = command.message.getId();
 
@@ -222,7 +222,7 @@ describe('Client should', function () {
     }, fail(done), fail(done));
   });
 
-  it('fetch all the existing entities of given type at once', done => {
+  it('fetches all the existing entities of given type at once', done => {
     const command = given.createTaskCommand({withPrefix: 'spine-web-test-at-once'});
     const taskId = command.message.getId();
 
@@ -238,7 +238,7 @@ describe('Client should', function () {
     }, fail(done), fail(done));
   });
 
-  it('fetch an empty list for entity that does not get created at once', done => {
+  it('fetches an empty list for entity that does not get created at once', done => {
     backendClient.fetchAll({ofType: given.TYPE.OF_ENTITY.PROJECT}).atOnce()
       .then(data => {
         assert.ok(data.length === 0);
@@ -246,7 +246,7 @@ describe('Client should', function () {
       }, fail(done));
   });
 
-  it('fetch an empty list for entity that does not get created one-by-one', done => {
+  it('fetches an empty list for entity that does not get created one-by-one', done => {
     backendClient.fetchAll({ofType: given.TYPE.OF_ENTITY.PROJECT}).oneByOne()
       .subscribe({
         next: fail(done),
@@ -255,7 +255,7 @@ describe('Client should', function () {
       });
   });
 
-  it('fail a malformed query', done => {
+  it('fails a malformed query', done => {
     const command = given.createTaskCommand({withPrefix: 'spine-web-test-malformed-query'});
 
     backendClient.sendCommand(command, () => {
@@ -270,7 +270,7 @@ describe('Client should', function () {
     }, fail(done), fail(done));
   });
 
-  it('subscribe to new entities of type', done => {
+  it('subscribes to new entities of type', done => {
     const TASKS_TO_BE_CREATED = 3;
     let taskIds;
     let count = 0;
@@ -309,7 +309,7 @@ describe('Client should', function () {
     });
   });
 
-  it('subscribe to entity changes of type', done => {
+  it('subscribes to entity changes of type', done => {
     const TASKS_TO_BE_CHANGED = 3;
     let taskIds;
     let countChanged = 0;
@@ -394,7 +394,7 @@ describe('Client should', function () {
     });
   });
 
-  it('subscribe to entity changes by id', done => {
+  it('subscribes to entity changes by id', done => {
     const expectedChangesCount = 2;
     const initialTaskName = 'Initial task name';
     const expectedRenames = ['Renamed once', 'Renamed twice'];
@@ -494,7 +494,7 @@ describe('Client should', function () {
     });
   });
 
-  it('fail a malformed subscription', done => {
+  it('fails a malformed subscription', done => {
     backendClient.subscribeToEntities({ofType: given.TYPE.MALFORMED})
       .then(() => {
         done(new Error('A malformed subscription should not yield results.'));

--- a/client-js/test/client/firebase-backend-test.js
+++ b/client-js/test/client/firebase-backend-test.js
@@ -55,7 +55,7 @@ class Given {
     return BackendClient.usingFirebase({
       atEndpoint: 'https://spine-dev.appspot.com',
       withFirebaseStorage: devFirebaseApp,
-      forActor: 'web-test-actor-2'
+      forActor: 'web-test-actor'
     });
   }
 

--- a/client-js/test/client/observable-test.js
+++ b/client-js/test/client/observable-test.js
@@ -18,7 +18,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// noinspection NodeJsCodingAssistanceForCoreModules
 import assert from 'assert';
 
 import {Observable} from '../../src/client/observable';

--- a/client-js/test/client/observable-test.js
+++ b/client-js/test/client/observable-test.js
@@ -25,11 +25,11 @@ import {Observable} from '../../src/client/observable';
 const MILLISECONDS = 1;
 const SECONDS = 1000 * MILLISECONDS;
 
-describe('Observable should', function () {
+describe('Observable', function () {
 
   this.timeout(5 * SECONDS);
 
-  it('send next values to the observer', done => {
+  it('sends next values to the observer', done => {
     const observable = new Observable(observer => {
       observer.next(1);
       observer.next(2);
@@ -54,7 +54,7 @@ describe('Observable should', function () {
     });
   });
 
-  it('send an error to the observer', done => {
+  it('sends an error to the observer', done => {
     const expectedError = new Error('An observable error.');
     const observable = new Observable(observer => {
       observer.next(1);

--- a/client-js/test/client/query-builder-test.js
+++ b/client-js/test/client/query-builder-test.js
@@ -86,7 +86,7 @@ class Given {
    * @param {Type} type
    */
   static assertTargetTypeEqual(target, type) {
-    assert.equal(target.getType(), type.url().value);
+    assert.equal(target.getType(), type.url().value());
   }
 
   /**

--- a/client-js/test/client/query-builder-test.js
+++ b/client-js/test/client/query-builder-test.js
@@ -437,7 +437,7 @@ describe('QueryBuilder', function () {
         .query()
         .select(Given.TYPE.TASK)
         .where(['Duck', 'duck', 'goose']);
-      done(new Error('An error was expected due to invalid #where() parameter.'))
+      done(new Error('An error was expected due to invalid #where() parameter.'));
     } catch (e) {
       done();
     }

--- a/client-js/test/client/query-builder-test.js
+++ b/client-js/test/client/query-builder-test.js
@@ -38,6 +38,11 @@ const SECONDS = 1000 * MILLISECONDS;
 
 
 class Given {
+
+  constructor() {
+    throw new Error('A utility Given class cannot be instantiated.');
+  }
+
   /**
    * @param {String} value
    * @return {TypedMessage}

--- a/client-js/test/client/query-builder-test.js
+++ b/client-js/test/client/query-builder-test.js
@@ -1,0 +1,515 @@
+/*
+ * Copyright 2018, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+import assert from 'assert';
+
+import {Type, TypedMessage, TypeUrl} from '../../src/client/typed-message';
+import {ActorRequestFactory} from '../../src/client/actor-request-factory';
+import {Task, TaskId} from '../../proto/test/js/spine/web/test/given/task_pb';
+import {AnyPacker} from '../../src/client/any-packer';
+import {Message} from 'google-protobuf';
+import {StringValue} from 'spine-web-client-proto/google/protobuf/wrappers_pb';
+import {
+  ColumnFilter,
+  CompositeColumnFilter,
+  EntityFilters
+} from 'spine-web-client-proto/spine/client/entities_pb';
+
+const MILLISECONDS = 1;
+const SECONDS = 1000 * MILLISECONDS;
+
+
+class Given {
+  /**
+   * @param {String} value
+   * @return {TypedMessage}
+   */
+  static newTaskId(value) {
+    const id = new TaskId();
+    id.setValue(value);
+    return new TypedMessage(id, Given.TYPE.TASK_ID)
+  }
+
+  /**
+   * @param {String[]} values
+   * @return {TypedMessage<TaskId>[]}
+   */
+  static newTaskIds(values) {
+    return values.map(Given.newTaskId);
+  }
+
+  /**
+   * @param {ActorContext} context
+   */
+  static assertActorContextCorrect(context) {
+    assert.ok(context);
+    assert.ok(context.getTimestamp().getSeconds() <= new Date().getTime());
+    assert.equal(context.getActor().getValue(), Given.ACTOR);
+  }
+
+  /**
+   * @param {Array} actual
+   * @param {Array} expected
+   */
+  static assertUnorderedEqual(actual, expected) {
+    assert.ok(actual.length, expected.length, 'Arrays are expected to be of the same size.');
+    expected.forEach(expectedItem => {
+      assert.ok(actual.includes(expectedItem), 'An item is expected to be included in array.');
+    });
+  }
+
+  /**
+   * @param {Target} target
+   * @param {Type} type
+   */
+  static assertTargetTypeEqual(target, type) {
+    assert.equal(target.getType(), type.url().value);
+  }
+
+  /**
+   * @param {Message} actual
+   * @param {Message} expected
+   */
+  static assertMessagesEqual(actual, expected) {
+    assert.ok(Message.equals(actual, expected), 'Messages are expected to be identical.')
+  }
+
+  /**
+   * @return {ActorRequestFactory}
+   */
+  static requestFactory() {
+    return new ActorRequestFactory(Given.ACTOR);
+  }
+
+  /**
+   * @param {string} column
+   * @param {TypedMessage} value
+   * @param {ColumnFilter.Operator} operator
+   * @return {ColumnFilter}
+   */
+  static newColumnFilter(column, value, operator = ColumnFilter.Operator.EQUAL) {
+    const filter = new ColumnFilter();
+    filter.setColumnName(column);
+    filter.setValue(AnyPacker.packTyped(value));
+    filter.setOperator(operator);
+    return filter;
+  }
+
+  /**
+   *
+   * @param {CompositeColumnFilter.CompositeOperator} operator
+   * @param {...ColumnFilter} filters
+   * @return {CompositeColumnFilter}
+   */
+  static newCompositeFilter(operator, ...filters) {
+    const filter = new CompositeColumnFilter();
+    filter.setFilterList(filters);
+    filter.setOperator(operator);
+    return filter;
+  }
+}
+
+Given.TYPE = {
+  TASK_ID: new Type(TaskId, new TypeUrl('type.spine.io/spine.web.test.given.TaskId')),
+  TASK: new Type(Task, new TypeUrl('type.spine.io/spine.web.test.given.Task')),
+};
+Given.ACTOR = 'spine-web-client-test-actor';
+
+describe('QueryBuilder', function () {
+
+  this.timeout(5 * SECONDS);
+
+  it('creates a Query of query for type', done => {
+    const query = Given.requestFactory()
+      .query()
+      .select(Given.TYPE.TASK)
+      .build();
+
+    assert.ok(query.getId());
+
+    Given.assertActorContextCorrect(query.getContext());
+
+    const target = query.getTarget();
+    assert.ok(target);
+    assert.ok(target.getIncludeAll());
+    Given.assertTargetTypeEqual(target, Given.TYPE.TASK);
+
+    done();
+  });
+
+  /********* IDs *********/
+
+  it('creates a Query for type with with no IDs', done => {
+    const query = Given.requestFactory()
+      .query()
+      .select(Given.TYPE.TASK)
+      .byIds([])
+      .build();
+
+    assert.ok(query.getId());
+
+    Given.assertActorContextCorrect(query.getContext());
+
+    const target = query.getTarget();
+    assert.ok(target);
+    assert.ok(target.getIncludeAll());
+    Given.assertTargetTypeEqual(target, Given.TYPE.TASK);
+
+    done();
+  });
+
+  it('creates a Query for type with multiple IDs', done => {
+    const values = ['meeny', 'miny', 'moe'];
+    const taskIds = Given.newTaskIds(values);
+
+    const query = Given.requestFactory()
+      .query()
+      .select(Given.TYPE.TASK)
+      .byIds(taskIds).build();
+
+    assert.ok(query.getId());
+
+    Given.assertActorContextCorrect(query.getContext());
+
+    const target = query.getTarget();
+    assert.ok(target);
+    Given.assertTargetTypeEqual(target, Given.TYPE.TASK);
+
+    const filters = target.getFilters();
+    assert.ok(filters);
+    assert.ok(filters.getFilterList().length === 0);
+
+    const idFilter = filters.getIdFilter();
+    assert.ok(idFilter);
+
+    const targetIds = idFilter.getIdsList()
+      .map(entityId => entityId.getId())
+      .map(any => AnyPacker.unpack(any).as(Given.TYPE.TASK_ID))
+      .map(taskId => taskId.getValue());
+
+    Given.assertUnorderedEqual(targetIds, values);
+
+    done();
+  });
+
+  it('throws an error on multiple #byIds() invocations', done => {
+    const firstIds = Given.newTaskIds(['tick']);
+    const secondIds = Given.newTaskIds(['tock']);
+    try {
+      Given.requestFactory()
+        .query()
+        .select(Given.TYPE.TASK)
+        .byIds(firstIds)
+        .byIds(secondIds);
+      done(new Error('#byIds() multiple invocations did not result in error.'));
+    } catch (error) {
+      done();
+    }
+  });
+
+  it('throws an error if #byIds() is invoked with non-Array value', done => {
+    try {
+      Given.requestFactory()
+        .query()
+        .select(Given.TYPE.TASK)
+        .byIds({error: true});
+      done(new Error('#byIds() non-Array value did not result in error.'));
+    } catch (error) {
+      done();
+    }
+  });
+
+  it('throws an error if #byIds() is invoked with non-TypedMessage IDs', done => {
+    try {
+      Given.requestFactory().query()
+        .select(Given.TYPE.TASK)
+        .byIds(['Tinker', 'Tailor', 'Soldier', 'Sailor']);
+      done(new Error('#byIds() non-TypedMessage IDs did not result in error.'));
+    } catch (error) {
+      done();
+    }
+  });
+
+  /********* FILTERS *********/
+
+  it('creates a Query with a no filters', done => {
+    const query = Given.requestFactory()
+      .query()
+      .select(Given.TYPE.TASK)
+      .where([])
+      .build();
+
+    assert.ok(query.getId());
+
+    Given.assertActorContextCorrect(query.getContext());
+
+    const target = query.getTarget();
+    assert.ok(target.getIncludeAll());
+    Given.assertTargetTypeEqual(target, Given.TYPE.TASK);
+
+    done();
+  });
+
+  it('creates a Query with a single ColumnFilter', done => {
+    const nameFilter = Given.newColumnFilter(
+      'name', new TypedMessage(new StringValue(['Implement tests']), Type.STRING)
+    );
+    const query = Given.requestFactory()
+      .query()
+      .select(Given.TYPE.TASK)
+      .where([nameFilter])
+      .build();
+
+    assert.ok(query.getId());
+    Given.assertActorContextCorrect(query.getContext());
+
+    const target = query.getTarget();
+    assert.ok(target);
+    assert.ok(!target.getIncludeAll());
+    Given.assertTargetTypeEqual(target, Given.TYPE.TASK);
+
+    const expectedCompositeFilter = new CompositeColumnFilter();
+    expectedCompositeFilter.setFilterList([nameFilter]);
+    expectedCompositeFilter.setOperator(CompositeColumnFilter.CompositeOperator.ALL);
+    const expectedFilters = new EntityFilters();
+    expectedFilters.setFilterList([expectedCompositeFilter]);
+
+    Given.assertMessagesEqual(target.getFilters(), expectedFilters);
+
+    done();
+  });
+
+  it('creates a Query with a multiple ColumnFilter', done => {
+    const nameFilter = Given.newColumnFilter(
+      'name', new TypedMessage(new StringValue(['Implement tests']), Type.STRING)
+    );
+    const descriptionFilter = Given.newColumnFilter(
+      'description', new TypedMessage(new StringValue(['Web needs tests, eh?']), Type.STRING)
+    );
+    const query = Given.requestFactory()
+      .query()
+      .select(Given.TYPE.TASK)
+      .where([nameFilter, descriptionFilter])
+      .build();
+
+    assert.ok(query.getId());
+    Given.assertActorContextCorrect(query.getContext());
+
+    const target = query.getTarget();
+    assert.ok(target);
+    assert.ok(!target.getIncludeAll());
+    Given.assertTargetTypeEqual(target, Given.TYPE.TASK);
+
+    const expectedCompositeFilter = new CompositeColumnFilter();
+    expectedCompositeFilter.setFilterList([nameFilter, descriptionFilter]);
+    expectedCompositeFilter.setOperator(CompositeColumnFilter.CompositeOperator.ALL);
+    const expectedFilters = new EntityFilters();
+    expectedFilters.setFilterList([expectedCompositeFilter]);
+
+    Given.assertMessagesEqual(target.getFilters(), expectedFilters);
+
+    done();
+  });
+
+  it('creates a Query with a single CompositeColumnFilter', done => {
+    const nameFilter1 = Given.newColumnFilter(
+      'name', new TypedMessage(new StringValue(['Implement tests']), Type.STRING)
+    );
+    const nameFilter2 = Given.newColumnFilter(
+      'name', new TypedMessage(new StringValue(['Create a PR']), Type.STRING)
+    );
+    const compositeColumnFilter = Given.newCompositeFilter(
+      CompositeColumnFilter.CompositeOperator.EITHER, nameFilter1, nameFilter2
+    );
+    const query = Given.requestFactory()
+      .query()
+      .select(Given.TYPE.TASK)
+      .where([compositeColumnFilter])
+      .build();
+
+    assert.ok(query.getId());
+    Given.assertActorContextCorrect(query.getContext());
+
+    const target = query.getTarget();
+    assert.ok(target);
+    assert.ok(!target.getIncludeAll());
+    Given.assertTargetTypeEqual(target, Given.TYPE.TASK);
+
+    const expectedFilters = new EntityFilters();
+    expectedFilters.setFilterList([compositeColumnFilter]);
+
+    Given.assertMessagesEqual(target.getFilters(), expectedFilters);
+
+    done();
+  });
+
+  it('creates a Query with a multiple CompositeColumnFilters', done => {
+    const nameFilter1 = Given.newColumnFilter(
+      'name', new TypedMessage(new StringValue(['Implement tests']), Type.STRING)
+    );
+    const nameFilter2 = Given.newColumnFilter(
+      'name', new TypedMessage(new StringValue(['Create a PR']), Type.STRING)
+    );
+    const nameFilter = Given.newCompositeFilter(
+      CompositeColumnFilter.CompositeOperator.EITHER, nameFilter1, nameFilter2
+    );
+    const descriptionFilter = Given.newCompositeFilter(
+      CompositeColumnFilter.CompositeOperator.AND,
+      Given.newColumnFilter(
+        'description', new TypedMessage(new StringValue(['Web needs tests, eh?']), Type.STRING)
+      )
+    );
+
+    const query = Given.requestFactory()
+      .query()
+      .select(Given.TYPE.TASK)
+      .where([nameFilter, descriptionFilter])
+      .build();
+
+    assert.ok(query.getId());
+    Given.assertActorContextCorrect(query.getContext());
+
+    const target = query.getTarget();
+    assert.ok(target);
+    assert.ok(!target.getIncludeAll());
+    Given.assertTargetTypeEqual(target, Given.TYPE.TASK);
+
+    const expectedFilters = new EntityFilters();
+    expectedFilters.setFilterList([nameFilter, descriptionFilter]);
+
+    Given.assertMessagesEqual(target.getFilters(), expectedFilters);
+
+    done();
+  });
+
+  it('throws an error if #where() is invoked with non-Array value', done => {
+    const nameFilter = Given.newColumnFilter(
+      'name', new TypedMessage(new StringValue(['Implement tests']), Type.STRING)
+    );
+
+    try {
+      const query = Given.requestFactory()
+        .query()
+        .select(Given.TYPE.TASK)
+        .where(nameFilter);
+      done(new Error('An error was expected due to invalid #where() parameter.'))
+    } catch (e) {
+      done();
+    }
+  });
+
+  it('throws an error if #where() is invoked with non-filter values', done => {
+    try {
+      const query = Given.requestFactory()
+        .query()
+        .select(Given.TYPE.TASK)
+        .where(['Duck', 'duck', 'goose']);
+      done(new Error('An error was expected due to invalid #where() parameter.'))
+    } catch (e) {
+      done();
+    }
+  });
+
+  it('throws an error if #where() is invoked with mixed ColumnFilter and CompositeColumnFilter values', done => {
+    try {
+      const query = Given.requestFactory()
+        .query()
+        .select(Given.TYPE.TASK)
+        .where([new ColumnFilter(), new CompositeColumnFilter()]);
+      done(new Error('An error was expected due to mixed column filter types.'))
+    } catch (e) {
+      done();
+    }
+  });
+
+  it('throws an error if #where() is invoked more than once', done => {
+    try {
+      const query = Given.requestFactory()
+        .query()
+        .select(Given.TYPE.TASK)
+        .where([new ColumnFilter()])
+        .where([new CompositeColumnFilter()]);
+      done(new Error('An error was expected due to multiple #where() invocations.'))
+    } catch (e) {
+      done();
+    }
+  });
+
+  /********* MASKS *********/
+
+  it('creates a Query with a provided field mask', done => {
+    const maskedFields = ['id', 'description'];
+    const query = Given.requestFactory()
+      .query()
+      .select(Given.TYPE.TASK)
+      .withMask(maskedFields)
+      .build();
+
+    assert.ok(query.getId());
+    Given.assertActorContextCorrect(query.getContext());
+
+    const target = query.getTarget();
+    assert.ok(target);
+    assert.ok(target.getIncludeAll());
+    Given.assertTargetTypeEqual(target, Given.TYPE.TASK);
+
+    Given.assertUnorderedEqual(query.getFieldMask().getPathsList(), maskedFields);
+
+    done();
+  });
+
+  it('throws an error if #withMask() is invoked more than once', done => {
+    try {
+      const query = Given.requestFactory()
+        .query()
+        .select(Given.TYPE.TASK)
+        .withMask(['name'])
+        .withMask(['description']);
+      done(new Error('An error was expected due to multiple #withMask() invocations.'))
+    } catch (e) {
+      done();
+    }
+  });
+
+  it('throws an error if #withMask() is invoked with non-Array value', done => {
+    try {
+      const query = Given.requestFactory()
+        .query()
+        .select(Given.TYPE.TASK)
+        .withMask('name');
+      done(new Error('An error was expected due to invalid #withMask() argument.'))
+    } catch (e) {
+      done();
+    }
+  });
+
+  it('throws an error if #withMask() is invoked with non-string field names', done => {
+    try {
+      const query = Given.requestFactory()
+        .query()
+        .select(Given.TYPE.TASK)
+        .withMask([22]);
+      done(new Error('An error was expected due to invalid #withMask() argument.'))
+    } catch (e) {
+      done();
+    }
+  });
+});

--- a/client-js/test/client/query-builder-test.js
+++ b/client-js/test/client/query-builder-test.js
@@ -377,7 +377,7 @@ describe('QueryBuilder', function () {
       CompositeColumnFilter.CompositeOperator.EITHER, nameFilter1, nameFilter2
     );
     const descriptionFilter = Given.newCompositeFilter(
-      CompositeColumnFilter.CompositeOperator.AND,
+      CompositeColumnFilter.CompositeOperator.ALL,
       Given.newColumnFilter(
         'description', new TypedMessage(new StringValue(['Web needs tests, eh?']), Type.STRING)
       )

--- a/client-js/test/client/query-builder-test.js
+++ b/client-js/test/client/query-builder-test.js
@@ -215,6 +215,70 @@ describe('QueryBuilder', function () {
     done();
   });
 
+  it('creates a Query for type with string IDs', done => {
+    const values = ['meeny', 'miny', 'moe'];
+
+    const query = Given.requestFactory()
+      .query()
+      .select(Given.TYPE.TASK)
+      .byIds(values).build();
+
+    assert.ok(query.getId());
+
+    Given.assertActorContextCorrect(query.getContext());
+
+    const target = query.getTarget();
+    assert.ok(target);
+    Given.assertTargetTypeEqual(target, Given.TYPE.TASK);
+
+    const filters = target.getFilters();
+    assert.ok(filters);
+    assert.ok(filters.getFilterList().length === 0);
+
+    const idFilter = filters.getIdFilter();
+    assert.ok(idFilter);
+
+    const targetIds = idFilter.getIdsList()
+      .map(entityId => entityId.getId())
+      .map(any => AnyPacker.unpack(any).asString());
+
+    Given.assertUnorderedEqual(targetIds, values);
+
+    done();
+  });
+
+  it('creates a Query for type with number IDs', done => {
+    const values = [29, 99971, 104729];
+
+    const query = Given.requestFactory()
+      .query()
+      .select(Given.TYPE.TASK)
+      .byIds(values).build();
+
+    assert.ok(query.getId());
+
+    Given.assertActorContextCorrect(query.getContext());
+
+    const target = query.getTarget();
+    assert.ok(target);
+    Given.assertTargetTypeEqual(target, Given.TYPE.TASK);
+
+    const filters = target.getFilters();
+    assert.ok(filters);
+    assert.ok(filters.getFilterList().length === 0);
+
+    const idFilter = filters.getIdFilter();
+    assert.ok(idFilter);
+
+    const targetIds = idFilter.getIdsList()
+      .map(entityId => entityId.getId())
+      .map(any => AnyPacker.unpack(any).asInt64());
+
+    Given.assertUnorderedEqual(targetIds, values);
+
+    done();
+  });
+
   it('throws an error on multiple #byIds() invocations', done => {
     const firstIds = Given.newTaskIds(['tick']);
     const secondIds = Given.newTaskIds(['tock']);
@@ -246,7 +310,7 @@ describe('QueryBuilder', function () {
     try {
       Given.requestFactory().query()
         .select(Given.TYPE.TASK)
-        .byIds(['Tinker', 'Tailor', 'Soldier', 'Sailor']);
+        .byIds([{tinker: 'tailor'}, {soldier: 'sailor'}]);
       done(new Error('#byIds() non-TypedMessage IDs did not result in error.'));
     } catch (error) {
       done();
@@ -274,9 +338,7 @@ describe('QueryBuilder', function () {
   });
 
   it('creates a Query with a single ColumnFilter', done => {
-    const nameFilter = Given.newColumnFilter(
-      'name', new TypedMessage(new StringValue(['Implement tests']), Type.STRING)
-    );
+    const nameFilter = Given.newColumnFilter('name', TypedMessage.string('Implement tests'));
     const query = Given.requestFactory()
       .query()
       .select(Given.TYPE.TASK)
@@ -303,11 +365,9 @@ describe('QueryBuilder', function () {
   });
 
   it('creates a Query with a multiple ColumnFilter', done => {
-    const nameFilter = Given.newColumnFilter(
-      'name', new TypedMessage(new StringValue(['Implement tests']), Type.STRING)
-    );
+    const nameFilter = Given.newColumnFilter('name', TypedMessage.string('Implement tests'));
     const descriptionFilter = Given.newColumnFilter(
-      'description', new TypedMessage(new StringValue(['Web needs tests, eh?']), Type.STRING)
+      'description', TypedMessage.string('Web needs tests, eh?')
     );
     const query = Given.requestFactory()
       .query()
@@ -335,12 +395,8 @@ describe('QueryBuilder', function () {
   });
 
   it('creates a Query with a single CompositeColumnFilter', done => {
-    const nameFilter1 = Given.newColumnFilter(
-      'name', new TypedMessage(new StringValue(['Implement tests']), Type.STRING)
-    );
-    const nameFilter2 = Given.newColumnFilter(
-      'name', new TypedMessage(new StringValue(['Create a PR']), Type.STRING)
-    );
+    const nameFilter1 = Given.newColumnFilter('name', TypedMessage.string('Implement tests'));
+    const nameFilter2 = Given.newColumnFilter('name', TypedMessage.string('Create a PR'));
     const compositeColumnFilter = Given.newCompositeFilter(
       CompositeColumnFilter.CompositeOperator.EITHER, nameFilter1, nameFilter2
     );
@@ -367,19 +423,15 @@ describe('QueryBuilder', function () {
   });
 
   it('creates a Query with a multiple CompositeColumnFilters', done => {
-    const nameFilter1 = Given.newColumnFilter(
-      'name', new TypedMessage(new StringValue(['Implement tests']), Type.STRING)
-    );
-    const nameFilter2 = Given.newColumnFilter(
-      'name', new TypedMessage(new StringValue(['Create a PR']), Type.STRING)
-    );
+    const nameFilter1 = Given.newColumnFilter('name', TypedMessage.string('Implement tests'));
+    const nameFilter2 = Given.newColumnFilter('name', TypedMessage.string('Create a PR'));
     const nameFilter = Given.newCompositeFilter(
       CompositeColumnFilter.CompositeOperator.EITHER, nameFilter1, nameFilter2
     );
     const descriptionFilter = Given.newCompositeFilter(
       CompositeColumnFilter.CompositeOperator.ALL,
       Given.newColumnFilter(
-        'description', new TypedMessage(new StringValue(['Web needs tests, eh?']), Type.STRING)
+        'description', TypedMessage.string('Web needs tests, eh?')
       )
     );
 
@@ -406,9 +458,7 @@ describe('QueryBuilder', function () {
   });
 
   it('throws an error if #where() is invoked with non-Array value', done => {
-    const nameFilter = Given.newColumnFilter(
-      'name', new TypedMessage(new StringValue(['Implement tests']), Type.STRING)
-    );
+    const nameFilter = Given.newColumnFilter('name', TypedMessage.string('Implement tests'));
 
     try {
       const query = Given.requestFactory()

--- a/client-js/test/client/query-builder-test.js
+++ b/client-js/test/client/query-builder-test.js
@@ -94,7 +94,7 @@ class Given {
    * @param {Message} expected
    */
   static assertMessagesEqual(actual, expected) {
-    assert.ok(Message.equals(actual, expected), 'Messages are expected to be identical.')
+    assert.ok(Message.equals(actual, expected), 'Messages are expected to be identical.');
   }
 
   /**

--- a/client-js/test/client/query-builder-test.js
+++ b/client-js/test/client/query-builder-test.js
@@ -50,7 +50,7 @@ class Given {
   static newTaskId(value) {
     const id = new TaskId();
     id.setValue(value);
-    return new TypedMessage(id, Given.TYPE.TASK_ID)
+    return new TypedMessage(id, Given.TYPE.TASK_ID);
   }
 
   /**
@@ -425,7 +425,7 @@ describe('QueryBuilder', function () {
         .query()
         .select(Given.TYPE.TASK)
         .where(nameFilter);
-      done(new Error('An error was expected due to invalid #where() parameter.'))
+      done(new Error('An error was expected due to invalid #where() parameter.'));
     } catch (e) {
       done();
     }
@@ -449,7 +449,7 @@ describe('QueryBuilder', function () {
         .query()
         .select(Given.TYPE.TASK)
         .where([new ColumnFilter(), new CompositeColumnFilter()]);
-      done(new Error('An error was expected due to mixed column filter types.'))
+      done(new Error('An error was expected due to mixed column filter types.'));
     } catch (e) {
       done();
     }

--- a/client-js/test/client/query-builder-test.js
+++ b/client-js/test/client/query-builder-test.js
@@ -21,7 +21,7 @@
 
 import assert from 'assert';
 
-import {Type, TypedMessage, TypeUrl} from '../../src/client/typed-message';
+import {Type, TypedMessage} from '../../src/client/typed-message';
 import {ActorRequestFactory, ColumnFilters} from '../../src/client/actor-request-factory';
 import {Task, TaskId} from '../../proto/test/js/spine/web/test/given/task_pb';
 import {AnyPacker} from '../../src/client/any-packer';
@@ -106,8 +106,8 @@ class Given {
 }
 
 Given.TYPE = {
-  TASK_ID: new Type(TaskId, new TypeUrl('type.spine.io/spine.web.test.given.TaskId')),
-  TASK: new Type(Task, new TypeUrl('type.spine.io/spine.web.test.given.Task')),
+  TASK_ID: Type.of(TaskId, 'type.spine.io/spine.web.test.given.TaskId'),
+  TASK: Type.of(Task, 'type.spine.io/spine.web.test.given.Task'),
 };
 Given.ACTOR = 'spine-web-client-test-actor';
 


### PR DESCRIPTION
In this PR a proper `QueryBuilder` akin the one in `spine-client` is implemented in `spine-client-js`.

Along with it were implemented:
- an `AnyPacker`;
- a new `Type` class mapping type URLs to JS message classes;
- `TypedMessage` static factories for primitive wrappers;
- all thrown strings were replaced with errors.