### PR TITLE
Message format selection using Guava `MediaType`

### DIFF
--- a/web/src/main/java/io/spine/web/command/CommandServlet.java
+++ b/web/src/main/java/io/spine/web/command/CommandServlet.java
@@ -20,6 +20,7 @@
 
 package io.spine.web.command;
 
+import com.google.common.net.MediaType;
 import io.spine.core.Ack;
 import io.spine.core.Command;
 import io.spine.server.CommandService;
@@ -34,6 +35,7 @@ import java.io.IOException;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.net.MediaType.JSON_UTF_8;
 import static io.spine.json.Json.toCompactJson;
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 
@@ -47,8 +49,7 @@ import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 @SuppressWarnings("serial") // Java serialization is not supported.
 public abstract class CommandServlet extends NonSerializableServlet {
 
-    @SuppressWarnings("DuplicateStringLiteralInspection") // The duplication is a coincidence.
-    private static final String MIME_TYPE = "application/json";
+    private static final MediaType MIME_TYPE = JSON_UTF_8;
 
     private final CommandService commandService;
 
@@ -78,6 +79,6 @@ public abstract class CommandServlet extends NonSerializableServlet {
             throws IOException {
         String json = toCompactJson(ack);
         response.getWriter().append(json);
-        response.setContentType(MIME_TYPE);
+        response.setContentType(MIME_TYPE.toString());
     }
 }

--- a/web/src/main/java/io/spine/web/parser/HttpMessages.java
+++ b/web/src/main/java/io/spine/web/parser/HttpMessages.java
@@ -42,8 +42,12 @@ import static java.util.stream.Collectors.joining;
  *
  * <p>In order to specify either format, add the {@code Content-Type} header. The accepted values
  * are {@code application/json} and {@code application/x-protobuf}, case insensitive. If the header
- * is absent, the JSON format is expected. If the header value is not recognized, the parsing is
- * failed.
+ * is absent, the JSON format is expected. If the header value is not recognized, the parsing fails,
+ * returning an empty {@link java.util.Optional Optional}.
+ *
+ * <p>No parameters are accepted in {@code Content-Type}, except for type, subtype and charset. Any
+ * unhandled {@code Content-Type} attributes will result in failed parsing returning an empty
+ * {@link java.util.Optional Optional}.
  *
  * <p>There is a difference in behavior when parsing one or the other format.
  * When parsing a JSON-encoded message, if an unknown field is found, the parsing is considered
@@ -51,8 +55,8 @@ import static java.util.stream.Collectors.joining;
  * the field can be found in the {@linkplain Message#getUnknownFields() unknown fields set} of
  * the parsed message.
  *
- * @see MessageFormat
  * @author Dmytro Dashenkov
+ * @see MessageFormat
  */
 public final class HttpMessages {
 
@@ -65,11 +69,15 @@ public final class HttpMessages {
     /**
      * Parses the body of the given request into a message of the given type.
      *
-     * @param request the request with a JSON in its body
-     * @param type    the class of message contained in the JSON
-     * @param <M>     the type of the message to parse
+     * @param request
+     *         the request with a JSON in its body
+     * @param type
+     *         the class of message contained in the JSON
+     * @param <M>
+     *         the type of the message to parse
      * @return parsed message or {@code Optional.empty()} if the message cannot be parsed
-     * @throws IOException if the {@code request} throws the exception
+     * @throws IOException
+     *         if the {@code request} throws the exception
      */
     public static <M extends Message> Optional<M> parse(HttpServletRequest request, Class<M> type)
             throws IOException {

--- a/web/src/main/java/io/spine/web/parser/JsonMessageParser.java
+++ b/web/src/main/java/io/spine/web/parser/JsonMessageParser.java
@@ -52,9 +52,6 @@ final class JsonMessageParser<M extends Message> implements MessageParser<M> {
         this.type = type;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Optional<M> parse(String raw) {
         String json = cleanUp(raw);

--- a/web/src/test/java/io/spine/web/parser/given/HttpMessagesTestEnv.java
+++ b/web/src/test/java/io/spine/web/parser/given/HttpMessagesTestEnv.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2018, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.web.parser.given;
+
+import com.google.protobuf.Int32Value;
+import com.google.protobuf.Message;
+import io.spine.core.Ack;
+import io.spine.core.AckVBuilder;
+import io.spine.web.parser.HttpMessages;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Base64;
+import java.util.Optional;
+
+import static io.spine.core.Responses.statusOk;
+import static io.spine.json.Json.toCompactJson;
+import static io.spine.protobuf.AnyPacker.pack;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test environment for {@link io.spine.web.parser.HttpMessagesTest HttpMessages Tests}.
+ *
+ * @author Mykhailo Drachuk
+ */
+public final class HttpMessagesTestEnv {
+
+    @SuppressWarnings("DuplicateStringLiteralInspection")
+    private static final String CONTENT_TYPE = "Content-Type";
+    public static final String JSON_TYPE = "application/json";
+    public static final String JSON_TYPE_UTF_8 = "application/json; charset=utf-8";
+    public static final String JSON_TYPE_CRAZY_CASE = "aPPliCatIon/JSon";
+    public static final String PROTOBUF_TYPE = "application/x-protobuf";
+
+    /** Prevents the test environment class instantiation. */
+    private HttpMessagesTestEnv() {
+    }
+
+    public static void testJsonWithContentType(String type) throws IOException {
+        Ack expectedAck = newAck(5);
+        String content = toCompactJson(expectedAck);
+        Optional<Ack> actual = HttpMessages.parse(request(content, type), Ack.class);
+        assertTrue(actual.isPresent());
+        assertEquals(expectedAck, actual.get());
+    }
+
+    public static Ack newAck(int id) {
+        return AckVBuilder.newBuilder()
+                          .setMessageId(pack(Int32Value.of(id)))
+                          .setStatus(statusOk())
+                          .build();
+    }
+
+    public static String base64(Message message) {
+        byte[] messageBytes = message.toByteArray();
+        String result = Base64.getEncoder()
+                              .encodeToString(messageBytes);
+        return result;
+    }
+
+    public static HttpServletRequest requestWithoutContentType(String content) throws IOException {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getReader()).thenReturn(new BufferedReader(new StringReader(content)));
+        return request;
+    }
+
+    public static HttpServletRequest request(String content, String format)
+            throws IOException {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getReader()).thenReturn(new BufferedReader(new StringReader(content)));
+        when(request.getHeader(eq(CONTENT_TYPE))).thenReturn(format);
+        return request;
+    }
+}


### PR DESCRIPTION
In this PR an implementation for the `MessageFormat` changed to use Guavas `MediaType` instead of  MIME type strings. This allows using a Content-Type with charset specified without breaking the format selection.

New behavior was documented and covered with tests.