### PR TITLE
Investigate NPM publishing failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ script:
   # fail the Travis build if execution of this script is failed.
   - chmod +x ./config/scripts/publish-artifacts.sh
   - ./config/scripts/publish-artifacts.sh
+  - ./gradlew :client-js:link
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/client-js/build.gradle
+++ b/client-js/build.gradle
@@ -75,8 +75,3 @@ clean {
 // Suppress building the JS project as a Java module.
 project.compileJava.enabled = false
 project.compileTestJava.enabled = false
-
-buildJs.doLast {
-    npm 'run', 'build'
-    npm 'run', 'build-dev'
-}

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "webpack --config webpack-prod.config.js",
     "build-dev": "webpack --config webpack-dev.config.js",
-    "transpile-before-publish": "babel main --out-dir build/npm-publication --source-maps",
+    "transpile-before-publish": "babel main --out-dir build/npm-publication --source-maps --ignore main/index.js",
     "coverage": "nyc --reporter=text-lcov npm run test >| build/coverage.lcov",
     "test": "mocha --require babel-polyfill --require babel-register --recursive --exit --full-trace ./test"
   },

--- a/scripts/js.gradle
+++ b/scripts/js.gradle
@@ -147,6 +147,13 @@ task buildJs {
     group = JAVA_SCRIPT_TASK_GROUP
     description = "Assembles the JavaScript source files."
 
+    outputs.files "$projectDir/dist"
+
+    doLast {
+        npm 'run', 'build'
+        npm 'run', 'build-dev'
+    }
+
     dependsOn installDependencies
 }
 
@@ -175,21 +182,33 @@ task checkNpmDirectoryAfterTranspine {
     dependsOn transpileSources
 }
 
+task copyBuildOutputs(type: Copy) {
+    group = JAVA_SCRIPT_TASK_GROUP
+    description = 'Prepares the NPM package for publish.'
+
+    from buildJs.outputs
+    into "$publicationDirectory/dist"
+
+    dependsOn buildJs
+}
+
 /**
  * Copies the NPM publication files into a temporary directory which they are published from.
  */
-task prepareJsPublication {
-//    group = JAVA_SCRIPT_TASK_GROUP
-//    description = 'Prepares the NPM package for publish.'
-//
-//    from projectDir
-//    into publicationDirectory
-//    include 'index.js'
-//    include 'package.json'
-//    include '.npmrc'
-//    include 'dist/**'
+task prepareJsPublication(type: Copy) {
+    group = JAVA_SCRIPT_TASK_GROUP
+    description = 'Prepares the NPM package for publish.'
+
+    from (projectDir) {
+        include 'index.js'
+        include 'package.json'
+        include '.npmrc'
+    }
+
+    into publicationDirectory
 
     dependsOn buildJs
+    dependsOn copyBuildOutputs
     dependsOn checkNpmDirectoryAfterTranspine
 }
 

--- a/scripts/js.gradle
+++ b/scripts/js.gradle
@@ -190,7 +190,6 @@ task prepareJsPublication(type: Copy) {
     }
 
     into publicationDirectory
-    exclude testSrcDir
 
     dependsOn buildJs
     dependsOn checkNpmDirectoryAfterTranspine

--- a/scripts/js.gradle
+++ b/scripts/js.gradle
@@ -162,6 +162,19 @@ task transpileSources {
     }
 }
 
+task checkNpmDirectoryAfterTranspine {
+    doLast {
+        def names = []
+        fileTree(publicationDirectory).visit { final details ->
+            names << details.file.path
+        }
+        final def collectedPaths = names.stream().collect(Collectors.joining('\n'))
+        println("===== After execution `:transpileSources` publication directory contains: \n ${collectedPaths}")
+    }
+
+    dependsOn transpileSources
+}
+
 /**
  * Copies the NPM publication files into a temporary directory which they are published from.
  */
@@ -180,7 +193,7 @@ task prepareJsPublication(type: Copy) {
     exclude testSrcDir
 
     dependsOn buildJs
-    dependsOn transpileSources
+    dependsOn checkNpmDirectoryAfterTranspine
 }
 
 /**

--- a/scripts/js.gradle
+++ b/scripts/js.gradle
@@ -182,14 +182,12 @@ task prepareJsPublication(type: Copy) {
     group = JAVA_SCRIPT_TASK_GROUP
     description = 'Prepares the NPM package for publish.'
 
-    from projectDir, {
-        include 'index.js'
-        include 'package.json'
-        include '.npmrc'
-        include 'dist/**'
-    }
-
+    from projectDir
     into publicationDirectory
+    include 'index.js'
+    include 'package.json'
+    include '.npmrc'
+    include 'dist/**'
 
     dependsOn buildJs
     dependsOn checkNpmDirectoryAfterTranspine

--- a/scripts/js.gradle
+++ b/scripts/js.gradle
@@ -178,16 +178,16 @@ task checkNpmDirectoryAfterTranspine {
 /**
  * Copies the NPM publication files into a temporary directory which they are published from.
  */
-task prepareJsPublication(type: Copy) {
-    group = JAVA_SCRIPT_TASK_GROUP
-    description = 'Prepares the NPM package for publish.'
-
-    from projectDir
-    into publicationDirectory
-    include 'index.js'
-    include 'package.json'
-    include '.npmrc'
-    include 'dist/**'
+task prepareJsPublication {
+//    group = JAVA_SCRIPT_TASK_GROUP
+//    description = 'Prepares the NPM package for publish.'
+//
+//    from projectDir
+//    into publicationDirectory
+//    include 'index.js'
+//    include 'package.json'
+//    include '.npmrc'
+//    include 'dist/**'
 
     dependsOn buildJs
     dependsOn checkNpmDirectoryAfterTranspine

--- a/scripts/js.gradle
+++ b/scripts/js.gradle
@@ -1,3 +1,5 @@
+import java.util.stream.Collectors
+
 /*
  * Copyright 2018, TeamDev Ltd. All rights reserved.
  *
@@ -189,6 +191,12 @@ task link {
     description = "Publishes the NPM package locally."
 
     doLast {
+        def names = []
+        fileTree(publicationDirectory).visit { final details ->
+            names << details.file.path
+        }
+        final def collectedPaths = names.stream().collect(Collectors.joining('\n'))
+        println("===== Before execution of `:link` publication directory contains: \n ${collectedPaths}")
         executeNpm(publicationDirectory as File, 'link')
     }
 


### PR DESCRIPTION
Do not merge this PR!

It is necessary to find out why the `spine-web` NPM package publishing fails during CI build. 