### PR TITLE
Handle concurrent exceptions

### DIFF
--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spine-web",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "license": "Apache-2.0",
   "description": "A JS client for interacting with Spine applications.",
   "homepage": "https://spine.io",

--- a/firebase-web/src/main/java/io/spine/web/firebase/subscription/SubscriptionRecord.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/subscription/SubscriptionRecord.java
@@ -119,9 +119,10 @@ final class SubscriptionRecord {
     }
 
     /**
-     * Creates a stream of response messages, mapping each each response message to JSON.
+     * Creates a stream of response messages, mapping each response message to JSON.
      *
-     * @param response Spines response to a query
+     * @param response
+     *         response to an entity query
      * @return a stream of messages represented by JSON strings
      */
     @SuppressWarnings("RedundantTypeArguments") // AnyPacker::unpack type cannot be inferred.

--- a/firebase-web/src/main/java/io/spine/web/firebase/subscription/SubscriptionRecord.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/subscription/SubscriptionRecord.java
@@ -35,6 +35,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Stream;
 
+import static io.spine.web.future.Completion.dispose;
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -72,12 +73,13 @@ final class SubscriptionRecord {
      * transaction.
      */
     private void flushNewVia(FirebaseClient firebaseClient) {
-        queryResponse.thenAccept(response -> {
+        CompletionStage<Void> stage = queryResponse.thenAccept(response -> {
             List<String> newEntries = mapMessagesToJson(response).collect(toList());
             NodeValue nodeValue = NodeValue.empty();
             newEntries.forEach(nodeValue::addChild);
             firebaseClient.merge(path(), nodeValue);
         });
+        dispose(stage);
     }
 
     /**
@@ -92,7 +94,7 @@ final class SubscriptionRecord {
      * already present in storage in a transaction.
      */
     private void flushDiffVia(FirebaseClient firebaseClient) {
-        queryResponse.thenAccept(response -> {
+        CompletionStage<Void> stage = queryResponse.thenAccept(response -> {
             List<String> newEntries = mapMessagesToJson(response).collect(toList());
             Optional<NodeValue> existingValue = firebaseClient.get(path());
             if (!existingValue.isPresent()) {
@@ -105,6 +107,7 @@ final class SubscriptionRecord {
                 updateWithDiff(diff, firebaseClient);
             }
         });
+        dispose(stage);
     }
 
     private void updateWithDiff(Diff diff, FirebaseClient firebaseClient) {

--- a/firebase-web/src/test/java/io/spine/web/firebase/FirebaseClientFactoryTest.java
+++ b/firebase-web/src/test/java/io/spine/web/firebase/FirebaseClientFactoryTest.java
@@ -28,13 +28,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertThat;
-import static io.spine.web.firebase.DatabaseUrls.from;
 import static io.spine.web.firebase.FirebaseCredentials.fromGoogleCredentials;
 
 @DisplayName("FirebaseClientFactory should")
 class FirebaseClientFactoryTest extends UtilityClassTest<FirebaseClientFactory> {
 
-    private static final DatabaseUrl SOME_URL = from("https://someUrl.com");
+    private static final DatabaseUrl SOME_URL = DatabaseUrls.from("https://someUrl.com");
 
     private static final MockGoogleCredential GOOGLE_CREDENTIALS =
             new MockGoogleCredential.Builder().build();

--- a/firebase-web/src/test/java/io/spine/web/firebase/given/FirebaseQueryMediatorTestEnv.java
+++ b/firebase-web/src/test/java/io/spine/web/firebase/given/FirebaseQueryMediatorTestEnv.java
@@ -20,6 +20,7 @@
 
 package io.spine.web.firebase.given;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.Any;
 import com.google.protobuf.Message;
 import io.grpc.stub.StreamObserver;
@@ -32,7 +33,6 @@ import io.spine.protobuf.AnyPacker;
 import java.util.ArrayList;
 import java.util.Collection;
 
-import static com.google.common.collect.ImmutableSet.copyOf;
 import static io.spine.core.Responses.ok;
 import static java.util.stream.Collectors.toSet;
 
@@ -50,9 +50,10 @@ public final class FirebaseQueryMediatorTestEnv {
 
         public TestQueryService(Message... messages) {
             super();
-            this.response = copyOf(messages).stream()
-                                            .map(AnyPacker::pack)
-                                            .collect(toSet());
+            this.response = ImmutableSet.copyOf(messages)
+                                        .stream()
+                                        .map(AnyPacker::pack)
+                                        .collect(toSet());
         }
 
         @Override

--- a/firebase-web/src/test/java/io/spine/web/firebase/query/QueryNodePathTest.java
+++ b/firebase-web/src/test/java/io/spine/web/firebase/query/QueryNodePathTest.java
@@ -41,7 +41,6 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static io.spine.time.ZoneIds.systemDefault;
-import static io.spine.web.firebase.query.QueryNodePath.of;
 import static java.util.stream.Collectors.toList;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -115,7 +114,7 @@ class QueryNodePathTest {
         );
         Query query = requestFactory.query()
                                     .all(Any.class);
-        String path = of(query).getValue();
+        String path = QueryNodePath.of(query).getValue();
         assertFalse(path.contains("#"));
         assertFalse(path.contains("."));
         assertFalse(path.contains("["));

--- a/firebase-web/src/test/java/io/spine/web/firebase/subscription/given/HasChildren.java
+++ b/firebase-web/src/test/java/io/spine/web/firebase/subscription/given/HasChildren.java
@@ -31,7 +31,6 @@ import java.util.Map;
 import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.collect.ImmutableMap.copyOf;
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -56,7 +55,7 @@ public class HasChildren implements ArgumentMatcher<NodeValue> {
      *         the expected entries in "nodeKey-nodeValue" format
      */
     public HasChildren(Map<String, String> expected) {
-        this.expected = copyOf(expected);
+        this.expected = ImmutableMap.copyOf(expected);
     }
 
     @Override

--- a/version.gradle
+++ b/version.gradle
@@ -24,7 +24,7 @@ ext {
     spineVersion = SPINE_VERSION
     spineBaseVersion = SPINE_VERSION
     
-    versionToPublish = SPINE_VERSION
+    versionToPublish = '1.0.0-SNAPSHOT'
     versionToPublishJs = '0.14.0'
 
     servletApiVersion = '4.0.0'

--- a/web/src/main/java/io/spine/web/command/CommandServlet.java
+++ b/web/src/main/java/io/spine/web/command/CommandServlet.java
@@ -25,6 +25,7 @@ import io.spine.core.Ack;
 import io.spine.core.Command;
 import io.spine.server.CommandService;
 import io.spine.web.NonSerializableServlet;
+import io.spine.web.future.FutureObserver;
 import io.spine.web.parser.HttpMessages;
 
 import javax.annotation.OverridingMethodsMustInvokeSuper;

--- a/web/src/main/java/io/spine/web/future/Completion.java
+++ b/web/src/main/java/io/spine/web/future/Completion.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.web.future;
+
+import io.spine.logging.Logging;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+
+import java.util.concurrent.CompletionStage;
+
+/**
+ * A set of utilities for working with dignified ending for a {@code CompletionStage}.
+ */
+public final class Completion {
+
+    private static final Logger log = Logging.get(Completion.class);
+
+    /**
+     * Prevents the utility class instantiation.
+     */
+    private Completion() {
+    }
+
+    /**
+     * Logs the exception of the given stage if any.
+     *
+     * <p>Does nothing if the stage completes successfully.
+     *
+     * <p>Note that the method does not block the thread but logs the exception when the given stage
+     * is complete.
+     *
+     * @param completionStage
+     *         stage which may complete exceptionally
+     */
+    public static void dispose(CompletionStage<?> completionStage) {
+        completionStage.whenComplete((result, exception) -> logException(exception));
+    }
+
+    private static void logException(@Nullable Throwable exception) {
+        if (exception != null) {
+            log.error("Failed to complete task.", exception);
+        }
+    }
+}

--- a/web/src/main/java/io/spine/web/future/FutureObserver.java
+++ b/web/src/main/java/io/spine/web/future/FutureObserver.java
@@ -18,7 +18,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.web.command;
+package io.spine.web.future;
 
 import io.grpc.stub.StreamObserver;
 
@@ -34,8 +34,6 @@ import static io.spine.util.Exceptions.newIllegalStateException;
  *
  * <p>This implementation works only with the unary gRPC calls, i.e. {@link #onNext(Object)} cannot
  * be called more then once.
- *
- * @author Dmytro Dashenkov
  */
 public final class FutureObserver<T> implements StreamObserver<T> {
 
@@ -82,9 +80,6 @@ public final class FutureObserver<T> implements StreamObserver<T> {
         return new FutureObserver<>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void onNext(T value) {
         if (future.isDone()) {
@@ -94,17 +89,11 @@ public final class FutureObserver<T> implements StreamObserver<T> {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void onError(Throwable t) {
         future.obtrudeException(t);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void onCompleted() {
         if (!future.isDone()) {

--- a/web/src/main/java/io/spine/web/future/package-info.java
+++ b/web/src/main/java/io/spine/web/future/package-info.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * This package contains classes working with {@code Future}s.
+ */
+
+@CheckReturnValue
+@ParametersAreNonnullByDefault
+package io.spine.web.future;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/web/src/main/java/io/spine/web/query/service/Local.java
+++ b/web/src/main/java/io/spine/web/query/service/Local.java
@@ -23,7 +23,7 @@ package io.spine.web.query.service;
 import io.spine.client.Query;
 import io.spine.client.QueryResponse;
 import io.spine.client.grpc.QueryServiceGrpc.QueryServiceImplBase;
-import io.spine.web.command.FutureObserver;
+import io.spine.web.future.FutureObserver;
 
 import java.util.concurrent.CompletableFuture;
 

--- a/web/src/test/java/io/spine/web/command/FutureObserverTest.java
+++ b/web/src/test/java/io/spine/web/command/FutureObserverTest.java
@@ -20,6 +20,7 @@
 
 package io.spine.web.command;
 
+import io.spine.web.future.FutureObserver;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 

--- a/web/src/test/java/io/spine/web/future/CompletionTest.java
+++ b/web/src/test/java/io/spine/web/future/CompletionTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.web.future;
+
+import com.google.common.truth.IterableSubject;
+import io.spine.logging.Logging;
+import io.spine.testing.UtilityClassTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.event.EventRecodingLogger;
+import org.slf4j.event.SubstituteLoggingEvent;
+import org.slf4j.helpers.SubstituteLogger;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.slf4j.event.Level.ERROR;
+
+@DisplayName("Completion should")
+class CompletionTest extends UtilityClassTest<Completion> {
+
+    private Queue<SubstituteLoggingEvent> log;
+
+    CompletionTest() {
+        super(Completion.class);
+    }
+
+    @BeforeEach
+    void setUp() {
+        Logger completionLogger = Logging.get(Completion.class);
+        SubstituteLogger substituteLogger = (SubstituteLogger) completionLogger;
+        log = new ArrayDeque<>();
+        substituteLogger.setDelegate(new EventRecodingLogger(substituteLogger, log));
+    }
+
+    @Test
+    @DisplayName("ignore stages which complete successfully")
+    void ignoreSuccessfulStages() {
+        CompletableFuture<Number> successfulStage = new CompletableFuture<>();
+        successfulStage.complete(42);
+        Completion.dispose(successfulStage);
+        assertThat(log).isEmpty();
+    }
+
+    @Test
+    @DisplayName("log stage exceptions")
+    void logExceptions() {
+        CompletableFuture<Number> failedStage = new CompletableFuture<>();
+        failedStage.completeExceptionally(new UnicornException());
+        Completion.dispose(failedStage);
+
+        IterableSubject assertLog = assertThat(log);
+        assertLog.isNotEmpty();
+        assertLog.hasSize(1);
+
+        SubstituteLoggingEvent loggingEvent = log.poll();
+        assertThat(loggingEvent.getLevel()).isEqualTo(ERROR);
+        assertThat(loggingEvent.getThrowable())
+                .isInstanceOf(UnicornException.class);
+    }
+
+    private static final class UnicornException extends Exception {
+        private static final long serialVersionUID = 0L;
+    }
+}

--- a/web/src/test/java/io/spine/web/future/FutureObserverTest.java
+++ b/web/src/test/java/io/spine/web/future/FutureObserverTest.java
@@ -18,9 +18,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.web.command;
+package io.spine.web.future;
 
-import io.spine.web.future.FutureObserver;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
This PR addresses the issue with the concurrent error handling in Query/Subscription bridges.

Before, when writing a record into Firebase, we ignored the errors which occurred when performing the record write itself (connecting to Firebase, etc.). Now, these errors are logged.

#### Why not rethrow?

The mechanism of `CompletionStage`s is designed to avoid throwing errors on the caller side. Thus, it is impossible to throw an exception in the processing thread. The user should either block the caller thread to wait for a result or an exception; or handle the exception normally, that is in a way which does not cause another exception.