### PR TITLE
Remove `instanceof` comparison with Protobuf Message constructor.

### DIFF
--- a/client-js/main/client/any-packer.js
+++ b/client-js/main/client/any-packer.js
@@ -19,7 +19,11 @@
  */
 
 import {Message} from 'google-protobuf';
-import {Type, TypedMessage} from './typed-message';
+import {
+  Type,
+  TypedMessage,
+  isProtobufMessage
+} from './typed-message';
 import {
   Int32Value,
   Int64Value,
@@ -351,7 +355,7 @@ export class AnyPacker {
    * @return {Any} a new Any with the provided message inside
    */
   static packMessage(message) {
-    if (!(message instanceof Message)) {
+    if (!isProtobufMessage(message)) {
       throw new Error('The `Message` type was expected by AnyPacker#packMessage().');
     }
     const typedMessage = TypedMessage.of(message);

--- a/client-js/main/client/typed-message.js
+++ b/client-js/main/client/typed-message.js
@@ -20,6 +20,7 @@
 
 "use strict";
 
+import {Message} from 'google-protobuf';
 import base64 from 'base64-js';
 import {Any} from '../proto/google/protobuf/any_pb';
 import {
@@ -37,6 +38,18 @@ import {Subscription, Topic} from '../proto/spine/client/subscription_pb';
 import {Command} from '../proto/spine/core/command_pb';
 import KnownTypes from './known-types';
 
+/**
+ * Checks if the object extends {@link Message}.
+ *
+ * <p>The implementation doesn't use `instanceof` check and check on prototypes
+ * since they may fail if different versions of the file are used at the same time
+ * (e.g. bundled and the original one).
+ *
+ * @param object the object to check
+ */
+export function isProtobufMessage(object) {
+  return typeof object.constructor.typeUrl === 'function';
+}
 
 /**
  * A URL of a Protobuf type.


### PR DESCRIPTION
Remove `instanceof` comparison with Protobuf Message constructor since it fails. The message instance depends on `Message` class retrieved from the project `npm` dependencies and the one is used to compare with is retrieved from the `spine-web` dependencies.