### PR TITLE
Use Firebase version specified by config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,20 @@ subprojects {
         })
     }
 
+    configurations.all({
+        resolutionStrategy {
+            /**
+             * {@code proto-google-common-protos} starting with version {@code 1.1.0}
+             * and {@code proto-google-iam-v1} starting with version {@code 0.1.29}
+             * include Protobuf message definitions alongside with compiled Java.
+             * This breaks the spine compiler which searches for all Protobuf definitions 
+             * in classpath, and assumes they implement the Type URLs.
+             */
+            force "com.google.api.grpc:proto-google-common-protos:1.0.0"
+            force "com.google.api.grpc:proto-google-iam-v1:0.1.28"
+        }
+    })
+
     ext {
         spineProtobufPluginId = 'io.spine.tools.spine-model-compiler'
 

--- a/build.gradle
+++ b/build.gradle
@@ -152,6 +152,21 @@ subprojects {
         testImplementation "io.spine:spine-testutil-client:$spineVersion"
     }
 
+
+    configurations.all({
+        resolutionStrategy {
+            /**
+             * {@code proto-google-common-protos} starting with version {@code 1.1.0}
+             * and {@code proto-google-iam-v1} starting with version {@code 0.1.29}
+             * include Protobuf message definitions alongside with compiled Java.
+             * This breaks the spine compiler which searches for all Protobuf definitions 
+             * in classpath, and assumes they implement the Type URLs.
+             */
+            force "com.google.api.grpc:proto-google-common-protos:1.0.0"
+            force "com.google.api.grpc:proto-google-iam-v1:0.1.28"
+        }
+    })
+
     sourceSets {
         main {
             java.srcDirs generatedJavaDir, "$sourcesRootDir/main/java", generatedSpineDir

--- a/build.gradle
+++ b/build.gradle
@@ -95,20 +95,6 @@ subprojects {
         })
     }
 
-    configurations.all({
-        resolutionStrategy {
-            /**
-             * {@code proto-google-common-protos} starting with version {@code 1.1.0}
-             * and {@code proto-google-iam-v1} starting with version {@code 0.1.29}
-             * include Protobuf message definitions alongside with compiled Java.
-             * This breaks the spine compiler which searches for all Protobuf definitions 
-             * in classpath, and assumes they implement the Type URLs.
-             */
-            force "com.google.api.grpc:proto-google-common-protos:1.0.0"
-            force "com.google.api.grpc:proto-google-iam-v1:0.1.28"
-        }
-    })
-
     ext {
         spineProtobufPluginId = 'io.spine.tools.spine-model-compiler'
 

--- a/firebase-web/build.gradle
+++ b/firebase-web/build.gradle
@@ -30,7 +30,7 @@ apply plugin: spineProtobufPluginId
 
 dependencies {
     api project(':web')
-    api ("com.google.firebase:firebase-admin:$firebaseVersion") {
+    api(deps.build.firebaseAdmin) {
         exclude group: 'com.google.guava', module: 'guava'
     }
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.6'

--- a/firebase-web/src/test/java/io/spine/web/firebase/FirebaseDatabasePathTest.java
+++ b/firebase-web/src/test/java/io/spine/web/firebase/FirebaseDatabasePathTest.java
@@ -110,7 +110,6 @@ class FirebaseDatabasePathTest {
     void testEscaped() {
         TestActorRequestFactory requestFactory = TestActorRequestFactory.newInstance(
                 "a.aa#@)?$0[abb-ab",
-                ZoneOffsets.getDefault(),
                 systemDefault()
         );
         Query query = requestFactory.query()

--- a/version.gradle
+++ b/version.gradle
@@ -26,6 +26,5 @@ ext {
     
     versionToPublish = '1.0.0-SNAPSHOT'
 
-    firebaseVersion = '6.6.0'
     servletApiVersion = '4.0.0'
 }

--- a/version.gradle
+++ b/version.gradle
@@ -26,6 +26,6 @@ ext {
     
     versionToPublish = '1.0.0-SNAPSHOT'
 
-    firebaseVersion = '5.9.0'
+    firebaseVersion = '6.6.0'
     servletApiVersion = '4.0.0'
 }


### PR DESCRIPTION
This PR uses the Firebase version specified in `config` module and updates code to be compatible with the latest Spine SNAPSHOT.