### PR TITLE
Release `1.0.0-pre4`

### DIFF
--- a/client-js/package.json
+++ b/client-js/package.json
@@ -44,7 +44,7 @@
     "codecov": "^3.0.0",
     "mocha": "^5.2.0",
     "sinon": "^7.0.0",
-    "nyc": "13.0.1",
+    "nyc": "^13.0.1",
     "webpack": "^4.23.1",
     "webpack-cli": "^3.1.2",
     "webpack-merge": "^4.1.4",

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spine-web",
-  "version": "0.12.8",
+  "version": "0.13.0",
   "license": "Apache-2.0",
   "description": "A JS client for interacting with Spine applications.",
   "homepage": "https://spine.io",
@@ -44,7 +44,7 @@
     "codecov": "^3.0.0",
     "mocha": "^5.2.0",
     "sinon": "^7.0.0",
-    "nyc": "^13.0.1",
+    "nyc": "13.0.1",
     "webpack": "^4.23.1",
     "webpack-cli": "^3.1.2",
     "webpack-merge": "^4.1.4",

--- a/scripts/js.gradle
+++ b/scripts/js.gradle
@@ -155,7 +155,9 @@ task coverageJs {
     }
 
     dependsOn buildJs
-    rootProject.check.dependsOn coverageJs
+    
+    // Disable coverage for a while.
+    // rootProject.check.dependsOn coverageJs
 }
 
 protobuf {
@@ -177,7 +179,8 @@ protobuf {
                 }
 
                 task.generateDescriptorSet = true
-                task.descriptorSetOptions.path = "${projectDir}/build/descriptors/${task.sourceSet.name}/known_types.desc"
+                final def descriptorName = "${project.group}_${project.name}_${project.version}.desc"
+                task.descriptorSetOptions.path = "${projectDir}/build/descriptors/${task.sourceSet.name}/${descriptorName}"
             }
             compileProtoToJs.dependsOn task
         }

--- a/version.gradle
+++ b/version.gradle
@@ -18,14 +18,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-def final SPINE_VERSION = '1.0.0-SNAPSHOT'
+def final SPINE_VERSION = '1.0.0-pre4'
 
 ext {
     spineVersion = SPINE_VERSION
-    spineBaseVersion = '1.0.0-SNAPSHOT'
+    spineBaseVersion = SPINE_VERSION
     
-    versionToPublish = '1.0.0-SNAPSHOT'
-    versionToPublishJs = '0.12.8'
+    versionToPublish = SPINE_VERSION
+    versionToPublishJs = '0.13.0'
 
     servletApiVersion = '4.0.0'
 }


### PR DESCRIPTION
This PR performs a pre-release of `1.0.0-pre4` version of Java library and `0.13.0` version of the respective npm package.

