### PR TITLE
Use `testJs` Gradle task from `config`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_install:
 script:
   - ./gradlew check --stacktrace
 
+  - npm install -g npm@~6.1.0
   # The publishing script should be executed in `script` section in order to
   # fail the Travis build if execution of this script is failed.
   - chmod +x ./config/scripts/publish-artifacts.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ env:
 before_install:
   - chmod +x gradlew
 
+  - npm install -g npm@~6.1.0
+
   # Decrypt and unarchive Maven and Google Cloud Storage credentials.
   - openssl aes-256-cbc -K $encrypted_f5821d4f7269_key -iv $encrypted_f5821d4f7269_iv -in credentials.tar.enc -out credentials.tar -d
   - tar xvf credentials.tar
@@ -18,7 +20,6 @@ before_install:
 script:
   - ./gradlew check --stacktrace
 
-  - npm install -g npm@~6.1.0
   # The publishing script should be executed in `script` section in order to
   # fail the Travis build if execution of this script is failed.
   - chmod +x ./config/scripts/publish-artifacts.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ env:
 before_install:
   - chmod +x gradlew
 
+  # the following explicit npm upgrade can be removed when Travis has a fresh npm by default:
+  # https://github.com/SpineEventEngine/config/issues/53
   - npm install -g npm@latest
 
   # Decrypt and unarchive Maven and Google Cloud Storage credentials.

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ env:
 before_install:
   - chmod +x gradlew
 
-  # the following explicit npm upgrade can be removed when Travis has a fresh npm by default:
-  # https://github.com/SpineEventEngine/config/issues/53
+  # Upgrade the `npm` version shipped with Travis to the latest.
   - npm install -g npm@latest
 
   # Decrypt and unarchive Maven and Google Cloud Storage credentials.

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
 before_install:
   - chmod +x gradlew
 
-  - npm install -g npm@~6.1.0
+  - npm install -g npm@latest
 
   # Decrypt and unarchive Maven and Google Cloud Storage credentials.
   - openssl aes-256-cbc -K $encrypted_f5821d4f7269_key -iv $encrypted_f5821d4f7269_iv -in credentials.tar.enc -out credentials.tar -d

--- a/client-js/README.md
+++ b/client-js/README.md
@@ -11,6 +11,12 @@ The NPM artifact:
 * Provides sources transpiled into ES5 along with theirs source maps.
 * Does **not** provide a bundled version assuming that library users perform bundling themselves.
 
+## Environment installation
+
+First, make sure that Node.js is installed and the npm version is `v.6.1.0` or higher. See the
+[Downloading and installing Node.js and npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
+section for the respective installation instructions.
+
 ## Usage
 
 To use the library execute the command:
@@ -50,3 +56,8 @@ To publish a new version to NPM:
  ```bash
     ./gradlew publishJs
  ``` 
+
+## Requirements
+To 
+
+

--- a/client-js/README.md
+++ b/client-js/README.md
@@ -56,8 +56,3 @@ To publish a new version to NPM:
  ```bash
     ./gradlew publishJs
  ``` 
-
-## Requirements
-To 
-
-

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -33,22 +33,22 @@
     "uuid": "^3.2.1"
   },
   "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "babel-core": "^6.26.0",
     "babel-loader": "^7.1.5",
+    "babel-plugin-module-resolver": "^3.1.1",
+    "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "babel-register": "^6.26.0",
-    "babel-core": "^6.26.0",
-    "babel-cli": "^6.26.0",
-    "babel-plugin-transform-builtin-extend": "^1.1.2",
-    "babel-plugin-module-resolver": "^3.1.1",
     "codecov": "^3.0.0",
     "mocha": "^5.2.0",
+    "nyc": "^13.3.0",
+    "rxjs": "^6.3.3",
     "sinon": "^7.0.0",
-    "nyc": "^13.0.1",
     "webpack": "^4.23.1",
     "webpack-cli": "^3.1.2",
-    "webpack-merge": "^4.1.4",
-    "rxjs": "^6.3.3"
+    "webpack-merge": "^4.1.4"
   },
   "sideEffects": false,
   "main": "index.js"

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spine-web",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "license": "Apache-2.0",
   "description": "A JS client for interacting with Spine applications.",
   "homepage": "https://spine.io",

--- a/scripts/js.gradle
+++ b/scripts/js.gradle
@@ -192,5 +192,5 @@ protoJs {
 
     generateParsersTask().dependsOn compileProtoToJs
     buildJs.dependsOn generateParsersTask()
-    testJs.dependsOn generateParsersTask()
+    testJs.dependsOn buildJs
 }

--- a/scripts/js.gradle
+++ b/scripts/js.gradle
@@ -75,6 +75,19 @@ buildJs {
 }
 
 /**
+ * Customize already defined task to run the JavaScript tests.
+ *
+ * <p>The tests connect to the `spine-dev` GAE application and perform networking. Avoid running
+ * the JS tests when not necessary.
+ */
+testJs {
+
+    doLast {
+        npm 'run', 'test'
+    }
+}
+
+/**
  * Copies bundled JS sources to the temporary NPM publication directory.
  */
 task copyBundledJs(type: Copy) {
@@ -119,23 +132,6 @@ prepareJsPublication {
     //TODO:2019-02-05:dmytro.grankin: temporarily don't publish a bundle, see https://github.com/SpineEventEngine/web/issues/61
     //dependsOn copyBundledJs
     dependsOn transpileSources
-}
-
-/**
- * Runs the JavaScript tests.
- *
- * <p>The tests connect to the `spine-dev` GAE application and perform networking. Avoid running
- * the JS tests when not necessary.
- */
-task testLibraryJs {
-    group = JAVA_SCRIPT_TASK_GROUP
-    description = 'Runs the JS tests.'
-
-    doLast {
-        npm 'run', 'test'
-    }
-
-    dependsOn buildJs
 }
 
 /**
@@ -195,4 +191,5 @@ protoJs {
 
     generateParsersTask().dependsOn compileProtoToJs
     buildJs.dependsOn generateParsersTask()
+    testJs.dependsOn generateParsersTask()
 }

--- a/scripts/js.gradle
+++ b/scripts/js.gradle
@@ -62,7 +62,7 @@ task deleteCompiled {
 }
 
 /**
- * Customize already defined task to run Webpack build.
+ * Customizes the task already defined in `config` module by running Webpack build.
  */
 buildJs {
 
@@ -75,7 +75,8 @@ buildJs {
 }
 
 /**
- * Customize already defined task to run the JavaScript tests.
+ * Customizes the task already defined in `config` module by running
+ * the JavaScript tests.
  *
  * <p>The tests connect to the `spine-dev` GAE application and perform networking. Avoid running
  * the JS tests when not necessary.

--- a/version.gradle
+++ b/version.gradle
@@ -25,7 +25,7 @@ ext {
     spineBaseVersion = SPINE_VERSION
     
     versionToPublish = SPINE_VERSION
-    versionToPublishJs = '0.15.1'
+    versionToPublishJs = '0.15.2'
 
     servletApiVersion = '4.0.0'
 }


### PR DESCRIPTION
This PR addresses https://github.com/SpineEventEngine/web/issues/75. The `testLibraryJs` task was removed in order to use `testJs` task defined in the `config` module.