### PR TITLE
Update Spine version to `1.0.0-pre6`

### DIFF
--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spine-web",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "license": "Apache-2.0",
   "description": "A JS client for interacting with Spine applications.",
   "homepage": "https://spine.io",

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spine-web",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "license": "Apache-2.0",
   "description": "A JS client for interacting with Spine applications.",
   "homepage": "https://spine.io",

--- a/version.gradle
+++ b/version.gradle
@@ -25,7 +25,7 @@ ext {
     spineBaseVersion = SPINE_VERSION
     
     versionToPublish = SPINE_VERSION
-    versionToPublishJs = '0.14.1'
+    versionToPublishJs = '0.15.0'
 
     servletApiVersion = '4.0.0'
 }

--- a/version.gradle
+++ b/version.gradle
@@ -18,14 +18,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-def final SPINE_VERSION = '1.0.0-pre5'
+def final SPINE_VERSION = '1.0.0-pre6'
 
 ext {
     spineVersion = SPINE_VERSION
     spineBaseVersion = SPINE_VERSION
     
-    versionToPublish = '1.0.0-SNAPSHOT'
-    versionToPublishJs = '0.14.0'
+    versionToPublish = SPINE_VERSION
+    versionToPublishJs = '0.14.1'
 
     servletApiVersion = '4.0.0'
 }


### PR DESCRIPTION
This PR updates Spine components, including `web`, to version `1.0.0-pre6`. 

The new version of Spine JS client is `0.15.0`.