### PR TITLE
Fix NPM publishing during CI build.

### DIFF
--- a/client-js/build.gradle
+++ b/client-js/build.gradle
@@ -75,8 +75,3 @@ clean {
 // Suppress building the JS project as a Java module.
 project.compileJava.enabled = false
 project.compileTestJava.enabled = false
-
-buildJs.doLast {
-    npm 'run', 'build'
-    npm 'run', 'build-dev'
-}

--- a/client-js/build.gradle
+++ b/client-js/build.gradle
@@ -22,10 +22,6 @@ apply from: "$rootDir/scripts/js.gradle"
 
 apply plugin: 'com.google.protobuf'
 
-ext {
-    nycOutputDir = "$projectDir/.nyc_output"
-}
-
 dependencies {
     protobuf project(':web')
     protobuf project(':firebase-web')
@@ -62,14 +58,6 @@ sourceSets {
         java.srcDirs = []
         resources.srcDirs = []
     }
-}
-
-clean {
-    delete nycOutputDir
-    delete "$projectDir/dist"
-    delete nodeModulesDir
-    delete genProtoMain
-    delete genProtoTest
 }
 
 // Suppress building the JS project as a Java module.

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "webpack --config webpack-prod.config.js",
     "build-dev": "webpack --config webpack-dev.config.js",
-    "transpile-before-publish": "babel main --out-dir build/npm-publication --source-maps",
+    "transpile-before-publish": "babel main --out-dir build/npm-publication --source-maps --ignore main/index.js",
     "coverage": "nyc --reporter=text-lcov npm run test >| build/coverage.lcov",
     "test": "mocha --require babel-polyfill --require babel-register --recursive --exit --full-trace ./test"
   },

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spine-web",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "license": "Apache-2.0",
   "description": "A JS client for interacting with Spine applications.",
   "homepage": "https://spine.io",

--- a/scripts/js.gradle
+++ b/scripts/js.gradle
@@ -107,7 +107,7 @@ apply plugin: 'io.spine.tools.proto-js-plugin'
 task deleteCompiled {
     group = JAVA_SCRIPT_TASK_GROUP
     description = 'Cleans old module dependencies and build outputs.'
-    
+
     doLast {
         delete buildJs.outputs
         delete installDependencies.outputs
@@ -143,7 +143,7 @@ protoJs {
 }
 
 /**
- * Assembles the JS sources.
+ * Assembles the bundled version of JS sources.
  *
  * This task is an analog of `build` for JS.
  *
@@ -164,9 +164,9 @@ task buildJs {
 }
 
 /**
- * Copies assembled JS sources to the temporary NPM publication directory.
+ * Copies bundled JS sources to the temporary NPM publication directory.
  */
-task copyJsBuildOutputs(type: Copy) {
+task copyBundeledJs(type: Copy) {
     group = JAVA_SCRIPT_TASK_GROUP
     description = 'Copies assembled JavaScript sources to the NPM publication directory.'
 
@@ -177,7 +177,7 @@ task copyJsBuildOutputs(type: Copy) {
 }
 
 /**
- * Transpiles sources before publishing them to NPM.
+ * Transpiles JS sources before publishing them to NPM.
  *
  * Puts the resulting files to the temporary NPM publication directory.
  */
@@ -191,7 +191,10 @@ task transpileSources {
 }
 
 /**
- * Copies the NPM publication files into a temporary directory which they are published from.
+ * Copies all remaining files into a temporary NPM publication directory.
+ * 
+ * This task finalizes assembling of files in the temporary NPM publication
+ * directory which they are published from.
  */
 task prepareJsPublication(type: Copy) {
     group = JAVA_SCRIPT_TASK_GROUP
@@ -206,7 +209,7 @@ task prepareJsPublication(type: Copy) {
     into publicationDirectory
 
     dependsOn buildJs
-    dependsOn copyJsBuildOutputs
+    dependsOn copyBundeledJs
     dependsOn transpileSources
 }
 

--- a/scripts/js.gradle
+++ b/scripts/js.gradle
@@ -145,6 +145,13 @@ task buildJs {
     group = JAVA_SCRIPT_TASK_GROUP
     description = "Assembles the JavaScript source files."
 
+    outputs.files "$projectDir/dist"
+    
+    doLast {
+        npm 'run', 'build'
+        npm 'run', 'build-dev'
+    }
+
     dependsOn installDependencies
 }
 

--- a/scripts/js.gradle
+++ b/scripts/js.gradle
@@ -186,7 +186,7 @@ task transpileSources {
     description = "Transpiles sources before publishing."
 
     doLast {
-        executeNpm(projectDir as File, 'run', 'transpile-before-publish')
+        npm 'run', 'transpile-before-publish'
     }
 }
 

--- a/scripts/js.gradle
+++ b/scripts/js.gradle
@@ -56,6 +56,7 @@ ext {
     genProtoMain = "$genProtoBaseDir/main/$genProtoSubDir"
     genProtoTest = "$genProtoBaseDir/test/$genProtoSubDir"
     nodeModulesDir = "$projectDir/node_modules"
+    nycOutputDir = "$projectDir/.nyc_output"
 
     npm = { final String... command ->
         ext.executeNpm(workDirectory as File, command)
@@ -101,11 +102,18 @@ protobuf {
 apply plugin: 'io.spine.tools.proto-js-plugin'
 
 /**
- * Cleans old module dependencies.
+ * Cleans old module dependencies and build outputs.
  */
-task cleanOldDependencies {
+task deleteCompiled {
+    group = JAVA_SCRIPT_TASK_GROUP
+    description = 'Cleans old module dependencies and build outputs.'
+    
     doLast {
-        delete nodeModulesDir
+        delete buildJs.outputs
+        delete installDependencies.outputs
+        delete genProtoMain
+        delete genProtoTest
+        delete coverageJs.outputs
     }
 }
 
@@ -257,6 +265,8 @@ task coverageJs {
     group = JAVA_SCRIPT_TASK_GROUP
     description = 'Runs the JS tests and collects the code coverage info.'
 
+    outputs.files nycOutputDir
+    
     doLast {
         npm 'run', 'coverage'
     }
@@ -267,5 +277,5 @@ task coverageJs {
 rootProject.check.dependsOn coverageJs
 
 build.dependsOn buildJs
-clean.dependsOn cleanOldDependencies
+clean.dependsOn deleteCompiled
 publish.dependsOn publishJs

--- a/scripts/js.gradle
+++ b/scripts/js.gradle
@@ -156,7 +156,22 @@ task buildJs {
 }
 
 /**
+ * Copies assembled JS sources to the temporary NPM publication directory.
+ */
+task copyJsBuildOutputs(type: Copy) {
+    group = JAVA_SCRIPT_TASK_GROUP
+    description = 'Copies assembled JavaScript sources to the NPM publication directory.'
+
+    from buildJs.outputs
+    into "$publicationDirectory/dist"
+
+    dependsOn buildJs
+}
+
+/**
  * Transpiles sources before publishing them to NPM.
+ *
+ * Puts the resulting files to the temporary NPM publication directory.
  */
 task transpileSources {
     group = JAVA_SCRIPT_TASK_GROUP
@@ -174,17 +189,16 @@ task prepareJsPublication(type: Copy) {
     group = JAVA_SCRIPT_TASK_GROUP
     description = 'Prepares the NPM package for publish.'
 
-    from projectDir, {
+    from (projectDir) {
         include 'index.js'
         include 'package.json'
         include '.npmrc'
-        include 'dist/**'
     }
 
     into publicationDirectory
-    exclude testSrcDir
 
     dependsOn buildJs
+    dependsOn copyJsBuildOutputs
     dependsOn transpileSources
 }
 

--- a/version.gradle
+++ b/version.gradle
@@ -25,7 +25,7 @@ ext {
     spineBaseVersion = '1.0.0-SNAPSHOT'
     
     versionToPublish = '1.0.0-SNAPSHOT'
-    versionToPublishJs = '0.12.4'
+    versionToPublishJs = '0.12.5'
 
     servletApiVersion = '4.0.0'
 }


### PR DESCRIPTION
This PR brings a fix for publishing `spine-web` package during CI build.

Publishing of incomplete library package was caused by corrupted execution of Gradle copy task. It was failing copying files generated during the execution of other tasks. Adding dependencies to the tasks `outputs` fixed this issue.