### PR TITLE
Use latest `config` which fixes publishing tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ before_install:
 script:
   - ./gradlew check --stacktrace
 
+  # Execute the task for debugging.
+  - ./gradlew :client-js:publishJs
+
   # The publishing script should be executed in `script` section in order to
   # fail the Travis build if execution of this script is failed.
   - chmod +x ./config/scripts/publish-artifacts.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,6 @@ before_install:
 script:
   - ./gradlew check --stacktrace
 
-  # Execute the task for debugging.
-  - ./gradlew :client-js:publishJs
-
   # The publishing script should be executed in `script` section in order to
   # fail the Travis build if execution of this script is failed.
   - chmod +x ./config/scripts/publish-artifacts.sh

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spine-web",
-  "version": "0.12.7",
+  "version": "0.12.8",
   "license": "Apache-2.0",
   "description": "A JS client for interacting with Spine applications.",
   "homepage": "https://spine.io",

--- a/scripts/js.gradle
+++ b/scripts/js.gradle
@@ -106,9 +106,14 @@ task transpileSources {
  */
 prepareJsPublication {
 
-    from (projectDir) {
-        include 'package.json'
-        include '.npmrc'
+    doLast {
+        copy {
+            from (projectDir) {
+                include 'package.json'
+                include '.npmrc'
+            }
+            into publicationDirectory
+        }
     }
 
     //TODO:2019-02-05:dmytro.grankin: temporarily don't publish a bundle, see https://github.com/SpineEventEngine/web/issues/61

--- a/version.gradle
+++ b/version.gradle
@@ -25,7 +25,7 @@ ext {
     spineBaseVersion = '1.0.0-SNAPSHOT'
     
     versionToPublish = '1.0.0-SNAPSHOT'
-    versionToPublishJs = '0.12.7'
+    versionToPublishJs = '0.12.8'
 
     servletApiVersion = '4.0.0'
 }


### PR DESCRIPTION
This PR fixes the publishing to NPM by updating to the latest `config`.

See the [PR](https://github.com/SpineEventEngine/config/pull/42) in `config`.