### PR TITLE
Introduce separate version numeration for NPM publishing.

### DIFF
--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spine-web",
-  "version": "1.0.0-SNAPSHOT",
+  "version": "0.12.0",
   "license": "Apache-2.0",
   "description": "A JS client for interacting with Spine applications.",
   "homepage": "https://spine.io",

--- a/scripts/update-js-version.gradle
+++ b/scripts/update-js-version.gradle
@@ -27,7 +27,7 @@ import groovy.json.JsonSlurper
  */
 
 ext.JS_PACKAGE_FILE_LOCATION = "$projectDir/package.json"
-ext.JS_PACKAGES_VERSION = versionToPublish
+ext.JS_PACKAGES_VERSION = versionToPublishJs
 
 Object readJsonFile(final String sourcePath) {
     def final packageJsonFile = file(sourcePath)

--- a/version.gradle
+++ b/version.gradle
@@ -25,6 +25,7 @@ ext {
     spineBaseVersion = '1.0.0-SNAPSHOT'
     
     versionToPublish = '1.0.0-SNAPSHOT'
+    versionToPublishJs = '0.12.0'
 
     servletApiVersion = '4.0.0'
 }


### PR DESCRIPTION
This PR changes the version numeration of the `spine-web` package at NPM.

From this moment, the `spine-web` package version will start from `0.12.0` and will be incremented in future releases by the minor version (e.g. `0.12.1`, `0.12.2` etc.).
The previous approach with a single `SNAPSHOT` version doesn't fit NPM policy. Once a package is published with a given name and version, that specific name and version combination can never be used again, even if it is removed with npm-unpublish. See the [`npm-publish`](https://docs.npmjs.com/cli/publish) description.

