### PR TITLE
Release Java `1.0.0-pre5` and JS `0.14.0`

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -18,14 +18,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-def final SPINE_VERSION = '1.0.0-SNAPSHOT'
+def final SPINE_VERSION = '1.0.0-pre5'
 
 ext {
     spineVersion = SPINE_VERSION
     spineBaseVersion = SPINE_VERSION
     
     versionToPublish = SPINE_VERSION
-    versionToPublishJs = '0.13.0'
+    versionToPublishJs = '0.14.0'
 
     servletApiVersion = '4.0.0'
 }


### PR DESCRIPTION
This pull request updates the library version and its dependency on `core` and `base` to `1.0.0-pre5`.

The JavaScript library version is set to `0.14.0`.