### PR TITLE
Enable license report

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,7 @@ subprojects {
     apply from: deps.scripts.javadocOptions
     apply from: deps.scripts.javacArgs
     apply from: deps.scripts.pmd
+    apply from: deps.scripts.projectLicenseReport
 
     sourceCompatibility = 1.8
     targetCompatibility = 1.8
@@ -197,3 +198,4 @@ subprojects {
 
 apply from: deps.scripts.jacoco
 apply from: deps.scripts.publish
+apply from: deps.scripts.repoLicenseReport

--- a/client-js/license-report/generate-license-report-md.js
+++ b/client-js/license-report/generate-license-report-md.js
@@ -53,7 +53,9 @@ const folder = './build/reports/dependency-license/dependency/';
 const libraryName = process.env.npm_package_name;
 const libraryVersion = process.env.npm_package_version;
 
-const stream = fs.createWriteStream(folder + "license-report.md", {'flags': 'a'});
+// Open the file for appending.
+const appending = {'flags': 'a'};
+const stream = fs.createWriteStream(folder + "license-report.md", appending);
 stream.once('open', function (fd) {
 
     checker.init({

--- a/client-js/license-report/generate-license-report-md.js
+++ b/client-js/license-report/generate-license-report-md.js
@@ -56,7 +56,7 @@ const libraryVersion = process.env.npm_package_version;
 // Open the file for appending.
 const appending = {'flags': 'a'};
 const stream = fs.createWriteStream(folder + "license-report.md", appending);
-stream.once('open', function (fd) {
+stream.once('open', function () {
 
     checker.init({
         start: './',

--- a/client-js/license-report/generate-license-report-md.js
+++ b/client-js/license-report/generate-license-report-md.js
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * A Node program printing all the NPM dependencies of the project to a file in Markdown.
+ *
+ * The resulting file is located in
+ * `<module-root>/build/reports/dependency-license/dependency/license-report.md`.
+ * The file is appended. So in case Java dependencies were written to the same file,
+ * they aren't overwritten.
+ *
+ * See `https://github.com/davglass/license-checker`.
+ */
+
+const fs = require('fs');
+const checker = require('license-checker');
+
+/**
+ * Prints the dependencies to the given `stream` in Markdown format.
+ *
+ * @param report a license report in JSON format
+ * @param stream destination
+ */
+function printDependencies(report, stream) {
+    for (let key in report) {
+        const item = report[key];
+        stream.write("1. **" + key + "**\n");
+        stream.write("   * Licenses: " + item.licenses + "\n");
+        stream.write("   * Repository: " + (item.repository ? item.repository : "unknown") + "\n");
+    }
+}
+
+
+// A folder in which the resulting file is written.
+const folder = './build/reports/dependency-license/dependency/';
+const libraryName = process.env.npm_package_name;
+const libraryVersion = process.env.npm_package_version;
+
+const stream = fs.createWriteStream(folder + "license-report.md", {'flags': 'a'});
+stream.once('open', function (fd) {
+
+    checker.init({
+        start: './',
+        production: true
+    }, function (err, packages) {
+        if (err) {
+            console.log("Error searching for production dependencies: " + err);
+        } else {
+            stream.write("\n\n\n#NPM dependencies of `" + libraryName + "@" + libraryVersion +"`");
+            stream.write("\n\n## `Production` dependencies:\n\n");
+            printDependencies(packages, stream);
+
+            checker.init({
+                start: './',
+                development: true
+            }, function (err, packages) {
+                if (err) {
+                    console.log("Error searching for development dependencies: " + err);
+                } else {
+                    stream.write("\n\n\n## NPM `Development` dependencies:\n\n");
+                    printDependencies(packages, stream);
+
+                    const now = new Date();
+                    stream.write("\n\nThis report was generated on **" + now + "** using " +
+                        "[NPM License Checker](https://github.com/davglass/license-checker) library.");
+
+                    stream.end();
+                }
+            });
+        }
+    });
+});

--- a/client-js/license-report/generate-license-report-md.js
+++ b/client-js/license-report/generate-license-report-md.js
@@ -65,7 +65,7 @@ stream.once('open', function () {
         if (err) {
             console.log("Error searching for production dependencies: " + err);
         } else {
-            stream.write("\n\n\n#NPM dependencies of `" + libraryName + "@" + libraryVersion +"`");
+            stream.write("\n\n\n#NPM dependencies of `" + libraryName + "@" + libraryVersion + "`");
             stream.write("\n\n## `Production` dependencies:\n\n");
             printDependencies(packages, stream);
 
@@ -81,7 +81,8 @@ stream.once('open', function () {
 
                     const now = new Date();
                     stream.write("\n\nThis report was generated on **" + now + "** using " +
-                        "[NPM License Checker](https://github.com/davglass/license-checker) library.");
+                        "[NPM License Checker](https://github.com/davglass/license-checker) " +
+                        "library.");
 
                     stream.end();
                 }

--- a/client-js/license-report/generate-license-report-md.js
+++ b/client-js/license-report/generate-license-report-md.js
@@ -76,7 +76,7 @@ stream.once('open', function (fd) {
                 if (err) {
                     console.log("Error searching for development dependencies: " + err);
                 } else {
-                    stream.write("\n\n\n## NPM `Development` dependencies:\n\n");
+                    stream.write("\n\n\n## `Development` dependencies:\n\n");
                     printDependencies(packages, stream);
 
                     const now = new Date();

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spine-web",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "license": "Apache-2.0",
   "description": "A JS client for interacting with Spine applications.",
   "homepage": "https://spine.io",
@@ -20,7 +20,8 @@
     "build-dev": "webpack --config webpack-dev.config.js",
     "transpile-before-publish": "babel main --out-dir build/npm-publication --source-maps",
     "coverage": "nyc --reporter=text-lcov npm run test >| build/coverage.lcov",
-    "test": "mocha --require babel-polyfill --require babel-register --recursive --exit --full-trace ./test"
+    "test": "mocha --require babel-polyfill --require babel-register --recursive --exit --full-trace ./test",
+    "license-report": "node ./license-report/generate-license-report-md.js"
   },
   "peerDependencies": {
     "rxjs": "6.3.x"
@@ -42,8 +43,9 @@
     "babel-preset-env": "^1.6.1",
     "babel-register": "^6.26.0",
     "codecov": "^3.0.0",
+    "license-checker": "^25.0.1",
     "mocha": "^5.2.0",
-    "nyc": "^13.3.0",
+    "nyc": "^14.0.0",
     "rxjs": "^6.3.3",
     "sinon": "^7.0.0",
     "webpack": "^4.23.1",

--- a/license-report.md
+++ b/license-report.md
@@ -644,10 +644,10 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Apr 16 20:21:29 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Apr 17 16:21:34 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
-#NPM dependencies of `spine-web@0.15.2`
+#NPM dependencies of `spine-web@0.15.3`
 
 ## `Production` dependencies:
 
@@ -963,7 +963,7 @@ This report was generated on **Tue Apr 16 20:21:29 EEST 2019** using [Gradle-Lic
 1. **signal-exit@3.0.1**
    * Licenses: ISC
    * Repository: https://github.com/tapjs/signal-exit
-1. **spine-web@0.15.2**
+1. **spine-web@0.15.3**
    * Licenses: Apache-2.0
    * Repository: https://github.com/SpineEventEngine/web
 1. **string-width@1.0.2**
@@ -1029,7 +1029,7 @@ This report was generated on **Tue Apr 16 20:21:29 EEST 2019** using [Gradle-Lic
 
 
 
-## NPM `Development` dependencies:
+## `Development` dependencies:
 
 1. **@babel/code-frame@7.0.0**
    * Licenses: MIT
@@ -2822,7 +2822,7 @@ This report was generated on **Tue Apr 16 20:21:29 EEST 2019** using [Gradle-Lic
 1. **spdx-satisfies@4.0.1**
    * Licenses: MIT
    * Repository: https://github.com/kemitchell/spdx-satisfies.js
-1. **spine-web@0.15.2**
+1. **spine-web@0.15.3**
    * Licenses: Apache-2.0
    * Repository: https://github.com/SpineEventEngine/web
 1. **split-string@3.1.0**
@@ -3085,7 +3085,7 @@ This report was generated on **Tue Apr 16 20:21:29 EEST 2019** using [Gradle-Lic
    * Repository: https://github.com/yargs/yargs
 
 
-This report was generated on **Tue Apr 16 2019 20:21:33 GMT+0300 (Eastern European Summer Time)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
+This report was generated on **Wed Apr 17 2019 16:21:40 GMT+0300 (Eastern European Summer Time)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
 
 
 

--- a/license-report.md
+++ b/license-report.md
@@ -1,0 +1,5796 @@
+
+    
+# Dependencies of `io.spine:spine-client-js:1.0.0-SNAPSHOT`
+
+## Runtime
+1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.errorprone **Name:** error_prone_annotations **Version:** 2.3.2
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.guava **Name:** failureaccess **Version:** 1.0.1
+     * **Manifest Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.guava **Name:** guava **Version:** 27.1-jre
+     * **Manifest Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.guava **Name:** listenablefuture **Version:** 9999.0-empty-to-avoid-conflict-with-guava
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.j2objc **Name:** j2objc-annotations **Version:** 1.1
+     * **POM Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.7.0
+     * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
+     * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
+
+1. **Group:** org.codehaus.mojo **Name:** animal-sniffer-annotations **Version:** 1.17
+     * **POM License: MIT license** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.slf4j **Name:** slf4j-api **Version:** 1.7.26
+     * **POM Project URL:** [http://www.slf4j.org](http://www.slf4j.org)
+     * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
+
+## Compile, tests and tooling
+1. **Group:** com.beust **Name:** jcommander **Version:** 1.72
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM Project URL:** [http://jcommander.org](http://jcommander.org)
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** com.fasterxml.jackson.core **Name:** jackson-annotations **Version:** 2.9.0
+     * **Project URL:** [http://github.com/FasterXML/jackson](http://github.com/FasterXML/jackson)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.fasterxml.jackson.core **Name:** jackson-core **Version:** 2.9.6
+     * **Project URL:** [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.fasterxml.jackson.core **Name:** jackson-databind **Version:** 2.9.6
+     * **Project URL:** [http://github.com/FasterXML/jackson](http://github.com/FasterXML/jackson)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.github.kevinstern **Name:** software-and-algorithms **Version:** 1.0
+     * **POM Project URL:** [https://www.github.com/KevinStern/software-and-algorithms](https://www.github.com/KevinStern/software-and-algorithms)
+     * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
+
+1. **Group:** com.github.stephenc.jcip **Name:** jcip-annotations **Version:** 1.0-1
+     * **POM Project URL:** [http://stephenc.github.com/jcip-annotations](http://stephenc.github.com/jcip-annotations)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.api **Name:** api-common **Version:** 1.7.0
+     * **POM Project URL:** [https://github.com/googleapis](https://github.com/googleapis)
+     * **POM License: BSD** - [https://github.com/googleapis/api-common-java/blob/master/LICENSE](https://github.com/googleapis/api-common-java/blob/master/LICENSE)
+
+1. **Group:** com.google.api **Name:** gax **Version:** 1.30.0
+     * **POM Project URL:** [https://github.com/googleapis](https://github.com/googleapis)
+     * **POM License: BSD** - [https://github.com/googleapis/gax-java/blob/master/LICENSE](https://github.com/googleapis/gax-java/blob/master/LICENSE)
+
+1. **Group:** com.google.api **Name:** gax-grpc **Version:** 1.30.0
+     * **POM Project URL:** [https://github.com/googleapis](https://github.com/googleapis)
+     * **POM License: BSD** - [https://github.com/googleapis/gax-java/blob/master/LICENSE](https://github.com/googleapis/gax-java/blob/master/LICENSE)
+
+1. **Group:** com.google.api **Name:** gax-httpjson **Version:** 0.47.0
+     * **POM Project URL:** [https://github.com/googleapis](https://github.com/googleapis)
+     * **POM License: BSD** - [https://github.com/googleapis/gax-java/blob/master/LICENSE](https://github.com/googleapis/gax-java/blob/master/LICENSE)
+
+1. **Group:** com.google.api-client **Name:** google-api-client **Version:** 1.25.0
+     * **Manifest Project URL:** [https://developers.google.com/api-client-library/java/](https://developers.google.com/api-client-library/java/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.api-client **Name:** google-api-client-gson **Version:** 1.25.0
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.api.grpc **Name:** proto-google-cloud-firestore-v1beta1 **Version:** 0.26.0
+     * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.api.grpc **Name:** proto-google-common-protos **Version:** 1.0.0
+     * **POM Project URL:** [https://github.com/googleapis/googleapis](https://github.com/googleapis/googleapis)
+     * **POM License: Apache-2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.api.grpc **Name:** proto-google-iam-v1 **Version:** 0.1.28
+     * **POM Project URL:** [https://github.com/googleapis/googleapis](https://github.com/googleapis/googleapis)
+     * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.apis **Name:** google-api-services-storage **Version:** v1-rev135-1.24.1
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.appengine **Name:** appengine-api-1.0-sdk **Version:** 1.9.70
+     * **POM License: Google App Engine Terms of Service** - [http://code.google.com/appengine/terms.html](http://code.google.com/appengine/terms.html)
+
+1. **Group:** com.google.auth **Name:** google-auth-library-credentials **Version:** 0.11.0
+     * **POM License: BSD New license** - [http://opensource.org/licenses/BSD-3-Clause](http://opensource.org/licenses/BSD-3-Clause)
+
+1. **Group:** com.google.auth **Name:** google-auth-library-oauth2-http **Version:** 0.11.0
+     * **POM License: BSD New license** - [http://opensource.org/licenses/BSD-3-Clause](http://opensource.org/licenses/BSD-3-Clause)
+
+1. **Group:** com.google.auto **Name:** auto-common **Version:** 0.10
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.auto.value **Name:** auto-value **Version:** 1.4
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.auto.value **Name:** auto-value-annotations **Version:** 1.6.3
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.cloud **Name:** google-cloud-core **Version:** 1.43.0
+     * **POM Project URL:** [https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core](https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core)
+     * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.cloud **Name:** google-cloud-core-grpc **Version:** 1.43.0
+     * **POM Project URL:** [https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core-grpc](https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core-grpc)
+     * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.cloud **Name:** google-cloud-core-http **Version:** 1.43.0
+     * **POM Project URL:** [https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core-http](https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core-http)
+     * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.cloud **Name:** google-cloud-firestore **Version:** 0.61.0-beta
+     * **POM Project URL:** [https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-firestore
+  ](https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-firestore
+  )
+     * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.cloud **Name:** google-cloud-storage **Version:** 1.43.0
+     * **POM Project URL:** [https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-storage](https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-storage)
+     * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.code.findbugs **Name:** jFormatString **Version:** 3.0.0
+     * **POM Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
+     * **POM License: GNU Lesser Public License** - [http://www.gnu.org/licenses/lgpl.html](http://www.gnu.org/licenses/lgpl.html)
+
+1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.0
+     * **POM Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.code.gson **Name:** gson **Version:** 2.7
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.code.gson **Name:** gson **Version:** 2.8.5
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.errorprone **Name:** error_prone_annotation **Version:** 2.3.2
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.errorprone **Name:** error_prone_annotations **Version:** 2.3.2
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.errorprone **Name:** error_prone_check_api **Version:** 2.3.2
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.errorprone **Name:** error_prone_core **Version:** 2.3.2
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.errorprone **Name:** error_prone_type_annotations **Version:** 2.3.2
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.errorprone **Name:** javac **Version:** 9+181-r4173-1
+     * **POM Project URL:** [https://github.com/google/error-prone-javac](https://github.com/google/error-prone-javac)
+     * **POM License: GNU General Public License, version 2, with the Classpath Exception** - [http://openjdk.java.net/legal/gplv2+ce.html](http://openjdk.java.net/legal/gplv2+ce.html)
+
+1. **Group:** com.google.firebase **Name:** firebase-admin **Version:** 6.7.0
+     * **POM Project URL:** [https://firebase.google.com/](https://firebase.google.com/)
+     * **POM License: Apache License, Version 2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.guava **Name:** failureaccess **Version:** 1.0.1
+     * **Manifest Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.guava **Name:** guava **Version:** 23.5-jre
+     * **Manifest Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.guava **Name:** guava **Version:** 27.1-jre
+     * **Manifest Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.guava **Name:** guava-testlib **Version:** 27.1-jre
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.guava **Name:** listenablefuture **Version:** 9999.0-empty-to-avoid-conflict-with-guava
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.http-client **Name:** google-http-client **Version:** 1.28.0
+     * **Manifest Project URL:** [http://www.google.com/](http://www.google.com/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.http-client **Name:** google-http-client-apache **Version:** 1.28.0
+     * **Manifest Project URL:** [http://www.google.com/](http://www.google.com/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.http-client **Name:** google-http-client-appengine **Version:** 1.24.1
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.http-client **Name:** google-http-client-gson **Version:** 1.25.0
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.http-client **Name:** google-http-client-jackson **Version:** 1.24.1
+     * **Manifest Project URL:** [http://www.google.com/](http://www.google.com/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.http-client **Name:** google-http-client-jackson2 **Version:** 1.25.0
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.j2objc **Name:** j2objc-annotations **Version:** 1.1
+     * **POM Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.oauth-client **Name:** google-oauth-client **Version:** 1.25.0
+     * **Manifest Project URL:** [http://www.google.com/](http://www.google.com/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.4.0
+     * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.6.1
+     * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.6.1
+     * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.protobuf **Name:** protoc **Version:** 3.6.1
+     * **POM Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.truth **Name:** truth **Version:** 0.43
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.truth.extensions **Name:** truth-java8-extension **Version:** 0.43
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.truth.extensions **Name:** truth-liteproto-extension **Version:** 0.43
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.truth.extensions **Name:** truth-proto-extension **Version:** 0.43
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.googlecode.java-diff-utils **Name:** diffutils **Version:** 1.3.0
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM Project URL:** [http://code.google.com/p/java-diff-utils/](http://code.google.com/p/java-diff-utils/)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.squareup **Name:** javapoet **Version:** 1.9.0
+     * **POM Project URL:** [http://github.com/square/javapoet/](http://github.com/square/javapoet/)
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.squareup.okhttp **Name:** okhttp **Version:** 2.5.0
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.squareup.okio **Name:** okio **Version:** 1.13.0
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-beanutils **Name:** commons-beanutils **Version:** 1.9.2
+     * **Project URL:** [http://commons.apache.org/proper/commons-beanutils/](http://commons.apache.org/proper/commons-beanutils/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-codec **Name:** commons-codec **Version:** 1.6
+     * **Project URL:** [http://commons.apache.org/codec/](http://commons.apache.org/codec/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-collections **Name:** commons-collections **Version:** 3.2.2
+     * **Project URL:** [http://commons.apache.org/collections/](http://commons.apache.org/collections/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-digester **Name:** commons-digester **Version:** 1.8.1
+     * **Project URL:** [http://commons.apache.org/digester/](http://commons.apache.org/digester/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-io **Name:** commons-io **Version:** 2.6
+     * **Project URL:** [http://commons.apache.org/proper/commons-io/](http://commons.apache.org/proper/commons-io/)
+     * **Manifest license URL:** [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: Apache License, Version 2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-logging **Name:** commons-logging **Version:** 1.2
+     * **Project URL:** [http://commons.apache.org/proper/commons-logging/](http://commons.apache.org/proper/commons-logging/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-validator **Name:** commons-validator **Version:** 1.6
+     * **Project URL:** [http://commons.apache.org/proper/commons-validator/](http://commons.apache.org/proper/commons-validator/)
+     * **Manifest license URL:** [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: Apache License, Version 2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** io.grpc **Name:** grpc-auth **Version:** 1.13.1
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-core **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-netty **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-netty-shaded **Version:** 1.13.1
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-okhttp **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-protobuf **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-protobuf-lite **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-stub **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.netty **Name:** netty-buffer **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-codec **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-codec-http **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-codec-http2 **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-codec-socks **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-common **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-handler **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-handler-proxy **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-resolver **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-transport **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.opencensus **Name:** opencensus-api **Version:** 0.18.0
+     * **POM Project URL:** [https://github.com/census-instrumentation/opencensus-java](https://github.com/census-instrumentation/opencensus-java)
+     * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** io.opencensus **Name:** opencensus-contrib-grpc-metrics **Version:** 0.18.0
+     * **POM Project URL:** [https://github.com/census-instrumentation/opencensus-java](https://github.com/census-instrumentation/opencensus-java)
+     * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** io.opencensus **Name:** opencensus-contrib-grpc-util **Version:** 0.15.0
+     * **POM Project URL:** [https://github.com/census-instrumentation/opencensus-java](https://github.com/census-instrumentation/opencensus-java)
+     * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** io.opencensus **Name:** opencensus-contrib-http-util **Version:** 0.18.0
+     * **POM Project URL:** [https://github.com/census-instrumentation/opencensus-java](https://github.com/census-instrumentation/opencensus-java)
+     * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** javax.servlet **Name:** javax.servlet-api **Version:** 4.0.0
+     * **Manifest Project URL:** [https://javaee.github.io](https://javaee.github.io)
+     * **Manifest license URL:** [https://oss.oracle.com/licenses/CDDL+GPL-1.1](https://oss.oracle.com/licenses/CDDL+GPL-1.1)
+     * **POM Project URL:** [https://javaee.github.io/servlet-spec/](https://javaee.github.io/servlet-spec/)
+     * **POM License: CDDL + GPLv2 with classpath exception** - [https://oss.oracle.com/licenses/CDDL+GPL-1.1](https://oss.oracle.com/licenses/CDDL+GPL-1.1)
+
+1. **Group:** joda-time **Name:** joda-time **Version:** 2.9.2
+     * **Project URL:** [http://www.joda.org/joda-time/](http://www.joda.org/joda-time/)
+     * **Manifest License:** Apache 2.0 (Not packaged)
+     * **POM License: Apache 2** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** junit **Name:** junit **Version:** 4.12
+     * **POM Project URL:** [http://junit.org](http://junit.org)
+     * **POM License: Eclipse Public License 1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+
+1. **Group:** net.bytebuddy **Name:** byte-buddy **Version:** 1.7.9
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** net.bytebuddy **Name:** byte-buddy-agent **Version:** 1.7.9
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** net.java.dev.javacc **Name:** javacc **Version:** 5.0
+     * **POM Project URL:** [https://javacc.dev.java.net/](https://javacc.dev.java.net/)
+     * **POM License: Berkeley Software Distribution (BSD) License** - [http://www.opensource.org/licenses/bsd-license.html](http://www.opensource.org/licenses/bsd-license.html)
+
+1. **Group:** net.sourceforge.pmd **Name:** pmd-core **Version:** 6.11.0
+     * **POM License: BSD-style** - [http://pmd.sourceforge.net/license.html](http://pmd.sourceforge.net/license.html)
+
+1. **Group:** net.sourceforge.pmd **Name:** pmd-java **Version:** 6.11.0
+     * **POM License: BSD-style** - [http://pmd.sourceforge.net/license.html](http://pmd.sourceforge.net/license.html)
+
+1. **Group:** net.sourceforge.saxon **Name:** saxon **Version:** 9.1.0.8
+     * **POM Project URL:** [http://saxon.sourceforge.net/](http://saxon.sourceforge.net/)
+     * **POM License: Mozilla Public License Version 1.0** - [http://www.mozilla.org/MPL/MPL-1.0.txt](http://www.mozilla.org/MPL/MPL-1.0.txt)
+
+1. **Group:** org.antlr **Name:** antlr4-runtime **Version:** 4.7
+     * **Manifest Project URL:** [http://www.antlr.org](http://www.antlr.org)
+     * **Manifest license URL:** [http://www.antlr.org/license.html](http://www.antlr.org/license.html)
+     * **POM License: The BSD License** - [http://www.antlr.org/license.html](http://www.antlr.org/license.html)
+
+1. **Group:** org.apache.commons **Name:** commons-lang3 **Version:** 3.8.1
+     * **Project URL:** [http://commons.apache.org/proper/commons-lang/](http://commons.apache.org/proper/commons-lang/)
+     * **Manifest license URL:** [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: Apache License, Version 2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.apache.httpcomponents **Name:** httpclient **Version:** 4.2.6
+     * **POM Project URL:** [http://hc.apache.org/httpcomponents-client](http://hc.apache.org/httpcomponents-client)
+     * **POM License: Apache License** **License:** LICENSE.txt
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.apache.httpcomponents **Name:** httpcore **Version:** 4.2.5
+     * **POM Project URL:** [http://hc.apache.org/httpcomponents-core-ga](http://hc.apache.org/httpcomponents-core-ga)
+     * **POM License: Apache License** **License:** LICENSE.txt
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.apiguardian **Name:** apiguardian-api **Version:** 1.0.0
+     * **POM Project URL:** [https://github.com/apiguardian-team/apiguardian](https://github.com/apiguardian-team/apiguardian)
+     * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.checkerframework **Name:** checker-compat-qual **Version:** 2.5.2
+     * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
+     * **POM License: GNU General Public License, version 2 (GPL2), with the classpath exception** - [http://www.gnu.org/software/classpath/license.html](http://www.gnu.org/software/classpath/license.html)
+     * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
+
+1. **Group:** org.checkerframework **Name:** checker-compat-qual **Version:** 2.5.5
+     * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
+     * **POM License: GNU General Public License, version 2 (GPL2), with the classpath exception** - [http://www.gnu.org/software/classpath/license.html](http://www.gnu.org/software/classpath/license.html)
+     * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
+
+1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.5.3
+     * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
+     * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
+
+1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.7.0
+     * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
+     * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
+
+1. **Group:** org.checkerframework **Name:** dataflow **Version:** 2.5.3
+     * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
+     * **POM License: GNU General Public License, version 2 (GPL2), with the classpath exception** - [http://www.gnu.org/software/classpath/license.html](http://www.gnu.org/software/classpath/license.html)
+     * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
+
+1. **Group:** org.checkerframework **Name:** javacutil **Version:** 2.5.3
+     * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
+     * **POM License: GNU General Public License, version 2 (GPL2), with the classpath exception** - [http://www.gnu.org/software/classpath/license.html](http://www.gnu.org/software/classpath/license.html)
+     * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
+
+1. **Group:** org.codehaus.jackson **Name:** jackson-core-asl **Version:** 1.9.11
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM Project URL:** [http://jackson.codehaus.org](http://jackson.codehaus.org)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.codehaus.mojo **Name:** animal-sniffer-annotations **Version:** 1.14
+     * **POM License: MIT license** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
+
+1. **Group:** org.codehaus.mojo **Name:** animal-sniffer-annotations **Version:** 1.17
+     * **POM License: MIT license** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.hamcrest **Name:** hamcrest-all **Version:** 1.3
+     * **POM License: New BSD License** - [http://www.opensource.org/licenses/bsd-license.php](http://www.opensource.org/licenses/bsd-license.php)
+
+1. **Group:** org.hamcrest **Name:** hamcrest-core **Version:** 1.3
+     * **POM License: New BSD License** - [http://www.opensource.org/licenses/bsd-license.php](http://www.opensource.org/licenses/bsd-license.php)
+
+1. **Group:** org.jacoco **Name:** org.jacoco.agent **Version:** 0.8.2
+     * **Manifest license URL:** [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+     * **POM License: Eclipse Public License v1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+
+1. **Group:** org.jacoco **Name:** org.jacoco.ant **Version:** 0.8.2
+     * **Manifest license URL:** [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+     * **POM License: Eclipse Public License v1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+
+1. **Group:** org.jacoco **Name:** org.jacoco.core **Version:** 0.8.2
+     * **Manifest license URL:** [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+     * **POM License: Eclipse Public License v1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+
+1. **Group:** org.jacoco **Name:** org.jacoco.report **Version:** 0.8.2
+     * **Manifest license URL:** [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+     * **POM License: Eclipse Public License v1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+
+1. **Group:** org.json **Name:** json **Version:** 20160810
+     * **Manifest license URL:** [http://json.org/license.html](http://json.org/license.html)
+     * **POM Project URL:** [https://github.com/douglascrockford/JSON-java](https://github.com/douglascrockford/JSON-java)
+     * **POM License: The JSON License** - [http://json.org/license.html](http://json.org/license.html)
+
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.4.0
+     * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
+     * **POM License: Eclipse Public License v2.0** - [http://www.eclipse.org/legal/epl-v20.html](http://www.eclipse.org/legal/epl-v20.html)
+
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-engine **Version:** 5.4.0
+     * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
+     * **POM License: Eclipse Public License v2.0** - [http://www.eclipse.org/legal/epl-v20.html](http://www.eclipse.org/legal/epl-v20.html)
+
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-params **Version:** 5.4.0
+     * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
+     * **POM License: Eclipse Public License v2.0** - [http://www.eclipse.org/legal/epl-v20.html](http://www.eclipse.org/legal/epl-v20.html)
+
+1. **Group:** org.junit.platform **Name:** junit-platform-commons **Version:** 1.4.0
+     * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
+     * **POM License: Eclipse Public License v2.0** - [http://www.eclipse.org/legal/epl-v20.html](http://www.eclipse.org/legal/epl-v20.html)
+
+1. **Group:** org.junit.platform **Name:** junit-platform-engine **Version:** 1.4.0
+     * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
+     * **POM License: Eclipse Public License v2.0** - [http://www.eclipse.org/legal/epl-v20.html](http://www.eclipse.org/legal/epl-v20.html)
+
+1. **Group:** org.mockito **Name:** mockito-core **Version:** 2.12.0
+     * **POM Project URL:** [https://github.com/mockito/mockito](https://github.com/mockito/mockito)
+     * **POM License: The MIT License** - [https://github.com/mockito/mockito/blob/master/LICENSE](https://github.com/mockito/mockito/blob/master/LICENSE)
+
+1. **Group:** org.objenesis **Name:** objenesis **Version:** 2.6
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM Project URL:** [http://objenesis.org](http://objenesis.org)
+     * **POM License: Apache 2** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.opentest4j **Name:** opentest4j **Version:** 1.1.1
+     * **POM Project URL:** [https://github.com/ota4j-team/opentest4j](https://github.com/ota4j-team/opentest4j)
+     * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.ow2.asm **Name:** asm **Version:** 6.2.1
+     * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
+     * **POM Project URL:** [http://asm.ow2.org/](http://asm.ow2.org/)
+     * **POM License: BSD** - [http://asm.ow2.org/license.html](http://asm.ow2.org/license.html)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.ow2.asm **Name:** asm **Version:** 7.0
+     * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
+     * **POM Project URL:** [http://asm.ow2.org/](http://asm.ow2.org/)
+     * **POM License: BSD** - [http://asm.ow2.org/license.html](http://asm.ow2.org/license.html)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.ow2.asm **Name:** asm-analysis **Version:** 6.2.1
+     * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
+     * **POM Project URL:** [http://asm.ow2.org/](http://asm.ow2.org/)
+     * **POM License: BSD** - [http://asm.ow2.org/license.html](http://asm.ow2.org/license.html)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.ow2.asm **Name:** asm-commons **Version:** 6.2.1
+     * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
+     * **POM Project URL:** [http://asm.ow2.org/](http://asm.ow2.org/)
+     * **POM License: BSD** - [http://asm.ow2.org/license.html](http://asm.ow2.org/license.html)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.ow2.asm **Name:** asm-tree **Version:** 6.2.1
+     * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
+     * **POM Project URL:** [http://asm.ow2.org/](http://asm.ow2.org/)
+     * **POM License: BSD** - [http://asm.ow2.org/license.html](http://asm.ow2.org/license.html)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.pcollections **Name:** pcollections **Version:** 2.1.2
+     * **POM Project URL:** [http://pcollections.org](http://pcollections.org)
+     * **POM License: The MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
+
+1. **Group:** org.slf4j **Name:** slf4j-api **Version:** 1.7.26
+     * **POM Project URL:** [http://www.slf4j.org](http://www.slf4j.org)
+     * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
+
+1. **Group:** org.slf4j **Name:** slf4j-jdk14 **Version:** 1.7.26
+     * **POM Project URL:** [http://www.slf4j.org](http://www.slf4j.org)
+     * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
+
+1. **Group:** org.threeten **Name:** threetenbp **Version:** 1.3.3
+     * **Manifest Project URL:** [http://www.threeten.org](http://www.threeten.org)
+     * **Manifest license URL:** [https://raw.githubusercontent.com/ThreeTen/threetenbp/master/LICENSE.txt](https://raw.githubusercontent.com/ThreeTen/threetenbp/master/LICENSE.txt)
+     * **POM Project URL:** [https://www.threeten.org/threetenbp](https://www.threeten.org/threetenbp)
+     * **POM License: BSD 3-clause** - [https://raw.githubusercontent.com/ThreeTen/threetenbp/master/LICENSE.txt](https://raw.githubusercontent.com/ThreeTen/threetenbp/master/LICENSE.txt)
+
+    
+        
+ The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
+
+
+This report was generated on **Tue Apr 16 20:21:29 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+
+
+#NPM dependencies of `spine-web@0.15.2`
+
+## `Production` dependencies:
+
+1. **@firebase/app-types@0.3.3**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk/tree/master/packages/app-types
+1. **@firebase/app@0.3.8**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk/tree/master/packages/app
+1. **@firebase/auth-types@0.5.1**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk/tree/master/packages/auth-types
+1. **@firebase/auth@0.9.2**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk/tree/master/packages/auth
+1. **@firebase/database-types@0.3.4**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk/tree/master/packages/database-types
+1. **@firebase/database@0.3.11**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk/tree/master/packages/database
+1. **@firebase/firestore-types@1.0.1**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk/tree/master/packages/firestore-types
+1. **@firebase/firestore@1.0.1**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk/tree/master/packages/firestore
+1. **@firebase/functions-types@0.2.2**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk/tree/master/packages/functions-types
+1. **@firebase/functions@0.3.6**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk/tree/master/packages/functions
+1. **@firebase/logger@0.1.5**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk/tree/master/packages/logger
+1. **@firebase/messaging-types@0.2.4**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk/tree/master/packages/messaging-types
+1. **@firebase/messaging@0.3.10**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk/tree/master/packages/messaging
+1. **@firebase/polyfill@0.3.5**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk/tree/master/packages/polyfill
+1. **@firebase/storage-types@0.2.4**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk/tree/master/packages/storage-types
+1. **@firebase/storage@0.2.7**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk/tree/master/packages/storage
+1. **@firebase/util@0.2.6**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk/tree/master/packages/util
+1. **@firebase/webchannel-wrapper@0.2.12**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk/tree/master/packages/webchannel-wrapper
+1. **abbrev@1.1.1**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/abbrev-js
+1. **ansi-regex@2.1.1**
+   * Licenses: MIT
+   * Repository: https://github.com/chalk/ansi-regex
+1. **aproba@1.2.0**
+   * Licenses: ISC
+   * Repository: https://github.com/iarna/aproba
+1. **are-we-there-yet@1.1.5**
+   * Licenses: ISC
+   * Repository: https://github.com/iarna/are-we-there-yet
+1. **ascli@1.0.1**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/dcodeIO/ascli
+1. **balanced-match@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/juliangruber/balanced-match
+1. **base64-js@1.3.0**
+   * Licenses: MIT
+   * Repository: https://github.com/beatgammit/base64-js
+1. **brace-expansion@1.1.11**
+   * Licenses: MIT
+   * Repository: https://github.com/juliangruber/brace-expansion
+1. **bytebuffer@5.0.1**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/dcodeIO/bytebuffer.js
+1. **camelcase@2.1.1**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/camelcase
+1. **chownr@1.1.1**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/chownr
+1. **cliui@3.2.0**
+   * Licenses: ISC
+   * Repository: https://github.com/yargs/cliui
+1. **code-point-at@1.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/code-point-at
+1. **colour@0.7.1**
+   * Licenses: MIT
+   * Repository: https://github.com/dcodeIO/colour.js
+1. **concat-map@0.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/substack/node-concat-map
+1. **console-control-strings@1.1.0**
+   * Licenses: ISC
+   * Repository: https://github.com/iarna/console-control-strings
+1. **core-js@2.5.5**
+   * Licenses: MIT
+   * Repository: https://github.com/zloirock/core-js
+1. **core-util-is@1.0.2**
+   * Licenses: MIT
+   * Repository: https://github.com/isaacs/core-util-is
+1. **debug@2.6.9**
+   * Licenses: MIT
+   * Repository: https://github.com/visionmedia/debug
+1. **decamelize@1.2.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/decamelize
+1. **deep-extend@0.6.0**
+   * Licenses: MIT
+   * Repository: https://github.com/unclechu/node-deep-extend
+1. **delegates@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/visionmedia/node-delegates
+1. **detect-libc@1.0.3**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/lovell/detect-libc
+1. **dom-storage@2.1.0**
+   * Licenses: MIT*
+   * Repository: git://git.coolaj86.com/coolaj86/dom-storage.js
+1. **encoding@0.1.12**
+   * Licenses: MIT
+   * Repository: https://github.com/andris9/encoding
+1. **faye-websocket@0.11.1**
+   * Licenses: MIT
+   * Repository: https://github.com/faye/faye-websocket-node
+1. **firebase@5.8.1**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk
+1. **fs-minipass@1.2.5**
+   * Licenses: ISC
+   * Repository: https://github.com/npm/fs-minipass
+1. **fs.realpath@1.0.0**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/fs.realpath
+1. **gauge@2.7.4**
+   * Licenses: ISC
+   * Repository: https://github.com/iarna/gauge
+1. **glob@7.1.3**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/node-glob
+1. **google-protobuf@3.6.1**
+   * Licenses: BSD-3-Clause
+   * Repository: https://github.com/google/protobuf/tree/master/js
+1. **grpc@1.17.0**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/grpc/grpc-node
+1. **has-unicode@2.0.1**
+   * Licenses: ISC
+   * Repository: https://github.com/iarna/has-unicode
+1. **http-parser-js@0.5.0**
+   * Licenses: MIT
+   * Repository: https://github.com/creationix/http-parser-js
+1. **iconv-lite@0.4.24**
+   * Licenses: MIT
+   * Repository: https://github.com/ashtuchkin/iconv-lite
+1. **ignore-walk@3.0.1**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/ignore-walk
+1. **inflight@1.0.6**
+   * Licenses: ISC
+   * Repository: https://github.com/npm/inflight
+1. **inherits@2.0.3**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/inherits
+1. **ini@1.3.5**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/ini
+1. **invert-kv@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/invert-kv
+1. **is-fullwidth-code-point@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/is-fullwidth-code-point
+1. **is-stream@1.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/is-stream
+1. **isarray@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/juliangruber/isarray
+1. **isomorphic-fetch@2.2.1**
+   * Licenses: MIT
+   * Repository: https://github.com/matthew-andrews/isomorphic-fetch
+1. **lcid@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/lcid
+1. **lodash.camelcase@4.3.0**
+   * Licenses: MIT
+   * Repository: https://github.com/lodash/lodash
+1. **lodash.clone@4.5.0**
+   * Licenses: MIT
+   * Repository: https://github.com/lodash/lodash
+1. **long@3.2.0**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/dcodeIO/long.js
+1. **minimatch@3.0.4**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/minimatch
+1. **minimist@0.0.8**
+   * Licenses: MIT
+   * Repository: https://github.com/substack/minimist
+1. **minimist@1.2.0**
+   * Licenses: MIT
+   * Repository: https://github.com/substack/minimist
+1. **minipass@2.3.5**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/minipass
+1. **minizlib@1.2.1**
+   * Licenses: MIT
+   * Repository: https://github.com/isaacs/minizlib
+1. **mkdirp@0.5.1**
+   * Licenses: MIT
+   * Repository: https://github.com/substack/node-mkdirp
+1. **ms@2.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/zeit/ms
+1. **nan@2.12.1**
+   * Licenses: MIT
+   * Repository: https://github.com/nodejs/nan
+1. **needle@2.2.4**
+   * Licenses: MIT
+   * Repository: https://github.com/tomas/needle
+1. **node-fetch@1.7.3**
+   * Licenses: MIT
+   * Repository: https://github.com/bitinn/node-fetch
+1. **node-pre-gyp@0.12.0**
+   * Licenses: BSD-3-Clause
+   * Repository: https://github.com/mapbox/node-pre-gyp
+1. **nopt@4.0.1**
+   * Licenses: ISC
+   * Repository: https://github.com/npm/nopt
+1. **npm-bundled@1.0.5**
+   * Licenses: ISC
+   * Repository: https://github.com/npm/npm-bundled
+1. **npm-packlist@1.1.12**
+   * Licenses: ISC
+   * Repository: https://github.com/npm/npm-packlist
+1. **npmlog@4.1.2**
+   * Licenses: ISC
+   * Repository: https://github.com/npm/npmlog
+1. **number-is-nan@1.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/number-is-nan
+1. **object-assign@4.1.1**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/object-assign
+1. **once@1.4.0**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/once
+1. **optjs@3.2.2**
+   * Licenses: MIT
+   * Repository: https://github.com/dcodeIO/opt.js
+1. **os-homedir@1.0.2**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/os-homedir
+1. **os-locale@1.4.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/os-locale
+1. **os-tmpdir@1.0.2**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/os-tmpdir
+1. **osenv@0.1.5**
+   * Licenses: ISC
+   * Repository: https://github.com/npm/osenv
+1. **path-is-absolute@1.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/path-is-absolute
+1. **process-nextick-args@2.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/calvinmetcalf/process-nextick-args
+1. **promise-polyfill@7.1.2**
+   * Licenses: MIT
+   * Repository: https://github.com/taylorhakes/promise-polyfill
+1. **protobufjs@5.0.3**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/dcodeIO/protobuf.js
+1. **rc@1.2.8**
+   * Licenses: (BSD-2-Clause OR MIT OR Apache-2.0)
+   * Repository: https://github.com/dominictarr/rc
+1. **readable-stream@2.3.6**
+   * Licenses: MIT
+   * Repository: https://github.com/nodejs/readable-stream
+1. **rimraf@2.6.2**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/rimraf
+1. **rxjs@6.4.0**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/reactivex/rxjs
+1. **safe-buffer@5.1.2**
+   * Licenses: MIT
+   * Repository: https://github.com/feross/safe-buffer
+1. **safer-buffer@2.1.2**
+   * Licenses: MIT
+   * Repository: https://github.com/ChALkeR/safer-buffer
+1. **sax@1.2.4**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/sax-js
+1. **semver@5.6.0**
+   * Licenses: ISC
+   * Repository: https://github.com/npm/node-semver
+1. **set-blocking@2.0.0**
+   * Licenses: ISC
+   * Repository: https://github.com/yargs/set-blocking
+1. **signal-exit@3.0.1**
+   * Licenses: ISC
+   * Repository: https://github.com/tapjs/signal-exit
+1. **spine-web@0.15.2**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/SpineEventEngine/web
+1. **string-width@1.0.2**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/string-width
+1. **string_decoder@1.1.1**
+   * Licenses: MIT
+   * Repository: https://github.com/nodejs/string_decoder
+1. **strip-ansi@3.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/chalk/strip-ansi
+1. **strip-json-comments@2.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/strip-json-comments
+1. **tar@4.4.8**
+   * Licenses: ISC
+   * Repository: https://github.com/npm/node-tar
+1. **tslib@1.9.0**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/Microsoft/tslib
+1. **util-deprecate@1.0.2**
+   * Licenses: MIT
+   * Repository: https://github.com/TooTallNate/util-deprecate
+1. **uuid@3.3.2**
+   * Licenses: MIT
+   * Repository: https://github.com/kelektiv/node-uuid
+1. **websocket-driver@0.7.0**
+   * Licenses: MIT
+   * Repository: https://github.com/faye/websocket-driver-node
+1. **websocket-extensions@0.1.3**
+   * Licenses: MIT
+   * Repository: https://github.com/faye/websocket-extensions-node
+1. **whatwg-fetch@2.0.4**
+   * Licenses: MIT
+   * Repository: https://github.com/github/fetch
+1. **whatwg-fetch@3.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/github/fetch
+1. **wide-align@1.1.3**
+   * Licenses: ISC
+   * Repository: https://github.com/iarna/wide-align
+1. **window-size@0.1.4**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/window-size
+1. **wrap-ansi@2.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/chalk/wrap-ansi
+1. **wrappy@1.0.2**
+   * Licenses: ISC
+   * Repository: https://github.com/npm/wrappy
+1. **xmlhttprequest@1.8.0**
+   * Licenses: MIT
+   * Repository: https://github.com/driverdan/node-XMLHttpRequest
+1. **y18n@3.2.1**
+   * Licenses: ISC
+   * Repository: https://github.com/yargs/y18n
+1. **yallist@3.0.3**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/yallist
+1. **yargs@3.32.0**
+   * Licenses: MIT
+   * Repository: https://github.com/bcoe/yargs
+
+
+
+## NPM `Development` dependencies:
+
+1. **@babel/code-frame@7.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-code-frame
+1. **@babel/generator@7.4.0**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-generator
+1. **@babel/helper-function-name@7.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-helper-function-name
+1. **@babel/helper-get-function-arity@7.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-helper-get-function-arity
+1. **@babel/helper-split-export-declaration@7.4.0**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-helper-split-export-declaration
+1. **@babel/highlight@7.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-highlight
+1. **@babel/parser@7.4.3**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-parser
+1. **@babel/template@7.4.0**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-template
+1. **@babel/traverse@7.4.3**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-traverse
+1. **@babel/types@7.4.0**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-types
+1. **@sinonjs/commons@1.3.0**
+   * Licenses: BSD-3-Clause
+   * Repository: https://github.com/sinonjs/commons
+1. **@sinonjs/formatio@3.1.0**
+   * Licenses: BSD-3-Clause
+   * Repository: https://github.com/sinonjs/formatio
+1. **@sinonjs/samsam@3.0.2**
+   * Licenses: BSD-3-Clause
+   * Repository: https://github.com/sinonjs/samsam
+1. **@webassemblyjs/ast@1.7.11**
+   * Licenses: MIT
+   * Repository: https://github.com/xtuc/webassemblyjs
+1. **@webassemblyjs/floating-point-hex-parser@1.7.11**
+   * Licenses: MIT
+   * Repository: https://github.com/xtuc/webassemblyjs
+1. **@webassemblyjs/helper-api-error@1.7.11**
+   * Licenses: MIT
+   * Repository: unknown
+1. **@webassemblyjs/helper-buffer@1.7.11**
+   * Licenses: MIT
+   * Repository: https://github.com/xtuc/webassemblyjs
+1. **@webassemblyjs/helper-code-frame@1.7.11**
+   * Licenses: MIT
+   * Repository: https://github.com/xtuc/webassemblyjs
+1. **@webassemblyjs/helper-fsm@1.7.11**
+   * Licenses: ISC
+   * Repository: unknown
+1. **@webassemblyjs/helper-module-context@1.7.11**
+   * Licenses: MIT
+   * Repository: https://github.com/xtuc/webassemblyjs
+1. **@webassemblyjs/helper-wasm-bytecode@1.7.11**
+   * Licenses: MIT
+   * Repository: https://github.com/xtuc/webassemblyjs
+1. **@webassemblyjs/helper-wasm-section@1.7.11**
+   * Licenses: MIT
+   * Repository: https://github.com/xtuc/webassemblyjs
+1. **@webassemblyjs/ieee754@1.7.11**
+   * Licenses: MIT
+   * Repository: unknown
+1. **@webassemblyjs/leb128@1.7.11**
+   * Licenses: MIT
+   * Repository: unknown
+1. **@webassemblyjs/utf8@1.7.11**
+   * Licenses: MIT
+   * Repository: https://github.com/xtuc/webassemblyjs
+1. **@webassemblyjs/wasm-edit@1.7.11**
+   * Licenses: MIT
+   * Repository: https://github.com/xtuc/webassemblyjs
+1. **@webassemblyjs/wasm-gen@1.7.11**
+   * Licenses: MIT
+   * Repository: https://github.com/xtuc/webassemblyjs
+1. **@webassemblyjs/wasm-opt@1.7.11**
+   * Licenses: MIT
+   * Repository: https://github.com/xtuc/webassemblyjs
+1. **@webassemblyjs/wasm-parser@1.7.11**
+   * Licenses: MIT
+   * Repository: https://github.com/xtuc/webassemblyjs
+1. **@webassemblyjs/wast-parser@1.7.11**
+   * Licenses: MIT
+   * Repository: https://github.com/xtuc/webassemblyjs
+1. **@webassemblyjs/wast-printer@1.7.11**
+   * Licenses: MIT
+   * Repository: https://github.com/xtuc/webassemblyjs
+1. **@xtuc/ieee754@1.2.0**
+   * Licenses: BSD-3-Clause
+   * Repository: https://github.com/feross/ieee754
+1. **@xtuc/long@4.2.1**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/dcodeIO/long.js
+1. **abbrev@1.1.1**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/abbrev-js
+1. **acorn-dynamic-import@4.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/kesne/acorn-dynamic-import
+1. **acorn@6.0.6**
+   * Licenses: MIT
+   * Repository: https://github.com/acornjs/acorn
+1. **ajv-errors@1.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/epoberezkin/ajv-errors
+1. **ajv-keywords@3.3.0**
+   * Licenses: MIT
+   * Repository: https://github.com/epoberezkin/ajv-keywords
+1. **ajv@6.7.0**
+   * Licenses: MIT
+   * Repository: https://github.com/epoberezkin/ajv
+1. **ansi-regex@2.1.1**
+   * Licenses: MIT
+   * Repository: https://github.com/chalk/ansi-regex
+1. **ansi-regex@3.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/chalk/ansi-regex
+1. **ansi-regex@4.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/chalk/ansi-regex
+1. **ansi-styles@2.2.1**
+   * Licenses: MIT
+   * Repository: https://github.com/chalk/ansi-styles
+1. **ansi-styles@3.2.1**
+   * Licenses: MIT
+   * Repository: https://github.com/chalk/ansi-styles
+1. **anymatch@1.3.2**
+   * Licenses: ISC
+   * Repository: https://github.com/es128/anymatch
+1. **anymatch@2.0.0**
+   * Licenses: ISC
+   * Repository: https://github.com/micromatch/anymatch
+1. **append-transform@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/istanbuljs/append-transform
+1. **aproba@1.2.0**
+   * Licenses: ISC
+   * Repository: https://github.com/iarna/aproba
+1. **archy@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/substack/node-archy
+1. **are-we-there-yet@1.1.5**
+   * Licenses: ISC
+   * Repository: https://github.com/iarna/are-we-there-yet
+1. **argparse@1.0.10**
+   * Licenses: MIT
+   * Repository: https://github.com/nodeca/argparse
+1. **argv@0.0.2**
+   * Licenses: MIT*
+   * Repository: unknown
+1. **arr-diff@2.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/arr-diff
+1. **arr-diff@4.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/arr-diff
+1. **arr-flatten@1.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/arr-flatten
+1. **arr-union@3.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/arr-union
+1. **array-find-index@1.0.2**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/array-find-index
+1. **array-from@2.1.1**
+   * Licenses: MIT
+   * Repository: https://github.com/studio-b12/array-from
+1. **array-unique@0.2.1**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/array-unique
+1. **array-unique@0.3.2**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/array-unique
+1. **asap@2.0.6**
+   * Licenses: MIT
+   * Repository: https://github.com/kriskowal/asap
+1. **asn1.js@4.10.1**
+   * Licenses: MIT
+   * Repository: https://github.com/indutny/asn1.js
+1. **asn1@0.2.4**
+   * Licenses: MIT
+   * Repository: https://github.com/joyent/node-asn1
+1. **assert-plus@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/mcavage/node-assert-plus
+1. **assert@1.4.1**
+   * Licenses: MIT
+   * Repository: https://github.com/defunctzombie/commonjs-assert
+1. **assign-symbols@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/assign-symbols
+1. **async-each@1.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/paulmillr/async-each
+1. **asynckit@0.4.0**
+   * Licenses: MIT
+   * Repository: https://github.com/alexindigo/asynckit
+1. **atob@2.1.2**
+   * Licenses: (MIT OR Apache-2.0)
+   * Repository: git://git.coolaj86.com/coolaj86/atob.js
+1. **aws-sign2@0.7.0**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/mikeal/aws-sign
+1. **aws4@1.8.0**
+   * Licenses: MIT
+   * Repository: https://github.com/mhart/aws4
+1. **babel-cli@6.26.0**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-cli
+1. **babel-code-frame@6.26.0**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-code-frame
+1. **babel-core@6.26.3**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-core
+1. **babel-generator@6.26.1**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-generator
+1. **babel-helper-builder-binary-assignment-operator-visitor@6.24.1**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-helper-builder-binary-assignment-operator-visitor
+1. **babel-helper-call-delegate@6.24.1**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-helper-call-delegate
+1. **babel-helper-define-map@6.26.0**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-helper-define-map
+1. **babel-helper-explode-assignable-expression@6.24.1**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-helper-explode-assignable-expression
+1. **babel-helper-function-name@6.24.1**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-helper-function-name
+1. **babel-helper-get-function-arity@6.24.1**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-helper-get-function-arity
+1. **babel-helper-hoist-variables@6.24.1**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-helper-hoist-variables
+1. **babel-helper-optimise-call-expression@6.24.1**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-helper-optimise-call-expression
+1. **babel-helper-regex@6.26.0**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-helper-regex
+1. **babel-helper-remap-async-to-generator@6.24.1**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-helper-remap-async-to-generator
+1. **babel-helper-replace-supers@6.24.1**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-helper-replace-supers
+1. **babel-helpers@6.24.1**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-helpers
+1. **babel-loader@7.1.5**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel-loader
+1. **babel-messages@6.23.0**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-messages
+1. **babel-plugin-check-es2015-constants@6.22.0**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-check-es2015-constants
+1. **babel-plugin-module-resolver@3.1.3**
+   * Licenses: MIT
+   * Repository: https://github.com/tleunen/babel-plugin-module-resolver
+1. **babel-plugin-syntax-async-functions@6.13.0**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-async-functions
+1. **babel-plugin-syntax-exponentiation-operator@6.13.0**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-exponentation-operator
+1. **babel-plugin-syntax-trailing-function-commas@6.22.0**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-trailing-function-commas
+1. **babel-plugin-transform-async-to-generator@6.24.1**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-async-to-generator
+1. **babel-plugin-transform-builtin-extend@1.1.2**
+   * Licenses: MIT
+   * Repository: https://github.com/loganfsmyth/babel-plugin-transform-builtin-extend
+1. **babel-plugin-transform-es2015-arrow-functions@6.22.0**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-es2015-arrow-functions
+1. **babel-plugin-transform-es2015-block-scoped-functions@6.22.0**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-es2015-block-scoped-functions
+1. **babel-plugin-transform-es2015-block-scoping@6.26.0**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-es2015-block-scoping
+1. **babel-plugin-transform-es2015-classes@6.24.1**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-es2015-classes
+1. **babel-plugin-transform-es2015-computed-properties@6.24.1**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-es2015-computed-properties
+1. **babel-plugin-transform-es2015-destructuring@6.23.0**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-es2015-destructuring
+1. **babel-plugin-transform-es2015-duplicate-keys@6.24.1**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-es2015-duplicate-keys
+1. **babel-plugin-transform-es2015-for-of@6.23.0**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-es2015-for-of
+1. **babel-plugin-transform-es2015-function-name@6.24.1**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-es2015-function-name
+1. **babel-plugin-transform-es2015-literals@6.22.0**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-es2015-literals
+1. **babel-plugin-transform-es2015-modules-amd@6.24.1**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-es2015-modules-amd
+1. **babel-plugin-transform-es2015-modules-commonjs@6.26.2**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-es2015-modules-commonjs
+1. **babel-plugin-transform-es2015-modules-systemjs@6.24.1**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-es2015-modules-systemjs
+1. **babel-plugin-transform-es2015-modules-umd@6.24.1**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-es2015-modules-umd
+1. **babel-plugin-transform-es2015-object-super@6.24.1**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-es2015-object-super
+1. **babel-plugin-transform-es2015-parameters@6.24.1**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-es2015-parameters
+1. **babel-plugin-transform-es2015-shorthand-properties@6.24.1**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-es2015-shorthand-properties
+1. **babel-plugin-transform-es2015-spread@6.22.0**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-es2015-spread
+1. **babel-plugin-transform-es2015-sticky-regex@6.24.1**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-es2015-sticky-regex
+1. **babel-plugin-transform-es2015-template-literals@6.22.0**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-es2015-template-literals
+1. **babel-plugin-transform-es2015-typeof-symbol@6.23.0**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-es2015-typeof-symbol
+1. **babel-plugin-transform-es2015-unicode-regex@6.24.1**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-es2015-unicode-regex
+1. **babel-plugin-transform-exponentiation-operator@6.24.1**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-exponentiation-operator
+1. **babel-plugin-transform-regenerator@6.26.0**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-regenerator
+1. **babel-plugin-transform-strict-mode@6.24.1**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-strict-mode
+1. **babel-polyfill@6.26.0**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-polyfill
+1. **babel-preset-env@1.7.0**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel-preset-env
+1. **babel-register@6.26.0**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-register
+1. **babel-runtime@6.26.0**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-runtime
+1. **babel-template@6.26.0**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-template
+1. **babel-traverse@6.26.0**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-traverse
+1. **babel-types@6.26.0**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babel/tree/master/packages/babel-types
+1. **babylon@6.18.0**
+   * Licenses: MIT
+   * Repository: https://github.com/babel/babylon
+1. **balanced-match@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/juliangruber/balanced-match
+1. **base@0.11.2**
+   * Licenses: MIT
+   * Repository: https://github.com/node-base/base
+1. **bcrypt-pbkdf@1.0.2**
+   * Licenses: BSD-3-Clause
+   * Repository: https://github.com/joyent/node-bcrypt-pbkdf
+1. **big.js@5.2.2**
+   * Licenses: MIT
+   * Repository: https://github.com/MikeMcl/big.js
+1. **binary-extensions@1.12.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/binary-extensions
+1. **bluebird@3.5.3**
+   * Licenses: MIT
+   * Repository: https://github.com/petkaantonov/bluebird
+1. **bn.js@4.11.8**
+   * Licenses: MIT
+   * Repository: https://github.com/indutny/bn.js
+1. **brace-expansion@1.1.11**
+   * Licenses: MIT
+   * Repository: https://github.com/juliangruber/brace-expansion
+1. **braces@1.8.5**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/braces
+1. **braces@2.3.2**
+   * Licenses: MIT
+   * Repository: https://github.com/micromatch/braces
+1. **brorand@1.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/indutny/brorand
+1. **browser-stdout@1.3.1**
+   * Licenses: ISC
+   * Repository: https://github.com/kumavis/browser-stdout
+1. **browserify-aes@1.2.0**
+   * Licenses: MIT
+   * Repository: https://github.com/crypto-browserify/browserify-aes
+1. **browserify-cipher@1.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/crypto-browserify/browserify-cipher
+1. **browserify-des@1.0.2**
+   * Licenses: MIT
+   * Repository: https://github.com/crypto-browserify/browserify-des
+1. **browserify-rsa@4.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/crypto-browserify/browserify-rsa
+1. **browserify-sign@4.0.4**
+   * Licenses: ISC
+   * Repository: https://github.com/crypto-browserify/browserify-sign
+1. **browserify-zlib@0.2.0**
+   * Licenses: MIT
+   * Repository: https://github.com/devongovett/browserify-zlib
+1. **browserslist@3.2.8**
+   * Licenses: MIT
+   * Repository: https://github.com/browserslist/browserslist
+1. **buffer-from@1.1.1**
+   * Licenses: MIT
+   * Repository: https://github.com/LinusU/buffer-from
+1. **buffer-xor@1.0.3**
+   * Licenses: MIT
+   * Repository: https://github.com/crypto-browserify/buffer-xor
+1. **buffer@4.9.1**
+   * Licenses: MIT
+   * Repository: https://github.com/feross/buffer
+1. **builtin-status-codes@3.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/bendrucker/builtin-status-codes
+1. **cacache@11.3.2**
+   * Licenses: ISC
+   * Repository: https://github.com/zkat/cacache
+1. **cache-base@1.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/cache-base
+1. **caching-transform@3.0.2**
+   * Licenses: MIT
+   * Repository: https://github.com/istanbuljs/caching-transform
+1. **camelcase@5.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/camelcase
+1. **camelcase@5.3.1**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/camelcase
+1. **caniuse-lite@1.0.30000932**
+   * Licenses: CC-BY-4.0
+   * Repository: https://github.com/ben-eb/caniuse-lite
+1. **caseless@0.12.0**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/mikeal/caseless
+1. **chalk@1.1.3**
+   * Licenses: MIT
+   * Repository: https://github.com/chalk/chalk
+1. **chalk@2.4.2**
+   * Licenses: MIT
+   * Repository: https://github.com/chalk/chalk
+1. **chokidar@1.7.0**
+   * Licenses: MIT
+   * Repository: https://github.com/paulmillr/chokidar
+1. **chokidar@2.0.4**
+   * Licenses: MIT
+   * Repository: https://github.com/paulmillr/chokidar
+1. **chownr@1.1.1**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/chownr
+1. **chrome-trace-event@1.0.0**
+   * Licenses: MIT
+   * Repository: github.com:samccone/chrome-trace-event
+1. **cipher-base@1.0.4**
+   * Licenses: MIT
+   * Repository: https://github.com/crypto-browserify/cipher-base
+1. **class-utils@0.3.6**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/class-utils
+1. **cliui@4.1.0**
+   * Licenses: ISC
+   * Repository: https://github.com/yargs/cliui
+1. **code-point-at@1.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/code-point-at
+1. **codecov@3.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/codecov/codecov-node
+1. **collection-visit@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/collection-visit
+1. **color-convert@1.9.3**
+   * Licenses: MIT
+   * Repository: https://github.com/Qix-/color-convert
+1. **color-name@1.1.3**
+   * Licenses: MIT
+   * Repository: https://github.com/dfcreative/color-name
+1. **combined-stream@1.0.7**
+   * Licenses: MIT
+   * Repository: https://github.com/felixge/node-combined-stream
+1. **commander@2.15.1**
+   * Licenses: MIT
+   * Repository: https://github.com/tj/commander.js
+1. **commander@2.17.1**
+   * Licenses: MIT
+   * Repository: https://github.com/tj/commander.js
+1. **commander@2.19.0**
+   * Licenses: MIT
+   * Repository: https://github.com/tj/commander.js
+1. **commander@2.20.0**
+   * Licenses: MIT
+   * Repository: https://github.com/tj/commander.js
+1. **commondir@1.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/substack/node-commondir
+1. **component-emitter@1.2.1**
+   * Licenses: MIT
+   * Repository: https://github.com/component/emitter
+1. **concat-map@0.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/substack/node-concat-map
+1. **concat-stream@1.6.2**
+   * Licenses: MIT
+   * Repository: https://github.com/maxogden/concat-stream
+1. **console-browserify@1.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/Raynos/console-browserify
+1. **console-control-strings@1.1.0**
+   * Licenses: ISC
+   * Repository: https://github.com/iarna/console-control-strings
+1. **constants-browserify@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/juliangruber/constants-browserify
+1. **convert-source-map@1.6.0**
+   * Licenses: MIT
+   * Repository: https://github.com/thlorenz/convert-source-map
+1. **copy-concurrently@1.0.5**
+   * Licenses: ISC
+   * Repository: https://github.com/npm/copy-concurrently
+1. **copy-descriptor@0.1.1**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/copy-descriptor
+1. **core-util-is@1.0.2**
+   * Licenses: MIT
+   * Repository: https://github.com/isaacs/core-util-is
+1. **cp-file@6.2.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/cp-file
+1. **create-ecdh@4.0.3**
+   * Licenses: MIT
+   * Repository: https://github.com/crypto-browserify/createECDH
+1. **create-hash@1.2.0**
+   * Licenses: MIT
+   * Repository: https://github.com/crypto-browserify/createHash
+1. **create-hmac@1.1.7**
+   * Licenses: MIT
+   * Repository: https://github.com/crypto-browserify/createHmac
+1. **cross-spawn@4.0.2**
+   * Licenses: MIT
+   * Repository: https://github.com/IndigoUnited/node-cross-spawn
+1. **cross-spawn@6.0.5**
+   * Licenses: MIT
+   * Repository: https://github.com/moxystudio/node-cross-spawn
+1. **crypto-browserify@3.12.0**
+   * Licenses: MIT
+   * Repository: https://github.com/crypto-browserify/crypto-browserify
+1. **cyclist@0.2.2**
+   * Licenses: MIT*
+   * Repository: https://github.com/mafintosh/cyclist
+1. **dashdash@1.14.1**
+   * Licenses: MIT
+   * Repository: https://github.com/trentm/node-dashdash
+1. **date-now@0.1.4**
+   * Licenses: MIT
+   * Repository: https://github.com/Colingo/date-now
+1. **debug@2.6.9**
+   * Licenses: MIT
+   * Repository: https://github.com/visionmedia/debug
+1. **debug@3.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/visionmedia/debug
+1. **debug@3.2.6**
+   * Licenses: MIT
+   * Repository: https://github.com/visionmedia/debug
+1. **debug@4.1.1**
+   * Licenses: MIT
+   * Repository: https://github.com/visionmedia/debug
+1. **debuglog@1.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/sam-github/node-debuglog
+1. **decode-uri-component@0.2.0**
+   * Licenses: MIT
+   * Repository: https://github.com/SamVerschueren/decode-uri-component
+1. **deep-extend@0.6.0**
+   * Licenses: MIT
+   * Repository: https://github.com/unclechu/node-deep-extend
+1. **default-require-extensions@2.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/avajs/default-require-extensions
+1. **define-property@0.2.5**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/define-property
+1. **define-property@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/define-property
+1. **define-property@2.0.2**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/define-property
+1. **delayed-stream@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/felixge/node-delayed-stream
+1. **delegates@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/visionmedia/node-delegates
+1. **des.js@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/indutny/des.js
+1. **detect-file@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/doowb/detect-file
+1. **detect-indent@4.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/detect-indent
+1. **detect-libc@1.0.3**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/lovell/detect-libc
+1. **dezalgo@1.0.3**
+   * Licenses: ISC
+   * Repository: https://github.com/npm/dezalgo
+1. **diff@3.5.0**
+   * Licenses: BSD-3-Clause
+   * Repository: https://github.com/kpdecker/jsdiff
+1. **diffie-hellman@5.0.3**
+   * Licenses: MIT
+   * Repository: https://github.com/crypto-browserify/diffie-hellman
+1. **domain-browser@1.2.0**
+   * Licenses: MIT
+   * Repository: https://github.com/bevry/domain-browser
+1. **duplexify@3.6.1**
+   * Licenses: MIT
+   * Repository: https://github.com/mafintosh/duplexify
+1. **ecc-jsbn@0.1.2**
+   * Licenses: MIT
+   * Repository: https://github.com/quartzjer/ecc-jsbn
+1. **electron-to-chromium@1.3.109**
+   * Licenses: ISC
+   * Repository: https://github.com/kilian/electron-to-chromium
+1. **elliptic@6.4.1**
+   * Licenses: MIT
+   * Repository: https://github.com/indutny/elliptic
+1. **emoji-regex@7.0.3**
+   * Licenses: MIT
+   * Repository: https://github.com/mathiasbynens/emoji-regex
+1. **emojis-list@2.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/kikobeats/emojis-list
+1. **end-of-stream@1.4.1**
+   * Licenses: MIT
+   * Repository: https://github.com/mafintosh/end-of-stream
+1. **enhanced-resolve@4.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/webpack/enhanced-resolve
+1. **errno@0.1.7**
+   * Licenses: MIT
+   * Repository: https://github.com/rvagg/node-errno
+1. **error-ex@1.3.2**
+   * Licenses: MIT
+   * Repository: https://github.com/qix-/node-error-ex
+1. **es6-error@4.1.1**
+   * Licenses: MIT
+   * Repository: https://github.com/bjyoungblood/es6-error
+1. **escape-string-regexp@1.0.5**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/escape-string-regexp
+1. **eslint-scope@4.0.0**
+   * Licenses: BSD-2-Clause
+   * Repository: https://github.com/eslint/eslint-scope
+1. **esprima@4.0.1**
+   * Licenses: BSD-2-Clause
+   * Repository: https://github.com/jquery/esprima
+1. **esrecurse@4.2.1**
+   * Licenses: BSD-2-Clause
+   * Repository: https://github.com/estools/esrecurse
+1. **estraverse@4.2.0**
+   * Licenses: BSD-2-Clause
+   * Repository: https://github.com/estools/estraverse
+1. **esutils@2.0.2**
+   * Licenses: BSD
+   * Repository: https://github.com/estools/esutils
+1. **events@3.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/Gozala/events
+1. **evp_bytestokey@1.0.3**
+   * Licenses: MIT
+   * Repository: https://github.com/crypto-browserify/EVP_BytesToKey
+1. **execa@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/execa
+1. **expand-brackets@0.1.5**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/expand-brackets
+1. **expand-brackets@2.1.4**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/expand-brackets
+1. **expand-range@1.8.2**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/expand-range
+1. **expand-tilde@2.0.2**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/expand-tilde
+1. **extend-shallow@2.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/extend-shallow
+1. **extend-shallow@3.0.2**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/extend-shallow
+1. **extend@3.0.2**
+   * Licenses: MIT
+   * Repository: https://github.com/justmoon/node-extend
+1. **extglob@0.3.2**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/extglob
+1. **extglob@2.0.4**
+   * Licenses: MIT
+   * Repository: https://github.com/micromatch/extglob
+1. **extsprintf@1.3.0**
+   * Licenses: MIT
+   * Repository: https://github.com/davepacheco/node-extsprintf
+1. **fast-deep-equal@2.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/epoberezkin/fast-deep-equal
+1. **fast-json-stable-stringify@2.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/epoberezkin/fast-json-stable-stringify
+1. **figgy-pudding@3.5.1**
+   * Licenses: ISC
+   * Repository: https://github.com/zkat/figgy-pudding
+1. **filename-regex@2.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/regexhq/filename-regex
+1. **fill-range@2.2.4**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/fill-range
+1. **fill-range@4.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/fill-range
+1. **find-babel-config@1.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/tleunen/find-babel-config
+1. **find-cache-dir@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/avajs/find-cache-dir
+1. **find-cache-dir@2.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/avajs/find-cache-dir
+1. **find-cache-dir@2.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/avajs/find-cache-dir
+1. **find-up@2.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/find-up
+1. **find-up@3.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/find-up
+1. **findup-sync@2.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/js-cli/node-findup-sync
+1. **flush-write-stream@1.0.3**
+   * Licenses: MIT
+   * Repository: https://github.com/mafintosh/flush-write-stream
+1. **for-in@1.0.2**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/for-in
+1. **for-own@0.1.5**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/for-own
+1. **foreground-child@1.5.6**
+   * Licenses: ISC
+   * Repository: https://github.com/tapjs/foreground-child
+1. **forever-agent@0.6.1**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/mikeal/forever-agent
+1. **form-data@2.3.3**
+   * Licenses: MIT
+   * Repository: https://github.com/form-data/form-data
+1. **fragment-cache@0.2.1**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/fragment-cache
+1. **from2@2.3.0**
+   * Licenses: MIT
+   * Repository: https://github.com/hughsk/from2
+1. **fs-minipass@1.2.5**
+   * Licenses: ISC
+   * Repository: https://github.com/npm/fs-minipass
+1. **fs-readdir-recursive@1.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/fs-utils/fs-readdir-recursive
+1. **fs-write-stream-atomic@1.0.10**
+   * Licenses: ISC
+   * Repository: https://github.com/npm/fs-write-stream-atomic
+1. **fs.realpath@1.0.0**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/fs.realpath
+1. **fsevents@1.2.7**
+   * Licenses: MIT
+   * Repository: https://github.com/strongloop/fsevents
+1. **gauge@2.7.4**
+   * Licenses: ISC
+   * Repository: https://github.com/iarna/gauge
+1. **get-caller-file@1.0.3**
+   * Licenses: ISC
+   * Repository: https://github.com/stefanpenner/get-caller-file
+1. **get-caller-file@2.0.5**
+   * Licenses: ISC
+   * Repository: https://github.com/stefanpenner/get-caller-file
+1. **get-stream@4.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/get-stream
+1. **get-value@2.0.6**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/get-value
+1. **getpass@0.1.7**
+   * Licenses: MIT
+   * Repository: https://github.com/arekinath/node-getpass
+1. **glob-base@0.3.0**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/glob-base
+1. **glob-parent@2.0.0**
+   * Licenses: ISC
+   * Repository: https://github.com/es128/glob-parent
+1. **glob-parent@3.1.0**
+   * Licenses: ISC
+   * Repository: https://github.com/es128/glob-parent
+1. **glob@7.1.2**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/node-glob
+1. **glob@7.1.3**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/node-glob
+1. **global-modules-path@2.3.1**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/rosen-vladimirov/global-modules-path
+1. **global-modules@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/global-modules
+1. **global-prefix@1.0.2**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/global-prefix
+1. **globals@11.11.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/globals
+1. **globals@9.18.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/globals
+1. **graceful-fs@4.1.15**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/node-graceful-fs
+1. **growl@1.10.5**
+   * Licenses: MIT
+   * Repository: https://github.com/tj/node-growl
+1. **handlebars@4.1.2**
+   * Licenses: MIT
+   * Repository: https://github.com/wycats/handlebars.js
+1. **har-schema@2.0.0**
+   * Licenses: ISC
+   * Repository: https://github.com/ahmadnassri/har-schema
+1. **har-validator@5.1.3**
+   * Licenses: MIT
+   * Repository: https://github.com/ahmadnassri/node-har-validator
+1. **has-ansi@2.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/has-ansi
+1. **has-flag@3.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/has-flag
+1. **has-unicode@2.0.1**
+   * Licenses: ISC
+   * Repository: https://github.com/iarna/has-unicode
+1. **has-value@0.3.1**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/has-value
+1. **has-value@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/has-value
+1. **has-values@0.1.4**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/has-values
+1. **has-values@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/has-values
+1. **hash-base@3.0.4**
+   * Licenses: MIT
+   * Repository: https://github.com/crypto-browserify/hash-base
+1. **hash.js@1.1.7**
+   * Licenses: MIT
+   * Repository: https://github.com/indutny/hash.js
+1. **hasha@3.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/hasha
+1. **he@1.1.1**
+   * Licenses: MIT
+   * Repository: https://github.com/mathiasbynens/he
+1. **hmac-drbg@1.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/indutny/hmac-drbg
+1. **home-or-tmp@2.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/home-or-tmp
+1. **homedir-polyfill@1.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/doowb/homedir-polyfill
+1. **hosted-git-info@2.7.1**
+   * Licenses: ISC
+   * Repository: https://github.com/npm/hosted-git-info
+1. **http-signature@1.2.0**
+   * Licenses: MIT
+   * Repository: https://github.com/joyent/node-http-signature
+1. **https-browserify@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/substack/https-browserify
+1. **iconv-lite@0.4.24**
+   * Licenses: MIT
+   * Repository: https://github.com/ashtuchkin/iconv-lite
+1. **ieee754@1.1.12**
+   * Licenses: BSD-3-Clause
+   * Repository: https://github.com/feross/ieee754
+1. **iferr@0.1.5**
+   * Licenses: MIT
+   * Repository: https://github.com/shesek/iferr
+1. **ignore-walk@3.0.1**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/ignore-walk
+1. **import-local@2.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/import-local
+1. **imurmurhash@0.1.4**
+   * Licenses: MIT
+   * Repository: https://github.com/jensyt/imurmurhash-js
+1. **indexof@0.0.1**
+   * Licenses: MIT*
+   * Repository: unknown
+1. **inflight@1.0.6**
+   * Licenses: ISC
+   * Repository: https://github.com/npm/inflight
+1. **inherits@2.0.1**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/inherits
+1. **inherits@2.0.3**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/inherits
+1. **ini@1.3.5**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/ini
+1. **interpret@1.2.0**
+   * Licenses: MIT
+   * Repository: https://github.com/gulpjs/interpret
+1. **invariant@2.2.4**
+   * Licenses: MIT
+   * Repository: https://github.com/zertosh/invariant
+1. **invert-kv@2.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/invert-kv
+1. **is-accessor-descriptor@0.1.6**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/is-accessor-descriptor
+1. **is-accessor-descriptor@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/is-accessor-descriptor
+1. **is-arrayish@0.2.1**
+   * Licenses: MIT
+   * Repository: https://github.com/qix-/node-is-arrayish
+1. **is-binary-path@1.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/is-binary-path
+1. **is-buffer@1.1.6**
+   * Licenses: MIT
+   * Repository: https://github.com/feross/is-buffer
+1. **is-data-descriptor@0.1.4**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/is-data-descriptor
+1. **is-data-descriptor@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/is-data-descriptor
+1. **is-descriptor@0.1.6**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/is-descriptor
+1. **is-descriptor@1.0.2**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/is-descriptor
+1. **is-dotfile@1.0.3**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/is-dotfile
+1. **is-equal-shallow@0.1.3**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/is-equal-shallow
+1. **is-extendable@0.1.1**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/is-extendable
+1. **is-extendable@1.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/is-extendable
+1. **is-extglob@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/is-extglob
+1. **is-extglob@2.1.1**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/is-extglob
+1. **is-finite@1.0.2**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/is-finite
+1. **is-fullwidth-code-point@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/is-fullwidth-code-point
+1. **is-fullwidth-code-point@2.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/is-fullwidth-code-point
+1. **is-glob@2.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/is-glob
+1. **is-glob@3.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/is-glob
+1. **is-glob@4.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/is-glob
+1. **is-number@2.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/is-number
+1. **is-number@3.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/is-number
+1. **is-number@4.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/is-number
+1. **is-plain-object@2.0.4**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/is-plain-object
+1. **is-posix-bracket@0.1.1**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/is-posix-bracket
+1. **is-primitive@2.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/is-primitive
+1. **is-typedarray@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/hughsk/is-typedarray
+1. **is-windows@1.0.2**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/is-windows
+1. **isarray@0.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/juliangruber/isarray
+1. **isarray@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/juliangruber/isarray
+1. **isexe@2.0.0**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/isexe
+1. **isobject@2.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/isobject
+1. **isobject@3.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/isobject
+1. **isstream@0.1.2**
+   * Licenses: MIT
+   * Repository: https://github.com/rvagg/isstream
+1. **istanbul-lib-coverage@2.0.4**
+   * Licenses: BSD-3-Clause
+   * Repository: https://github.com/istanbuljs/istanbuljs
+1. **istanbul-lib-hook@2.0.6**
+   * Licenses: BSD-3-Clause
+   * Repository: https://github.com/istanbuljs/istanbuljs
+1. **istanbul-lib-instrument@3.2.0**
+   * Licenses: BSD-3-Clause
+   * Repository: https://github.com/istanbuljs/istanbuljs
+1. **istanbul-lib-report@2.0.7**
+   * Licenses: BSD-3-Clause
+   * Repository: https://github.com/istanbuljs/istanbuljs
+1. **istanbul-lib-source-maps@3.0.5**
+   * Licenses: BSD-3-Clause
+   * Repository: https://github.com/istanbuljs/istanbuljs
+1. **istanbul-reports@2.2.2**
+   * Licenses: BSD-3-Clause
+   * Repository: https://github.com/istanbuljs/istanbuljs
+1. **js-tokens@3.0.2**
+   * Licenses: MIT
+   * Repository: https://github.com/lydell/js-tokens
+1. **js-tokens@4.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/lydell/js-tokens
+1. **js-yaml@3.13.1**
+   * Licenses: MIT
+   * Repository: https://github.com/nodeca/js-yaml
+1. **jsbn@0.1.1**
+   * Licenses: MIT
+   * Repository: https://github.com/andyperlitch/jsbn
+1. **jsesc@0.5.0**
+   * Licenses: MIT
+   * Repository: https://github.com/mathiasbynens/jsesc
+1. **jsesc@1.3.0**
+   * Licenses: MIT
+   * Repository: https://github.com/mathiasbynens/jsesc
+1. **jsesc@2.5.2**
+   * Licenses: MIT
+   * Repository: https://github.com/mathiasbynens/jsesc
+1. **json-parse-better-errors@1.0.2**
+   * Licenses: MIT
+   * Repository: https://github.com/zkat/json-parse-better-errors
+1. **json-schema-traverse@0.4.1**
+   * Licenses: MIT
+   * Repository: https://github.com/epoberezkin/json-schema-traverse
+1. **json-schema@0.2.3**
+   * Licenses: AFLv2.1,BSD
+   * Repository: https://github.com/kriszyp/json-schema
+1. **json-stringify-safe@5.0.1**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/json-stringify-safe
+1. **json5@0.5.1**
+   * Licenses: MIT
+   * Repository: https://github.com/aseemk/json5
+1. **json5@1.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/json5/json5
+1. **jsprim@1.4.1**
+   * Licenses: MIT
+   * Repository: https://github.com/joyent/node-jsprim
+1. **just-extend@4.0.2**
+   * Licenses: MIT
+   * Repository: https://github.com/angus-c/just
+1. **kind-of@3.2.2**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/kind-of
+1. **kind-of@4.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/kind-of
+1. **kind-of@5.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/kind-of
+1. **kind-of@6.0.2**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/kind-of
+1. **lcid@2.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/lcid
+1. **license-checker@25.0.1**
+   * Licenses: BSD-3-Clause
+   * Repository: https://github.com/davglass/license-checker
+1. **lightercollective@0.1.0**
+   * Licenses: ISC
+   * Repository: unknown
+1. **load-json-file@4.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/load-json-file
+1. **loader-runner@2.4.0**
+   * Licenses: MIT
+   * Repository: https://github.com/webpack/loader-runner
+1. **loader-utils@1.2.3**
+   * Licenses: MIT
+   * Repository: https://github.com/webpack/loader-utils
+1. **locate-path@2.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/locate-path
+1. **locate-path@3.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/locate-path
+1. **lodash.debounce@4.0.8**
+   * Licenses: MIT
+   * Repository: https://github.com/lodash/lodash
+1. **lodash.flattendeep@4.4.0**
+   * Licenses: MIT
+   * Repository: https://github.com/lodash/lodash
+1. **lodash.get@4.4.2**
+   * Licenses: MIT
+   * Repository: https://github.com/lodash/lodash
+1. **lodash@4.17.11**
+   * Licenses: MIT
+   * Repository: https://github.com/lodash/lodash
+1. **lolex@2.7.5**
+   * Licenses: BSD-3-Clause
+   * Repository: https://github.com/sinonjs/lolex
+1. **lolex@3.0.0**
+   * Licenses: BSD-3-Clause
+   * Repository: https://github.com/sinonjs/lolex
+1. **loose-envify@1.4.0**
+   * Licenses: MIT
+   * Repository: https://github.com/zertosh/loose-envify
+1. **lru-cache@4.1.5**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/node-lru-cache
+1. **lru-cache@5.1.1**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/node-lru-cache
+1. **make-dir@1.3.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/make-dir
+1. **make-dir@2.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/make-dir
+1. **map-age-cleaner@0.1.3**
+   * Licenses: MIT
+   * Repository: https://github.com/SamVerschueren/map-age-cleaner
+1. **map-cache@0.2.2**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/map-cache
+1. **map-visit@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/map-visit
+1. **math-random@1.0.4**
+   * Licenses: MIT
+   * Repository: https://github.com/michaelrhodes/math-random
+1. **md5.js@1.3.5**
+   * Licenses: MIT
+   * Repository: https://github.com/crypto-browserify/md5.js
+1. **mem@4.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/mem
+1. **memory-fs@0.4.1**
+   * Licenses: MIT
+   * Repository: https://github.com/webpack/memory-fs
+1. **merge-source-map@1.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/keik/merge-source-map
+1. **micromatch@2.3.11**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/micromatch
+1. **micromatch@3.1.10**
+   * Licenses: MIT
+   * Repository: https://github.com/micromatch/micromatch
+1. **miller-rabin@4.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/indutny/miller-rabin
+1. **mime-db@1.37.0**
+   * Licenses: MIT
+   * Repository: https://github.com/jshttp/mime-db
+1. **mime-types@2.1.21**
+   * Licenses: MIT
+   * Repository: https://github.com/jshttp/mime-types
+1. **mimic-fn@1.2.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/mimic-fn
+1. **minimalistic-assert@1.0.1**
+   * Licenses: ISC
+   * Repository: https://github.com/calvinmetcalf/minimalistic-assert
+1. **minimalistic-crypto-utils@1.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/indutny/minimalistic-crypto-utils
+1. **minimatch@3.0.4**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/minimatch
+1. **minimist@0.0.8**
+   * Licenses: MIT
+   * Repository: https://github.com/substack/minimist
+1. **minimist@1.2.0**
+   * Licenses: MIT
+   * Repository: https://github.com/substack/minimist
+1. **minipass@2.3.5**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/minipass
+1. **minizlib@1.2.1**
+   * Licenses: MIT
+   * Repository: https://github.com/isaacs/minizlib
+1. **mississippi@3.0.0**
+   * Licenses: BSD-2-Clause
+   * Repository: https://github.com/maxogden/mississippi
+1. **mixin-deep@1.3.1**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/mixin-deep
+1. **mkdirp@0.5.1**
+   * Licenses: MIT
+   * Repository: https://github.com/substack/node-mkdirp
+1. **mocha@5.2.0**
+   * Licenses: MIT
+   * Repository: https://github.com/mochajs/mocha
+1. **move-concurrently@1.0.1**
+   * Licenses: ISC
+   * Repository: https://github.com/npm/move-concurrently
+1. **ms@2.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/zeit/ms
+1. **ms@2.1.1**
+   * Licenses: MIT
+   * Repository: https://github.com/zeit/ms
+1. **nanomatch@1.2.13**
+   * Licenses: MIT
+   * Repository: https://github.com/micromatch/nanomatch
+1. **needle@2.2.4**
+   * Licenses: MIT
+   * Repository: https://github.com/tomas/needle
+1. **neo-async@2.6.0**
+   * Licenses: MIT
+   * Repository: https://github.com/suguru03/neo-async
+1. **nested-error-stacks@2.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/mdlavin/nested-error-stacks
+1. **nice-try@1.0.5**
+   * Licenses: MIT
+   * Repository: https://github.com/electerious/nice-try
+1. **nise@1.4.8**
+   * Licenses: BSD-3-Clause
+   * Repository: https://github.com/sinonjs/nise
+1. **node-libs-browser@2.2.0**
+   * Licenses: MIT
+   * Repository: https://github.com/webpack/node-libs-browser
+1. **node-pre-gyp@0.10.3**
+   * Licenses: BSD-3-Clause
+   * Repository: https://github.com/mapbox/node-pre-gyp
+1. **nopt@4.0.1**
+   * Licenses: ISC
+   * Repository: https://github.com/npm/nopt
+1. **normalize-package-data@2.5.0**
+   * Licenses: BSD-2-Clause
+   * Repository: https://github.com/npm/normalize-package-data
+1. **normalize-path@2.1.1**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/normalize-path
+1. **npm-bundled@1.0.5**
+   * Licenses: ISC
+   * Repository: https://github.com/npm/npm-bundled
+1. **npm-packlist@1.2.0**
+   * Licenses: ISC
+   * Repository: https://github.com/npm/npm-packlist
+1. **npm-run-path@2.0.2**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/npm-run-path
+1. **npmlog@4.1.2**
+   * Licenses: ISC
+   * Repository: https://github.com/npm/npmlog
+1. **number-is-nan@1.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/number-is-nan
+1. **nyc@14.0.0**
+   * Licenses: ISC
+   * Repository: https://github.com/istanbuljs/nyc
+1. **oauth-sign@0.9.0**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/mikeal/oauth-sign
+1. **object-assign@4.1.1**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/object-assign
+1. **object-copy@0.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/object-copy
+1. **object-visit@1.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/object-visit
+1. **object.omit@2.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/object.omit
+1. **object.pick@1.3.0**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/object.pick
+1. **once@1.4.0**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/once
+1. **optimist@0.6.1**
+   * Licenses: MIT*
+   * Repository: https://github.com/substack/node-optimist
+1. **os-browserify@0.3.0**
+   * Licenses: MIT
+   * Repository: https://github.com/CoderPuppy/os-browserify
+1. **os-homedir@1.0.2**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/os-homedir
+1. **os-locale@3.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/os-locale
+1. **os-tmpdir@1.0.2**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/os-tmpdir
+1. **osenv@0.1.5**
+   * Licenses: ISC
+   * Repository: https://github.com/npm/osenv
+1. **output-file-sync@1.1.2**
+   * Licenses: MIT
+   * Repository: https://github.com/shinnn/output-file-sync
+1. **p-defer@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/p-defer
+1. **p-finally@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/p-finally
+1. **p-is-promise@2.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/p-is-promise
+1. **p-limit@1.3.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/p-limit
+1. **p-limit@2.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/p-limit
+1. **p-limit@2.2.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/p-limit
+1. **p-locate@2.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/p-locate
+1. **p-locate@3.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/p-locate
+1. **p-try@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/p-try
+1. **p-try@2.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/p-try
+1. **p-try@2.2.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/p-try
+1. **package-hash@3.0.0**
+   * Licenses: ISC
+   * Repository: https://github.com/novemberborn/package-hash
+1. **pako@1.0.8**
+   * Licenses: (MIT AND Zlib)
+   * Repository: https://github.com/nodeca/pako
+1. **parallel-transform@1.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/mafintosh/parallel-transform
+1. **parse-asn1@5.1.3**
+   * Licenses: ISC
+   * Repository: https://github.com/crypto-browserify/parse-asn1
+1. **parse-glob@3.0.4**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/parse-glob
+1. **parse-json@4.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/parse-json
+1. **parse-passwd@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/doowb/parse-passwd
+1. **pascalcase@0.1.1**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/pascalcase
+1. **path-browserify@0.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/substack/path-browserify
+1. **path-dirname@1.0.2**
+   * Licenses: MIT
+   * Repository: https://github.com/es128/path-dirname
+1. **path-exists@3.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/path-exists
+1. **path-is-absolute@1.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/path-is-absolute
+1. **path-key@2.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/path-key
+1. **path-parse@1.0.6**
+   * Licenses: MIT
+   * Repository: https://github.com/jbgutierrez/path-parse
+1. **path-to-regexp@1.7.0**
+   * Licenses: MIT
+   * Repository: https://github.com/pillarjs/path-to-regexp
+1. **path-type@3.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/path-type
+1. **pbkdf2@3.0.17**
+   * Licenses: MIT
+   * Repository: https://github.com/crypto-browserify/pbkdf2
+1. **performance-now@2.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/braveg1rl/performance-now
+1. **pify@3.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/pify
+1. **pify@4.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/pify
+1. **pkg-dir@2.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/pkg-dir
+1. **pkg-dir@3.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/pkg-dir
+1. **pkg-up@2.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/pkg-up
+1. **posix-character-classes@0.1.1**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/posix-character-classes
+1. **preserve@0.2.0**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/preserve
+1. **private@0.1.8**
+   * Licenses: MIT
+   * Repository: https://github.com/benjamn/private
+1. **process-nextick-args@2.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/calvinmetcalf/process-nextick-args
+1. **process@0.11.10**
+   * Licenses: MIT
+   * Repository: https://github.com/shtylman/node-process
+1. **promise-inflight@1.0.1**
+   * Licenses: ISC
+   * Repository: https://github.com/iarna/promise-inflight
+1. **prr@1.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/rvagg/prr
+1. **pseudomap@1.0.2**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/pseudomap
+1. **psl@1.1.31**
+   * Licenses: MIT
+   * Repository: https://github.com/wrangr/psl
+1. **public-encrypt@4.0.3**
+   * Licenses: MIT
+   * Repository: https://github.com/crypto-browserify/publicEncrypt
+1. **pump@2.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/mafintosh/pump
+1. **pump@3.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/mafintosh/pump
+1. **pumpify@1.5.1**
+   * Licenses: MIT
+   * Repository: https://github.com/mafintosh/pumpify
+1. **punycode@1.3.2**
+   * Licenses: MIT
+   * Repository: https://github.com/bestiejs/punycode.js
+1. **punycode@1.4.1**
+   * Licenses: MIT
+   * Repository: https://github.com/bestiejs/punycode.js
+1. **punycode@2.1.1**
+   * Licenses: MIT
+   * Repository: https://github.com/bestiejs/punycode.js
+1. **qs@6.5.2**
+   * Licenses: BSD-3-Clause
+   * Repository: https://github.com/ljharb/qs
+1. **querystring-es3@0.2.1**
+   * Licenses: MIT
+   * Repository: https://github.com/mike-spainhower/querystring
+1. **querystring@0.2.0**
+   * Licenses: MIT
+   * Repository: https://github.com/Gozala/querystring
+1. **randomatic@3.1.1**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/randomatic
+1. **randombytes@2.0.6**
+   * Licenses: MIT
+   * Repository: https://github.com/crypto-browserify/randombytes
+1. **randomfill@1.0.4**
+   * Licenses: MIT
+   * Repository: https://github.com/crypto-browserify/randomfill
+1. **rc@1.2.8**
+   * Licenses: (BSD-2-Clause OR MIT OR Apache-2.0)
+   * Repository: https://github.com/dominictarr/rc
+1. **read-installed@4.0.3**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/read-installed
+1. **read-package-json@2.0.13**
+   * Licenses: ISC
+   * Repository: https://github.com/npm/read-package-json
+1. **read-pkg-up@4.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/read-pkg-up
+1. **read-pkg@3.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/read-pkg
+1. **readable-stream@2.3.6**
+   * Licenses: MIT
+   * Repository: https://github.com/nodejs/readable-stream
+1. **readdir-scoped-modules@1.0.2**
+   * Licenses: ISC
+   * Repository: https://github.com/npm/readdir-scoped-modules
+1. **readdirp@2.2.1**
+   * Licenses: MIT
+   * Repository: https://github.com/paulmillr/readdirp
+1. **regenerate@1.4.0**
+   * Licenses: MIT
+   * Repository: https://github.com/mathiasbynens/regenerate
+1. **regenerator-runtime@0.10.5**
+   * Licenses: MIT
+   * Repository: https://github.com/facebook/regenerator/tree/master/packages/regenerator-runtime
+1. **regenerator-runtime@0.11.1**
+   * Licenses: MIT
+   * Repository: https://github.com/facebook/regenerator/tree/master/packages/regenerator-runtime
+1. **regenerator-transform@0.10.1**
+   * Licenses: BSD*
+   * Repository: https://github.com/facebook/regenerator/tree/master/packages/regenerator-transform
+1. **regex-cache@0.4.4**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/regex-cache
+1. **regex-not@1.0.2**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/regex-not
+1. **regexpu-core@2.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/mathiasbynens/regexpu-core
+1. **regjsgen@0.2.0**
+   * Licenses: MIT
+   * Repository: https://github.com/d10/regjsgen
+1. **regjsparser@0.1.5**
+   * Licenses: BSD*
+   * Repository: https://github.com/jviereck/regjsparser
+1. **release-zalgo@1.0.0**
+   * Licenses: ISC
+   * Repository: https://github.com/novemberborn/release-zalgo
+1. **remove-trailing-separator@1.1.0**
+   * Licenses: ISC
+   * Repository: https://github.com/darsain/remove-trailing-separator
+1. **repeat-element@1.1.3**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/repeat-element
+1. **repeat-string@1.6.1**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/repeat-string
+1. **repeating@2.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/repeating
+1. **request@2.88.0**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/request/request
+1. **require-directory@2.1.1**
+   * Licenses: MIT
+   * Repository: https://github.com/troygoode/node-require-directory
+1. **require-main-filename@1.0.1**
+   * Licenses: ISC
+   * Repository: https://github.com/yargs/require-main-filename
+1. **require-main-filename@2.0.0**
+   * Licenses: ISC
+   * Repository: https://github.com/yargs/require-main-filename
+1. **reselect@3.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/reactjs/reselect
+1. **resolve-cwd@2.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/resolve-cwd
+1. **resolve-dir@1.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/resolve-dir
+1. **resolve-from@3.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/resolve-from
+1. **resolve-from@4.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/resolve-from
+1. **resolve-url@0.2.1**
+   * Licenses: MIT
+   * Repository: https://github.com/lydell/resolve-url
+1. **resolve@1.10.0**
+   * Licenses: MIT
+   * Repository: https://github.com/browserify/resolve
+1. **ret@0.1.15**
+   * Licenses: MIT
+   * Repository: https://github.com/fent/ret.js
+1. **rimraf@2.6.3**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/rimraf
+1. **ripemd160@2.0.2**
+   * Licenses: MIT
+   * Repository: https://github.com/crypto-browserify/ripemd160
+1. **run-queue@1.0.3**
+   * Licenses: ISC
+   * Repository: https://github.com/iarna/run-queue
+1. **safe-buffer@5.1.2**
+   * Licenses: MIT
+   * Repository: https://github.com/feross/safe-buffer
+1. **safe-regex@1.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/substack/safe-regex
+1. **safer-buffer@2.1.2**
+   * Licenses: MIT
+   * Repository: https://github.com/ChALkeR/safer-buffer
+1. **sax@1.2.4**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/sax-js
+1. **schema-utils@0.4.7**
+   * Licenses: MIT
+   * Repository: https://github.com/webpack-contrib/schema-utils
+1. **schema-utils@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/webpack-contrib/schema-utils
+1. **semver@5.6.0**
+   * Licenses: ISC
+   * Repository: https://github.com/npm/node-semver
+1. **semver@6.0.0**
+   * Licenses: ISC
+   * Repository: https://github.com/npm/node-semver
+1. **serialize-javascript@1.6.1**
+   * Licenses: BSD-3-Clause
+   * Repository: https://github.com/yahoo/serialize-javascript
+1. **set-blocking@2.0.0**
+   * Licenses: ISC
+   * Repository: https://github.com/yargs/set-blocking
+1. **set-value@0.4.3**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/set-value
+1. **set-value@2.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/set-value
+1. **setimmediate@1.0.5**
+   * Licenses: MIT
+   * Repository: https://github.com/YuzuJS/setImmediate
+1. **sha.js@2.4.11**
+   * Licenses: (MIT AND BSD-3-Clause)
+   * Repository: https://github.com/crypto-browserify/sha.js
+1. **shebang-command@1.2.0**
+   * Licenses: MIT
+   * Repository: https://github.com/kevva/shebang-command
+1. **shebang-regex@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/shebang-regex
+1. **signal-exit@3.0.2**
+   * Licenses: ISC
+   * Repository: https://github.com/tapjs/signal-exit
+1. **sinon@7.2.3**
+   * Licenses: BSD-3-Clause
+   * Repository: https://github.com/sinonjs/sinon
+1. **slash@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/slash
+1. **slide@1.1.6**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/slide-flow-control
+1. **snapdragon-node@2.1.1**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/snapdragon-node
+1. **snapdragon-util@3.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/snapdragon-util
+1. **snapdragon@0.8.2**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/snapdragon
+1. **source-list-map@2.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/webpack/source-list-map
+1. **source-map-resolve@0.5.2**
+   * Licenses: MIT
+   * Repository: https://github.com/lydell/source-map-resolve
+1. **source-map-support@0.4.18**
+   * Licenses: MIT
+   * Repository: https://github.com/evanw/node-source-map-support
+1. **source-map-support@0.5.10**
+   * Licenses: MIT
+   * Repository: https://github.com/evanw/node-source-map-support
+1. **source-map-url@0.4.0**
+   * Licenses: MIT
+   * Repository: https://github.com/lydell/source-map-url
+1. **source-map@0.5.7**
+   * Licenses: BSD-3-Clause
+   * Repository: https://github.com/mozilla/source-map
+1. **source-map@0.6.1**
+   * Licenses: BSD-3-Clause
+   * Repository: https://github.com/mozilla/source-map
+1. **spawn-wrap@1.4.2**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/spawn-wrap
+1. **spdx-compare@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/kemitchell/spdx-compare.js
+1. **spdx-correct@3.1.0**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/jslicense/spdx-correct.js
+1. **spdx-exceptions@2.2.0**
+   * Licenses: CC-BY-3.0
+   * Repository: https://github.com/kemitchell/spdx-exceptions.json
+1. **spdx-expression-parse@3.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/jslicense/spdx-expression-parse.js
+1. **spdx-license-ids@3.0.4**
+   * Licenses: CC0-1.0
+   * Repository: https://github.com/shinnn/spdx-license-ids
+1. **spdx-ranges@2.1.0**
+   * Licenses: CC-BY-3.0
+   * Repository: https://github.com/kemitchell/spdx-ranges.js
+1. **spdx-satisfies@4.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/kemitchell/spdx-satisfies.js
+1. **spine-web@0.15.2**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/SpineEventEngine/web
+1. **split-string@3.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/split-string
+1. **sprintf-js@1.0.3**
+   * Licenses: BSD-3-Clause
+   * Repository: https://github.com/alexei/sprintf.js
+1. **sshpk@1.16.1**
+   * Licenses: MIT
+   * Repository: https://github.com/joyent/node-sshpk
+1. **ssri@6.0.1**
+   * Licenses: ISC
+   * Repository: https://github.com/zkat/ssri
+1. **static-extend@0.1.2**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/static-extend
+1. **stream-browserify@2.0.2**
+   * Licenses: MIT
+   * Repository: https://github.com/browserify/stream-browserify
+1. **stream-each@1.2.3**
+   * Licenses: MIT
+   * Repository: https://github.com/mafintosh/stream-each
+1. **stream-http@2.8.3**
+   * Licenses: MIT
+   * Repository: https://github.com/jhiesey/stream-http
+1. **stream-shift@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/mafintosh/stream-shift
+1. **string-width@1.0.2**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/string-width
+1. **string-width@2.1.1**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/string-width
+1. **string-width@3.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/string-width
+1. **string_decoder@1.1.1**
+   * Licenses: MIT
+   * Repository: https://github.com/nodejs/string_decoder
+1. **strip-ansi@3.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/chalk/strip-ansi
+1. **strip-ansi@4.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/chalk/strip-ansi
+1. **strip-ansi@5.2.0**
+   * Licenses: MIT
+   * Repository: https://github.com/chalk/strip-ansi
+1. **strip-bom@3.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/strip-bom
+1. **strip-eof@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/strip-eof
+1. **strip-json-comments@2.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/strip-json-comments
+1. **supports-color@2.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/chalk/supports-color
+1. **supports-color@5.4.0**
+   * Licenses: MIT
+   * Repository: https://github.com/chalk/supports-color
+1. **supports-color@5.5.0**
+   * Licenses: MIT
+   * Repository: https://github.com/chalk/supports-color
+1. **supports-color@6.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/chalk/supports-color
+1. **tapable@1.1.1**
+   * Licenses: MIT
+   * Repository: https://github.com/webpack/tapable
+1. **tar@4.4.8**
+   * Licenses: ISC
+   * Repository: https://github.com/npm/node-tar
+1. **terser-webpack-plugin@1.2.1**
+   * Licenses: MIT
+   * Repository: https://github.com/webpack-contrib/terser-webpack-plugin
+1. **terser@3.14.1**
+   * Licenses: BSD-2-Clause
+   * Repository: https://github.com/fabiosantoscode/terser
+1. **test-exclude@5.2.2**
+   * Licenses: ISC
+   * Repository: https://github.com/istanbuljs/istanbuljs
+1. **text-encoding@0.6.4**
+   * Licenses: Unlicense
+   * Repository: https://github.com/inexorabletash/text-encoding
+1. **through2@2.0.5**
+   * Licenses: MIT
+   * Repository: https://github.com/rvagg/through2
+1. **timers-browserify@2.0.10**
+   * Licenses: MIT
+   * Repository: https://github.com/jryans/timers-browserify
+1. **to-arraybuffer@1.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/jhiesey/to-arraybuffer
+1. **to-fast-properties@1.0.3**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/to-fast-properties
+1. **to-fast-properties@2.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/to-fast-properties
+1. **to-object-path@0.3.0**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/to-object-path
+1. **to-regex-range@2.1.1**
+   * Licenses: MIT
+   * Repository: https://github.com/micromatch/to-regex-range
+1. **to-regex@3.0.2**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/to-regex
+1. **tough-cookie@2.4.3**
+   * Licenses: BSD-3-Clause
+   * Repository: https://github.com/salesforce/tough-cookie
+1. **treeify@1.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/notatestuser/treeify
+1. **trim-right@1.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/trim-right
+1. **tty-browserify@0.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/substack/tty-browserify
+1. **tunnel-agent@0.6.0**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/mikeal/tunnel-agent
+1. **tweetnacl@0.14.5**
+   * Licenses: Unlicense
+   * Repository: https://github.com/dchest/tweetnacl-js
+1. **type-detect@4.0.8**
+   * Licenses: MIT
+   * Repository: https://github.com/chaijs/type-detect
+1. **typedarray@0.0.6**
+   * Licenses: MIT
+   * Repository: https://github.com/substack/typedarray
+1. **uglify-js@3.5.4**
+   * Licenses: BSD-2-Clause
+   * Repository: https://github.com/mishoo/UglifyJS2
+1. **union-value@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/union-value
+1. **unique-filename@1.1.1**
+   * Licenses: ISC
+   * Repository: https://github.com/iarna/unique-filename
+1. **unique-slug@2.0.1**
+   * Licenses: ISC
+   * Repository: https://github.com/iarna/unique-slug
+1. **unset-value@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/unset-value
+1. **upath@1.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/anodynos/upath
+1. **uri-js@4.2.2**
+   * Licenses: BSD-2-Clause
+   * Repository: https://github.com/garycourt/uri-js
+1. **urix@0.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/lydell/urix
+1. **url@0.11.0**
+   * Licenses: MIT
+   * Repository: https://github.com/defunctzombie/node-url
+1. **urlgrey@0.4.4**
+   * Licenses: BSD-2-Clause
+   * Repository: https://github.com/cainus/urlgrey
+1. **use@3.1.1**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/use
+1. **user-home@1.1.1**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/user-home
+1. **util-deprecate@1.0.2**
+   * Licenses: MIT
+   * Repository: https://github.com/TooTallNate/util-deprecate
+1. **util-extend@1.0.3**
+   * Licenses: MIT
+   * Repository: https://github.com/isaacs/util-extend
+1. **util@0.10.3**
+   * Licenses: MIT
+   * Repository: https://github.com/defunctzombie/node-util
+1. **util@0.11.1**
+   * Licenses: MIT
+   * Repository: https://github.com/defunctzombie/node-util
+1. **v8-compile-cache@2.0.2**
+   * Licenses: MIT
+   * Repository: unknown
+1. **v8flags@2.1.1**
+   * Licenses: MIT
+   * Repository: https://github.com/tkellen/node-v8flags
+1. **validate-npm-package-license@3.0.4**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/kemitchell/validate-npm-package-license.js
+1. **verror@1.10.0**
+   * Licenses: MIT
+   * Repository: https://github.com/davepacheco/node-verror
+1. **vm-browserify@0.0.4**
+   * Licenses: MIT
+   * Repository: https://github.com/substack/vm-browserify
+1. **watchpack@1.6.0**
+   * Licenses: MIT
+   * Repository: https://github.com/webpack/watchpack
+1. **webpack-cli@3.2.1**
+   * Licenses: MIT
+   * Repository: https://github.com/webpack/webpack-cli
+1. **webpack-merge@4.2.1**
+   * Licenses: MIT
+   * Repository: https://github.com/survivejs/webpack-merge
+1. **webpack-sources@1.3.0**
+   * Licenses: MIT
+   * Repository: https://github.com/webpack/webpack-sources
+1. **webpack@4.29.0**
+   * Licenses: MIT
+   * Repository: https://github.com/webpack/webpack
+1. **which-module@2.0.0**
+   * Licenses: ISC
+   * Repository: https://github.com/nexdrew/which-module
+1. **which@1.3.1**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/node-which
+1. **wide-align@1.1.3**
+   * Licenses: ISC
+   * Repository: https://github.com/iarna/wide-align
+1. **wordwrap@0.0.3**
+   * Licenses: MIT
+   * Repository: https://github.com/substack/node-wordwrap
+1. **worker-farm@1.6.0**
+   * Licenses: MIT
+   * Repository: https://github.com/rvagg/node-worker-farm
+1. **wrappy@1.0.2**
+   * Licenses: ISC
+   * Repository: https://github.com/npm/wrappy
+1. **write-file-atomic@2.4.2**
+   * Licenses: ISC
+   * Repository: https://github.com/iarna/write-file-atomic
+1. **xtend@4.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/Raynos/xtend
+1. **y18n@4.0.0**
+   * Licenses: ISC
+   * Repository: https://github.com/yargs/y18n
+1. **yallist@2.1.2**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/yallist
+1. **yallist@3.0.3**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/yallist
+1. **yargs-parser@11.1.1**
+   * Licenses: ISC
+   * Repository: https://github.com/yargs/yargs-parser
+1. **yargs-parser@13.0.0**
+   * Licenses: ISC
+   * Repository: https://github.com/yargs/yargs-parser
+1. **yargs@12.0.5**
+   * Licenses: MIT
+   * Repository: https://github.com/yargs/yargs
+1. **yargs@13.2.2**
+   * Licenses: MIT
+   * Repository: https://github.com/yargs/yargs
+
+
+This report was generated on **Tue Apr 16 2019 20:21:33 GMT+0300 (Eastern European Summer Time)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
+
+
+
+    
+# Dependencies of `io.spine.gcloud:spine-firebase-web:1.0.0-SNAPSHOT`
+
+## Runtime
+1. **Group:** com.fasterxml.jackson.core **Name:** jackson-annotations **Version:** 2.9.0
+     * **Project URL:** [http://github.com/FasterXML/jackson](http://github.com/FasterXML/jackson)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.fasterxml.jackson.core **Name:** jackson-core **Version:** 2.9.6
+     * **Project URL:** [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.fasterxml.jackson.core **Name:** jackson-databind **Version:** 2.9.6
+     * **Project URL:** [http://github.com/FasterXML/jackson](http://github.com/FasterXML/jackson)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.api **Name:** api-common **Version:** 1.7.0
+     * **POM Project URL:** [https://github.com/googleapis](https://github.com/googleapis)
+     * **POM License: BSD** - [https://github.com/googleapis/api-common-java/blob/master/LICENSE](https://github.com/googleapis/api-common-java/blob/master/LICENSE)
+
+1. **Group:** com.google.api **Name:** gax **Version:** 1.30.0
+     * **POM Project URL:** [https://github.com/googleapis](https://github.com/googleapis)
+     * **POM License: BSD** - [https://github.com/googleapis/gax-java/blob/master/LICENSE](https://github.com/googleapis/gax-java/blob/master/LICENSE)
+
+1. **Group:** com.google.api **Name:** gax-grpc **Version:** 1.30.0
+     * **POM Project URL:** [https://github.com/googleapis](https://github.com/googleapis)
+     * **POM License: BSD** - [https://github.com/googleapis/gax-java/blob/master/LICENSE](https://github.com/googleapis/gax-java/blob/master/LICENSE)
+
+1. **Group:** com.google.api **Name:** gax-httpjson **Version:** 0.47.0
+     * **POM Project URL:** [https://github.com/googleapis](https://github.com/googleapis)
+     * **POM License: BSD** - [https://github.com/googleapis/gax-java/blob/master/LICENSE](https://github.com/googleapis/gax-java/blob/master/LICENSE)
+
+1. **Group:** com.google.api-client **Name:** google-api-client **Version:** 1.25.0
+     * **Manifest Project URL:** [https://developers.google.com/api-client-library/java/](https://developers.google.com/api-client-library/java/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.api-client **Name:** google-api-client-gson **Version:** 1.25.0
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.api.grpc **Name:** proto-google-cloud-firestore-v1beta1 **Version:** 0.26.0
+     * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.api.grpc **Name:** proto-google-common-protos **Version:** 1.0.0
+     * **POM Project URL:** [https://github.com/googleapis/googleapis](https://github.com/googleapis/googleapis)
+     * **POM License: Apache-2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.api.grpc **Name:** proto-google-iam-v1 **Version:** 0.1.28
+     * **POM Project URL:** [https://github.com/googleapis/googleapis](https://github.com/googleapis/googleapis)
+     * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.apis **Name:** google-api-services-storage **Version:** v1-rev135-1.24.1
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.appengine **Name:** appengine-api-1.0-sdk **Version:** 1.9.70
+     * **POM License: Google App Engine Terms of Service** - [http://code.google.com/appengine/terms.html](http://code.google.com/appengine/terms.html)
+
+1. **Group:** com.google.auth **Name:** google-auth-library-credentials **Version:** 0.11.0
+     * **POM License: BSD New license** - [http://opensource.org/licenses/BSD-3-Clause](http://opensource.org/licenses/BSD-3-Clause)
+
+1. **Group:** com.google.auth **Name:** google-auth-library-oauth2-http **Version:** 0.11.0
+     * **POM License: BSD New license** - [http://opensource.org/licenses/BSD-3-Clause](http://opensource.org/licenses/BSD-3-Clause)
+
+1. **Group:** com.google.auto.value **Name:** auto-value **Version:** 1.4
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.cloud **Name:** google-cloud-core **Version:** 1.43.0
+     * **POM Project URL:** [https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core](https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core)
+     * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.cloud **Name:** google-cloud-core-grpc **Version:** 1.43.0
+     * **POM Project URL:** [https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core-grpc](https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core-grpc)
+     * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.cloud **Name:** google-cloud-core-http **Version:** 1.43.0
+     * **POM Project URL:** [https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core-http](https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core-http)
+     * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.cloud **Name:** google-cloud-firestore **Version:** 0.61.0-beta
+     * **POM Project URL:** [https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-firestore
+  ](https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-firestore
+  )
+     * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.cloud **Name:** google-cloud-storage **Version:** 1.43.0
+     * **POM Project URL:** [https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-storage](https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-storage)
+     * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.code.gson **Name:** gson **Version:** 2.7
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.errorprone **Name:** error_prone_annotations **Version:** 2.3.2
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.firebase **Name:** firebase-admin **Version:** 6.7.0
+     * **POM Project URL:** [https://firebase.google.com/](https://firebase.google.com/)
+     * **POM License: Apache License, Version 2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.guava **Name:** failureaccess **Version:** 1.0.1
+     * **Manifest Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.guava **Name:** guava **Version:** 27.1-jre
+     * **Manifest Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.guava **Name:** listenablefuture **Version:** 9999.0-empty-to-avoid-conflict-with-guava
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.http-client **Name:** google-http-client **Version:** 1.28.0
+     * **Manifest Project URL:** [http://www.google.com/](http://www.google.com/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.http-client **Name:** google-http-client-apache **Version:** 1.28.0
+     * **Manifest Project URL:** [http://www.google.com/](http://www.google.com/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.http-client **Name:** google-http-client-appengine **Version:** 1.24.1
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.http-client **Name:** google-http-client-gson **Version:** 1.25.0
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.http-client **Name:** google-http-client-jackson **Version:** 1.24.1
+     * **Manifest Project URL:** [http://www.google.com/](http://www.google.com/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.http-client **Name:** google-http-client-jackson2 **Version:** 1.25.0
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.j2objc **Name:** j2objc-annotations **Version:** 1.1
+     * **POM Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.oauth-client **Name:** google-oauth-client **Version:** 1.25.0
+     * **Manifest Project URL:** [http://www.google.com/](http://www.google.com/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.6.1
+     * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.6.1
+     * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.squareup **Name:** javapoet **Version:** 1.9.0
+     * **POM Project URL:** [http://github.com/square/javapoet/](http://github.com/square/javapoet/)
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.squareup.okhttp **Name:** okhttp **Version:** 2.5.0
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.squareup.okio **Name:** okio **Version:** 1.13.0
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-beanutils **Name:** commons-beanutils **Version:** 1.9.2
+     * **Project URL:** [http://commons.apache.org/proper/commons-beanutils/](http://commons.apache.org/proper/commons-beanutils/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-codec **Name:** commons-codec **Version:** 1.6
+     * **Project URL:** [http://commons.apache.org/codec/](http://commons.apache.org/codec/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-collections **Name:** commons-collections **Version:** 3.2.2
+     * **Project URL:** [http://commons.apache.org/collections/](http://commons.apache.org/collections/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-digester **Name:** commons-digester **Version:** 1.8.1
+     * **Project URL:** [http://commons.apache.org/digester/](http://commons.apache.org/digester/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-logging **Name:** commons-logging **Version:** 1.2
+     * **Project URL:** [http://commons.apache.org/proper/commons-logging/](http://commons.apache.org/proper/commons-logging/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-validator **Name:** commons-validator **Version:** 1.6
+     * **Project URL:** [http://commons.apache.org/proper/commons-validator/](http://commons.apache.org/proper/commons-validator/)
+     * **Manifest license URL:** [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: Apache License, Version 2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** io.grpc **Name:** grpc-auth **Version:** 1.13.1
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-core **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-netty **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-netty-shaded **Version:** 1.13.1
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-okhttp **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-protobuf **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-protobuf-lite **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-stub **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.netty **Name:** netty-buffer **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-codec **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-codec-http **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-codec-http2 **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-codec-socks **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-common **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-handler **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-handler-proxy **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-resolver **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-transport **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.opencensus **Name:** opencensus-api **Version:** 0.18.0
+     * **POM Project URL:** [https://github.com/census-instrumentation/opencensus-java](https://github.com/census-instrumentation/opencensus-java)
+     * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** io.opencensus **Name:** opencensus-contrib-grpc-metrics **Version:** 0.18.0
+     * **POM Project URL:** [https://github.com/census-instrumentation/opencensus-java](https://github.com/census-instrumentation/opencensus-java)
+     * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** io.opencensus **Name:** opencensus-contrib-grpc-util **Version:** 0.15.0
+     * **POM Project URL:** [https://github.com/census-instrumentation/opencensus-java](https://github.com/census-instrumentation/opencensus-java)
+     * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** io.opencensus **Name:** opencensus-contrib-http-util **Version:** 0.18.0
+     * **POM Project URL:** [https://github.com/census-instrumentation/opencensus-java](https://github.com/census-instrumentation/opencensus-java)
+     * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** javax.servlet **Name:** javax.servlet-api **Version:** 4.0.0
+     * **Manifest Project URL:** [https://javaee.github.io](https://javaee.github.io)
+     * **Manifest license URL:** [https://oss.oracle.com/licenses/CDDL+GPL-1.1](https://oss.oracle.com/licenses/CDDL+GPL-1.1)
+     * **POM Project URL:** [https://javaee.github.io/servlet-spec/](https://javaee.github.io/servlet-spec/)
+     * **POM License: CDDL + GPLv2 with classpath exception** - [https://oss.oracle.com/licenses/CDDL+GPL-1.1](https://oss.oracle.com/licenses/CDDL+GPL-1.1)
+
+1. **Group:** joda-time **Name:** joda-time **Version:** 2.9.2
+     * **Project URL:** [http://www.joda.org/joda-time/](http://www.joda.org/joda-time/)
+     * **Manifest License:** Apache 2.0 (Not packaged)
+     * **POM License: Apache 2** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.apache.httpcomponents **Name:** httpclient **Version:** 4.2.6
+     * **POM Project URL:** [http://hc.apache.org/httpcomponents-client](http://hc.apache.org/httpcomponents-client)
+     * **POM License: Apache License** **License:** LICENSE.txt
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.apache.httpcomponents **Name:** httpcore **Version:** 4.2.5
+     * **POM Project URL:** [http://hc.apache.org/httpcomponents-core-ga](http://hc.apache.org/httpcomponents-core-ga)
+     * **POM License: Apache License** **License:** LICENSE.txt
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.checkerframework **Name:** checker-compat-qual **Version:** 2.5.2
+     * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
+     * **POM License: GNU General Public License, version 2 (GPL2), with the classpath exception** - [http://www.gnu.org/software/classpath/license.html](http://www.gnu.org/software/classpath/license.html)
+     * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
+
+1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.7.0
+     * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
+     * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
+
+1. **Group:** org.codehaus.jackson **Name:** jackson-core-asl **Version:** 1.9.11
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM Project URL:** [http://jackson.codehaus.org](http://jackson.codehaus.org)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.codehaus.mojo **Name:** animal-sniffer-annotations **Version:** 1.17
+     * **POM License: MIT license** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.json **Name:** json **Version:** 20160810
+     * **Manifest license URL:** [http://json.org/license.html](http://json.org/license.html)
+     * **POM Project URL:** [https://github.com/douglascrockford/JSON-java](https://github.com/douglascrockford/JSON-java)
+     * **POM License: The JSON License** - [http://json.org/license.html](http://json.org/license.html)
+
+1. **Group:** org.slf4j **Name:** slf4j-api **Version:** 1.7.26
+     * **POM Project URL:** [http://www.slf4j.org](http://www.slf4j.org)
+     * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
+
+1. **Group:** org.threeten **Name:** threetenbp **Version:** 1.3.3
+     * **Manifest Project URL:** [http://www.threeten.org](http://www.threeten.org)
+     * **Manifest license URL:** [https://raw.githubusercontent.com/ThreeTen/threetenbp/master/LICENSE.txt](https://raw.githubusercontent.com/ThreeTen/threetenbp/master/LICENSE.txt)
+     * **POM Project URL:** [https://www.threeten.org/threetenbp](https://www.threeten.org/threetenbp)
+     * **POM License: BSD 3-clause** - [https://raw.githubusercontent.com/ThreeTen/threetenbp/master/LICENSE.txt](https://raw.githubusercontent.com/ThreeTen/threetenbp/master/LICENSE.txt)
+
+## Compile, tests and tooling
+1. **Group:** com.beust **Name:** jcommander **Version:** 1.72
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM Project URL:** [http://jcommander.org](http://jcommander.org)
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** com.fasterxml.jackson.core **Name:** jackson-annotations **Version:** 2.9.0
+     * **Project URL:** [http://github.com/FasterXML/jackson](http://github.com/FasterXML/jackson)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.fasterxml.jackson.core **Name:** jackson-core **Version:** 2.9.6
+     * **Project URL:** [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.fasterxml.jackson.core **Name:** jackson-databind **Version:** 2.9.6
+     * **Project URL:** [http://github.com/FasterXML/jackson](http://github.com/FasterXML/jackson)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.github.kevinstern **Name:** software-and-algorithms **Version:** 1.0
+     * **POM Project URL:** [https://www.github.com/KevinStern/software-and-algorithms](https://www.github.com/KevinStern/software-and-algorithms)
+     * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
+
+1. **Group:** com.github.stephenc.jcip **Name:** jcip-annotations **Version:** 1.0-1
+     * **POM Project URL:** [http://stephenc.github.com/jcip-annotations](http://stephenc.github.com/jcip-annotations)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.api **Name:** api-common **Version:** 1.7.0
+     * **POM Project URL:** [https://github.com/googleapis](https://github.com/googleapis)
+     * **POM License: BSD** - [https://github.com/googleapis/api-common-java/blob/master/LICENSE](https://github.com/googleapis/api-common-java/blob/master/LICENSE)
+
+1. **Group:** com.google.api **Name:** gax **Version:** 1.30.0
+     * **POM Project URL:** [https://github.com/googleapis](https://github.com/googleapis)
+     * **POM License: BSD** - [https://github.com/googleapis/gax-java/blob/master/LICENSE](https://github.com/googleapis/gax-java/blob/master/LICENSE)
+
+1. **Group:** com.google.api **Name:** gax-grpc **Version:** 1.30.0
+     * **POM Project URL:** [https://github.com/googleapis](https://github.com/googleapis)
+     * **POM License: BSD** - [https://github.com/googleapis/gax-java/blob/master/LICENSE](https://github.com/googleapis/gax-java/blob/master/LICENSE)
+
+1. **Group:** com.google.api **Name:** gax-httpjson **Version:** 0.47.0
+     * **POM Project URL:** [https://github.com/googleapis](https://github.com/googleapis)
+     * **POM License: BSD** - [https://github.com/googleapis/gax-java/blob/master/LICENSE](https://github.com/googleapis/gax-java/blob/master/LICENSE)
+
+1. **Group:** com.google.api-client **Name:** google-api-client **Version:** 1.25.0
+     * **Manifest Project URL:** [https://developers.google.com/api-client-library/java/](https://developers.google.com/api-client-library/java/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.api-client **Name:** google-api-client-gson **Version:** 1.25.0
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.api.grpc **Name:** proto-google-cloud-firestore-v1beta1 **Version:** 0.26.0
+     * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.api.grpc **Name:** proto-google-common-protos **Version:** 1.0.0
+     * **POM Project URL:** [https://github.com/googleapis/googleapis](https://github.com/googleapis/googleapis)
+     * **POM License: Apache-2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.api.grpc **Name:** proto-google-iam-v1 **Version:** 0.1.28
+     * **POM Project URL:** [https://github.com/googleapis/googleapis](https://github.com/googleapis/googleapis)
+     * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.apis **Name:** google-api-services-storage **Version:** v1-rev135-1.24.1
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.appengine **Name:** appengine-api-1.0-sdk **Version:** 1.9.70
+     * **POM License: Google App Engine Terms of Service** - [http://code.google.com/appengine/terms.html](http://code.google.com/appengine/terms.html)
+
+1. **Group:** com.google.auth **Name:** google-auth-library-credentials **Version:** 0.11.0
+     * **POM License: BSD New license** - [http://opensource.org/licenses/BSD-3-Clause](http://opensource.org/licenses/BSD-3-Clause)
+
+1. **Group:** com.google.auth **Name:** google-auth-library-oauth2-http **Version:** 0.11.0
+     * **POM License: BSD New license** - [http://opensource.org/licenses/BSD-3-Clause](http://opensource.org/licenses/BSD-3-Clause)
+
+1. **Group:** com.google.auto **Name:** auto-common **Version:** 0.10
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.auto.value **Name:** auto-value **Version:** 1.4
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.auto.value **Name:** auto-value-annotations **Version:** 1.6.3
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.cloud **Name:** google-cloud-core **Version:** 1.43.0
+     * **POM Project URL:** [https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core](https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core)
+     * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.cloud **Name:** google-cloud-core-grpc **Version:** 1.43.0
+     * **POM Project URL:** [https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core-grpc](https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core-grpc)
+     * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.cloud **Name:** google-cloud-core-http **Version:** 1.43.0
+     * **POM Project URL:** [https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core-http](https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core-http)
+     * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.cloud **Name:** google-cloud-firestore **Version:** 0.61.0-beta
+     * **POM Project URL:** [https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-firestore
+  ](https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-firestore
+  )
+     * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.cloud **Name:** google-cloud-storage **Version:** 1.43.0
+     * **POM Project URL:** [https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-storage](https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-storage)
+     * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.code.findbugs **Name:** jFormatString **Version:** 3.0.0
+     * **POM Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
+     * **POM License: GNU Lesser Public License** - [http://www.gnu.org/licenses/lgpl.html](http://www.gnu.org/licenses/lgpl.html)
+
+1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.0
+     * **POM Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.code.gson **Name:** gson **Version:** 2.7
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.code.gson **Name:** gson **Version:** 2.8.5
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.errorprone **Name:** error_prone_annotation **Version:** 2.3.2
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.errorprone **Name:** error_prone_annotations **Version:** 2.3.2
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.errorprone **Name:** error_prone_check_api **Version:** 2.3.2
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.errorprone **Name:** error_prone_core **Version:** 2.3.2
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.errorprone **Name:** error_prone_type_annotations **Version:** 2.3.2
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.errorprone **Name:** javac **Version:** 9+181-r4173-1
+     * **POM Project URL:** [https://github.com/google/error-prone-javac](https://github.com/google/error-prone-javac)
+     * **POM License: GNU General Public License, version 2, with the Classpath Exception** - [http://openjdk.java.net/legal/gplv2+ce.html](http://openjdk.java.net/legal/gplv2+ce.html)
+
+1. **Group:** com.google.firebase **Name:** firebase-admin **Version:** 6.7.0
+     * **POM Project URL:** [https://firebase.google.com/](https://firebase.google.com/)
+     * **POM License: Apache License, Version 2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.guava **Name:** failureaccess **Version:** 1.0.1
+     * **Manifest Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.guava **Name:** guava **Version:** 23.5-jre
+     * **Manifest Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.guava **Name:** guava **Version:** 27.1-jre
+     * **Manifest Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.guava **Name:** guava-testlib **Version:** 27.1-jre
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.guava **Name:** listenablefuture **Version:** 9999.0-empty-to-avoid-conflict-with-guava
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.http-client **Name:** google-http-client **Version:** 1.28.0
+     * **Manifest Project URL:** [http://www.google.com/](http://www.google.com/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.http-client **Name:** google-http-client-apache **Version:** 1.28.0
+     * **Manifest Project URL:** [http://www.google.com/](http://www.google.com/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.http-client **Name:** google-http-client-appengine **Version:** 1.24.1
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.http-client **Name:** google-http-client-gson **Version:** 1.25.0
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.http-client **Name:** google-http-client-jackson **Version:** 1.24.1
+     * **Manifest Project URL:** [http://www.google.com/](http://www.google.com/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.http-client **Name:** google-http-client-jackson2 **Version:** 1.25.0
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.j2objc **Name:** j2objc-annotations **Version:** 1.1
+     * **POM Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.oauth-client **Name:** google-oauth-client **Version:** 1.25.0
+     * **Manifest Project URL:** [http://www.google.com/](http://www.google.com/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.4.0
+     * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.6.1
+     * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.6.1
+     * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.protobuf **Name:** protoc **Version:** 3.6.1
+     * **POM Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.truth **Name:** truth **Version:** 0.43
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.truth.extensions **Name:** truth-java8-extension **Version:** 0.43
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.truth.extensions **Name:** truth-liteproto-extension **Version:** 0.43
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.truth.extensions **Name:** truth-proto-extension **Version:** 0.43
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.googlecode.java-diff-utils **Name:** diffutils **Version:** 1.3.0
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM Project URL:** [http://code.google.com/p/java-diff-utils/](http://code.google.com/p/java-diff-utils/)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.squareup **Name:** javapoet **Version:** 1.9.0
+     * **POM Project URL:** [http://github.com/square/javapoet/](http://github.com/square/javapoet/)
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.squareup.okhttp **Name:** okhttp **Version:** 2.5.0
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.squareup.okio **Name:** okio **Version:** 1.13.0
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-beanutils **Name:** commons-beanutils **Version:** 1.9.2
+     * **Project URL:** [http://commons.apache.org/proper/commons-beanutils/](http://commons.apache.org/proper/commons-beanutils/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-codec **Name:** commons-codec **Version:** 1.6
+     * **Project URL:** [http://commons.apache.org/codec/](http://commons.apache.org/codec/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-collections **Name:** commons-collections **Version:** 3.2.2
+     * **Project URL:** [http://commons.apache.org/collections/](http://commons.apache.org/collections/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-digester **Name:** commons-digester **Version:** 1.8.1
+     * **Project URL:** [http://commons.apache.org/digester/](http://commons.apache.org/digester/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-io **Name:** commons-io **Version:** 2.6
+     * **Project URL:** [http://commons.apache.org/proper/commons-io/](http://commons.apache.org/proper/commons-io/)
+     * **Manifest license URL:** [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: Apache License, Version 2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-logging **Name:** commons-logging **Version:** 1.2
+     * **Project URL:** [http://commons.apache.org/proper/commons-logging/](http://commons.apache.org/proper/commons-logging/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-validator **Name:** commons-validator **Version:** 1.6
+     * **Project URL:** [http://commons.apache.org/proper/commons-validator/](http://commons.apache.org/proper/commons-validator/)
+     * **Manifest license URL:** [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: Apache License, Version 2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** io.grpc **Name:** grpc-auth **Version:** 1.13.1
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-core **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-netty **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-netty-shaded **Version:** 1.13.1
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-okhttp **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-protobuf **Version:** 1.13.1
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-protobuf **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-protobuf-lite **Version:** 1.13.1
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-protobuf-lite **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-stub **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** protoc-gen-grpc-java **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.netty **Name:** netty-buffer **Version:** 4.1.22.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-buffer **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-codec **Version:** 4.1.22.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-codec **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-codec-http **Version:** 4.1.22.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-codec-http **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-codec-http2 **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-codec-socks **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-common **Version:** 4.1.22.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-common **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-handler **Version:** 4.1.22.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-handler **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-handler-proxy **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-resolver **Version:** 4.1.22.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-resolver **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-transport **Version:** 4.1.22.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-transport **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.opencensus **Name:** opencensus-api **Version:** 0.18.0
+     * **POM Project URL:** [https://github.com/census-instrumentation/opencensus-java](https://github.com/census-instrumentation/opencensus-java)
+     * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** io.opencensus **Name:** opencensus-contrib-grpc-metrics **Version:** 0.18.0
+     * **POM Project URL:** [https://github.com/census-instrumentation/opencensus-java](https://github.com/census-instrumentation/opencensus-java)
+     * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** io.opencensus **Name:** opencensus-contrib-grpc-util **Version:** 0.15.0
+     * **POM Project URL:** [https://github.com/census-instrumentation/opencensus-java](https://github.com/census-instrumentation/opencensus-java)
+     * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** io.opencensus **Name:** opencensus-contrib-http-util **Version:** 0.18.0
+     * **POM Project URL:** [https://github.com/census-instrumentation/opencensus-java](https://github.com/census-instrumentation/opencensus-java)
+     * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** javax.servlet **Name:** javax.servlet-api **Version:** 4.0.0
+     * **Manifest Project URL:** [https://javaee.github.io](https://javaee.github.io)
+     * **Manifest license URL:** [https://oss.oracle.com/licenses/CDDL+GPL-1.1](https://oss.oracle.com/licenses/CDDL+GPL-1.1)
+     * **POM Project URL:** [https://javaee.github.io/servlet-spec/](https://javaee.github.io/servlet-spec/)
+     * **POM License: CDDL + GPLv2 with classpath exception** - [https://oss.oracle.com/licenses/CDDL+GPL-1.1](https://oss.oracle.com/licenses/CDDL+GPL-1.1)
+
+1. **Group:** joda-time **Name:** joda-time **Version:** 2.9.2
+     * **Project URL:** [http://www.joda.org/joda-time/](http://www.joda.org/joda-time/)
+     * **Manifest License:** Apache 2.0 (Not packaged)
+     * **POM License: Apache 2** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** junit **Name:** junit **Version:** 4.12
+     * **POM Project URL:** [http://junit.org](http://junit.org)
+     * **POM License: Eclipse Public License 1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+
+1. **Group:** net.bytebuddy **Name:** byte-buddy **Version:** 1.7.9
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** net.bytebuddy **Name:** byte-buddy-agent **Version:** 1.7.9
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** net.java.dev.javacc **Name:** javacc **Version:** 5.0
+     * **POM Project URL:** [https://javacc.dev.java.net/](https://javacc.dev.java.net/)
+     * **POM License: Berkeley Software Distribution (BSD) License** - [http://www.opensource.org/licenses/bsd-license.html](http://www.opensource.org/licenses/bsd-license.html)
+
+1. **Group:** net.sourceforge.pmd **Name:** pmd-core **Version:** 6.11.0
+     * **POM License: BSD-style** - [http://pmd.sourceforge.net/license.html](http://pmd.sourceforge.net/license.html)
+
+1. **Group:** net.sourceforge.pmd **Name:** pmd-java **Version:** 6.11.0
+     * **POM License: BSD-style** - [http://pmd.sourceforge.net/license.html](http://pmd.sourceforge.net/license.html)
+
+1. **Group:** net.sourceforge.saxon **Name:** saxon **Version:** 9.1.0.8
+     * **POM Project URL:** [http://saxon.sourceforge.net/](http://saxon.sourceforge.net/)
+     * **POM License: Mozilla Public License Version 1.0** - [http://www.mozilla.org/MPL/MPL-1.0.txt](http://www.mozilla.org/MPL/MPL-1.0.txt)
+
+1. **Group:** org.antlr **Name:** antlr4-runtime **Version:** 4.7
+     * **Manifest Project URL:** [http://www.antlr.org](http://www.antlr.org)
+     * **Manifest license URL:** [http://www.antlr.org/license.html](http://www.antlr.org/license.html)
+     * **POM License: The BSD License** - [http://www.antlr.org/license.html](http://www.antlr.org/license.html)
+
+1. **Group:** org.apache.commons **Name:** commons-lang3 **Version:** 3.8.1
+     * **Project URL:** [http://commons.apache.org/proper/commons-lang/](http://commons.apache.org/proper/commons-lang/)
+     * **Manifest license URL:** [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: Apache License, Version 2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.apache.httpcomponents **Name:** httpclient **Version:** 4.2.6
+     * **POM Project URL:** [http://hc.apache.org/httpcomponents-client](http://hc.apache.org/httpcomponents-client)
+     * **POM License: Apache License** **License:** LICENSE.txt
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.apache.httpcomponents **Name:** httpcore **Version:** 4.2.5
+     * **POM Project URL:** [http://hc.apache.org/httpcomponents-core-ga](http://hc.apache.org/httpcomponents-core-ga)
+     * **POM License: Apache License** **License:** LICENSE.txt
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.apiguardian **Name:** apiguardian-api **Version:** 1.0.0
+     * **POM Project URL:** [https://github.com/apiguardian-team/apiguardian](https://github.com/apiguardian-team/apiguardian)
+     * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.checkerframework **Name:** checker-compat-qual **Version:** 2.5.2
+     * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
+     * **POM License: GNU General Public License, version 2 (GPL2), with the classpath exception** - [http://www.gnu.org/software/classpath/license.html](http://www.gnu.org/software/classpath/license.html)
+     * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
+
+1. **Group:** org.checkerframework **Name:** checker-compat-qual **Version:** 2.5.5
+     * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
+     * **POM License: GNU General Public License, version 2 (GPL2), with the classpath exception** - [http://www.gnu.org/software/classpath/license.html](http://www.gnu.org/software/classpath/license.html)
+     * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
+
+1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.5.3
+     * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
+     * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
+
+1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.7.0
+     * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
+     * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
+
+1. **Group:** org.checkerframework **Name:** dataflow **Version:** 2.5.3
+     * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
+     * **POM License: GNU General Public License, version 2 (GPL2), with the classpath exception** - [http://www.gnu.org/software/classpath/license.html](http://www.gnu.org/software/classpath/license.html)
+     * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
+
+1. **Group:** org.checkerframework **Name:** javacutil **Version:** 2.5.3
+     * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
+     * **POM License: GNU General Public License, version 2 (GPL2), with the classpath exception** - [http://www.gnu.org/software/classpath/license.html](http://www.gnu.org/software/classpath/license.html)
+     * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
+
+1. **Group:** org.codehaus.jackson **Name:** jackson-core-asl **Version:** 1.9.11
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM Project URL:** [http://jackson.codehaus.org](http://jackson.codehaus.org)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.codehaus.mojo **Name:** animal-sniffer-annotations **Version:** 1.14
+     * **POM License: MIT license** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
+
+1. **Group:** org.codehaus.mojo **Name:** animal-sniffer-annotations **Version:** 1.17
+     * **POM License: MIT license** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.hamcrest **Name:** hamcrest-all **Version:** 1.3
+     * **POM License: New BSD License** - [http://www.opensource.org/licenses/bsd-license.php](http://www.opensource.org/licenses/bsd-license.php)
+
+1. **Group:** org.hamcrest **Name:** hamcrest-core **Version:** 1.3
+     * **POM License: New BSD License** - [http://www.opensource.org/licenses/bsd-license.php](http://www.opensource.org/licenses/bsd-license.php)
+
+1. **Group:** org.jacoco **Name:** org.jacoco.agent **Version:** 0.8.2
+     * **Manifest license URL:** [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+     * **POM License: Eclipse Public License v1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+
+1. **Group:** org.jacoco **Name:** org.jacoco.ant **Version:** 0.8.2
+     * **Manifest license URL:** [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+     * **POM License: Eclipse Public License v1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+
+1. **Group:** org.jacoco **Name:** org.jacoco.core **Version:** 0.8.2
+     * **Manifest license URL:** [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+     * **POM License: Eclipse Public License v1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+
+1. **Group:** org.jacoco **Name:** org.jacoco.report **Version:** 0.8.2
+     * **Manifest license URL:** [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+     * **POM License: Eclipse Public License v1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+
+1. **Group:** org.json **Name:** json **Version:** 20160810
+     * **Manifest license URL:** [http://json.org/license.html](http://json.org/license.html)
+     * **POM Project URL:** [https://github.com/douglascrockford/JSON-java](https://github.com/douglascrockford/JSON-java)
+     * **POM License: The JSON License** - [http://json.org/license.html](http://json.org/license.html)
+
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.4.0
+     * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
+     * **POM License: Eclipse Public License v2.0** - [http://www.eclipse.org/legal/epl-v20.html](http://www.eclipse.org/legal/epl-v20.html)
+
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-engine **Version:** 5.4.0
+     * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
+     * **POM License: Eclipse Public License v2.0** - [http://www.eclipse.org/legal/epl-v20.html](http://www.eclipse.org/legal/epl-v20.html)
+
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-params **Version:** 5.4.0
+     * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
+     * **POM License: Eclipse Public License v2.0** - [http://www.eclipse.org/legal/epl-v20.html](http://www.eclipse.org/legal/epl-v20.html)
+
+1. **Group:** org.junit.platform **Name:** junit-platform-commons **Version:** 1.4.0
+     * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
+     * **POM License: Eclipse Public License v2.0** - [http://www.eclipse.org/legal/epl-v20.html](http://www.eclipse.org/legal/epl-v20.html)
+
+1. **Group:** org.junit.platform **Name:** junit-platform-engine **Version:** 1.4.0
+     * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
+     * **POM License: Eclipse Public License v2.0** - [http://www.eclipse.org/legal/epl-v20.html](http://www.eclipse.org/legal/epl-v20.html)
+
+1. **Group:** org.mockito **Name:** mockito-core **Version:** 2.12.0
+     * **POM Project URL:** [https://github.com/mockito/mockito](https://github.com/mockito/mockito)
+     * **POM License: The MIT License** - [https://github.com/mockito/mockito/blob/master/LICENSE](https://github.com/mockito/mockito/blob/master/LICENSE)
+
+1. **Group:** org.objenesis **Name:** objenesis **Version:** 2.6
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM Project URL:** [http://objenesis.org](http://objenesis.org)
+     * **POM License: Apache 2** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.opentest4j **Name:** opentest4j **Version:** 1.1.1
+     * **POM Project URL:** [https://github.com/ota4j-team/opentest4j](https://github.com/ota4j-team/opentest4j)
+     * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.ow2.asm **Name:** asm **Version:** 6.2.1
+     * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
+     * **POM Project URL:** [http://asm.ow2.org/](http://asm.ow2.org/)
+     * **POM License: BSD** - [http://asm.ow2.org/license.html](http://asm.ow2.org/license.html)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.ow2.asm **Name:** asm **Version:** 7.0
+     * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
+     * **POM Project URL:** [http://asm.ow2.org/](http://asm.ow2.org/)
+     * **POM License: BSD** - [http://asm.ow2.org/license.html](http://asm.ow2.org/license.html)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.ow2.asm **Name:** asm-analysis **Version:** 6.2.1
+     * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
+     * **POM Project URL:** [http://asm.ow2.org/](http://asm.ow2.org/)
+     * **POM License: BSD** - [http://asm.ow2.org/license.html](http://asm.ow2.org/license.html)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.ow2.asm **Name:** asm-commons **Version:** 6.2.1
+     * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
+     * **POM Project URL:** [http://asm.ow2.org/](http://asm.ow2.org/)
+     * **POM License: BSD** - [http://asm.ow2.org/license.html](http://asm.ow2.org/license.html)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.ow2.asm **Name:** asm-tree **Version:** 6.2.1
+     * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
+     * **POM Project URL:** [http://asm.ow2.org/](http://asm.ow2.org/)
+     * **POM License: BSD** - [http://asm.ow2.org/license.html](http://asm.ow2.org/license.html)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.pcollections **Name:** pcollections **Version:** 2.1.2
+     * **POM Project URL:** [http://pcollections.org](http://pcollections.org)
+     * **POM License: The MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
+
+1. **Group:** org.slf4j **Name:** slf4j-api **Version:** 1.7.26
+     * **POM Project URL:** [http://www.slf4j.org](http://www.slf4j.org)
+     * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
+
+1. **Group:** org.slf4j **Name:** slf4j-jdk14 **Version:** 1.7.26
+     * **POM Project URL:** [http://www.slf4j.org](http://www.slf4j.org)
+     * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
+
+1. **Group:** org.threeten **Name:** threetenbp **Version:** 1.3.3
+     * **Manifest Project URL:** [http://www.threeten.org](http://www.threeten.org)
+     * **Manifest license URL:** [https://raw.githubusercontent.com/ThreeTen/threetenbp/master/LICENSE.txt](https://raw.githubusercontent.com/ThreeTen/threetenbp/master/LICENSE.txt)
+     * **POM Project URL:** [https://www.threeten.org/threetenbp](https://www.threeten.org/threetenbp)
+     * **POM License: BSD 3-clause** - [https://raw.githubusercontent.com/ThreeTen/threetenbp/master/LICENSE.txt](https://raw.githubusercontent.com/ThreeTen/threetenbp/master/LICENSE.txt)
+
+    
+        
+ The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
+
+
+This report was generated on **Tue Apr 16 20:21:34 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+
+
+
+    
+# Dependencies of `io.spine:spine-web:1.0.0-SNAPSHOT`
+
+## Runtime
+1. **Group:** com.google.api.grpc **Name:** proto-google-common-protos **Version:** 1.0.0
+     * **POM Project URL:** [https://github.com/googleapis/googleapis](https://github.com/googleapis/googleapis)
+     * **POM License: Apache-2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.code.gson **Name:** gson **Version:** 2.7
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.errorprone **Name:** error_prone_annotations **Version:** 2.3.2
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.guava **Name:** failureaccess **Version:** 1.0.1
+     * **Manifest Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.guava **Name:** guava **Version:** 27.1-jre
+     * **Manifest Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.guava **Name:** listenablefuture **Version:** 9999.0-empty-to-avoid-conflict-with-guava
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.http-client **Name:** google-http-client **Version:** 1.28.0
+     * **Manifest Project URL:** [http://www.google.com/](http://www.google.com/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.http-client **Name:** google-http-client-apache **Version:** 1.28.0
+     * **Manifest Project URL:** [http://www.google.com/](http://www.google.com/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.j2objc **Name:** j2objc-annotations **Version:** 1.1
+     * **POM Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.6.1
+     * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.6.1
+     * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.squareup **Name:** javapoet **Version:** 1.9.0
+     * **POM Project URL:** [http://github.com/square/javapoet/](http://github.com/square/javapoet/)
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.squareup.okhttp **Name:** okhttp **Version:** 2.5.0
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.squareup.okio **Name:** okio **Version:** 1.13.0
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-codec **Name:** commons-codec **Version:** 1.6
+     * **Project URL:** [http://commons.apache.org/codec/](http://commons.apache.org/codec/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-logging **Name:** commons-logging **Version:** 1.1.1
+     * **POM Project URL:** [http://commons.apache.org/logging](http://commons.apache.org/logging)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-core **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-netty **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-okhttp **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-protobuf **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-protobuf-lite **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-stub **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.netty **Name:** netty-buffer **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-codec **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-codec-http **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-codec-http2 **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-codec-socks **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-common **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-handler **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-handler-proxy **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-resolver **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-transport **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.opencensus **Name:** opencensus-api **Version:** 0.18.0
+     * **POM Project URL:** [https://github.com/census-instrumentation/opencensus-java](https://github.com/census-instrumentation/opencensus-java)
+     * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** io.opencensus **Name:** opencensus-contrib-grpc-metrics **Version:** 0.18.0
+     * **POM Project URL:** [https://github.com/census-instrumentation/opencensus-java](https://github.com/census-instrumentation/opencensus-java)
+     * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** io.opencensus **Name:** opencensus-contrib-http-util **Version:** 0.18.0
+     * **POM Project URL:** [https://github.com/census-instrumentation/opencensus-java](https://github.com/census-instrumentation/opencensus-java)
+     * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** javax.servlet **Name:** javax.servlet-api **Version:** 4.0.0
+     * **Manifest Project URL:** [https://javaee.github.io](https://javaee.github.io)
+     * **Manifest license URL:** [https://oss.oracle.com/licenses/CDDL+GPL-1.1](https://oss.oracle.com/licenses/CDDL+GPL-1.1)
+     * **POM Project URL:** [https://javaee.github.io/servlet-spec/](https://javaee.github.io/servlet-spec/)
+     * **POM License: CDDL + GPLv2 with classpath exception** - [https://oss.oracle.com/licenses/CDDL+GPL-1.1](https://oss.oracle.com/licenses/CDDL+GPL-1.1)
+
+1. **Group:** org.apache.httpcomponents **Name:** httpclient **Version:** 4.2.6
+     * **POM Project URL:** [http://hc.apache.org/httpcomponents-client](http://hc.apache.org/httpcomponents-client)
+     * **POM License: Apache License** **License:** LICENSE.txt
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.apache.httpcomponents **Name:** httpcore **Version:** 4.2.5
+     * **POM Project URL:** [http://hc.apache.org/httpcomponents-core-ga](http://hc.apache.org/httpcomponents-core-ga)
+     * **POM License: Apache License** **License:** LICENSE.txt
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.checkerframework **Name:** checker-compat-qual **Version:** 2.5.2
+     * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
+     * **POM License: GNU General Public License, version 2 (GPL2), with the classpath exception** - [http://www.gnu.org/software/classpath/license.html](http://www.gnu.org/software/classpath/license.html)
+     * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
+
+1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.7.0
+     * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
+     * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
+
+1. **Group:** org.codehaus.mojo **Name:** animal-sniffer-annotations **Version:** 1.17
+     * **POM License: MIT license** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.slf4j **Name:** slf4j-api **Version:** 1.7.26
+     * **POM Project URL:** [http://www.slf4j.org](http://www.slf4j.org)
+     * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
+
+## Compile, tests and tooling
+1. **Group:** com.beust **Name:** jcommander **Version:** 1.72
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM Project URL:** [http://jcommander.org](http://jcommander.org)
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** com.github.kevinstern **Name:** software-and-algorithms **Version:** 1.0
+     * **POM Project URL:** [https://www.github.com/KevinStern/software-and-algorithms](https://www.github.com/KevinStern/software-and-algorithms)
+     * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
+
+1. **Group:** com.github.stephenc.jcip **Name:** jcip-annotations **Version:** 1.0-1
+     * **POM Project URL:** [http://stephenc.github.com/jcip-annotations](http://stephenc.github.com/jcip-annotations)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.api.grpc **Name:** proto-google-common-protos **Version:** 1.0.0
+     * **POM Project URL:** [https://github.com/googleapis/googleapis](https://github.com/googleapis/googleapis)
+     * **POM License: Apache-2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.auto **Name:** auto-common **Version:** 0.10
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.auto.value **Name:** auto-value-annotations **Version:** 1.6.3
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.code.findbugs **Name:** jFormatString **Version:** 3.0.0
+     * **POM Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
+     * **POM License: GNU Lesser Public License** - [http://www.gnu.org/licenses/lgpl.html](http://www.gnu.org/licenses/lgpl.html)
+
+1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.0
+     * **POM Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.code.gson **Name:** gson **Version:** 2.7
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.code.gson **Name:** gson **Version:** 2.8.5
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.errorprone **Name:** error_prone_annotation **Version:** 2.3.2
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.errorprone **Name:** error_prone_annotations **Version:** 2.3.2
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.errorprone **Name:** error_prone_check_api **Version:** 2.3.2
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.errorprone **Name:** error_prone_core **Version:** 2.3.2
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.errorprone **Name:** error_prone_type_annotations **Version:** 2.3.2
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.errorprone **Name:** javac **Version:** 9+181-r4173-1
+     * **POM Project URL:** [https://github.com/google/error-prone-javac](https://github.com/google/error-prone-javac)
+     * **POM License: GNU General Public License, version 2, with the Classpath Exception** - [http://openjdk.java.net/legal/gplv2+ce.html](http://openjdk.java.net/legal/gplv2+ce.html)
+
+1. **Group:** com.google.guava **Name:** failureaccess **Version:** 1.0.1
+     * **Manifest Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.guava **Name:** guava **Version:** 23.5-jre
+     * **Manifest Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.guava **Name:** guava **Version:** 27.1-jre
+     * **Manifest Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.guava **Name:** guava-testlib **Version:** 27.1-jre
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.guava **Name:** listenablefuture **Version:** 9999.0-empty-to-avoid-conflict-with-guava
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.http-client **Name:** google-http-client **Version:** 1.28.0
+     * **Manifest Project URL:** [http://www.google.com/](http://www.google.com/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.http-client **Name:** google-http-client-apache **Version:** 1.28.0
+     * **Manifest Project URL:** [http://www.google.com/](http://www.google.com/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.j2objc **Name:** j2objc-annotations **Version:** 1.1
+     * **POM Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.4.0
+     * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.6.1
+     * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.6.1
+     * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.protobuf **Name:** protoc **Version:** 3.6.1
+     * **POM Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.truth **Name:** truth **Version:** 0.43
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.truth.extensions **Name:** truth-java8-extension **Version:** 0.43
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.truth.extensions **Name:** truth-liteproto-extension **Version:** 0.43
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.truth.extensions **Name:** truth-proto-extension **Version:** 0.43
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.googlecode.java-diff-utils **Name:** diffutils **Version:** 1.3.0
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM Project URL:** [http://code.google.com/p/java-diff-utils/](http://code.google.com/p/java-diff-utils/)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.squareup **Name:** javapoet **Version:** 1.9.0
+     * **POM Project URL:** [http://github.com/square/javapoet/](http://github.com/square/javapoet/)
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.squareup.okhttp **Name:** okhttp **Version:** 2.5.0
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.squareup.okio **Name:** okio **Version:** 1.13.0
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-codec **Name:** commons-codec **Version:** 1.6
+     * **Project URL:** [http://commons.apache.org/codec/](http://commons.apache.org/codec/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-io **Name:** commons-io **Version:** 2.6
+     * **Project URL:** [http://commons.apache.org/proper/commons-io/](http://commons.apache.org/proper/commons-io/)
+     * **Manifest license URL:** [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: Apache License, Version 2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-logging **Name:** commons-logging **Version:** 1.1.1
+     * **POM Project URL:** [http://commons.apache.org/logging](http://commons.apache.org/logging)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-core **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-netty **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-okhttp **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-protobuf **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-protobuf-lite **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-stub **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** protoc-gen-grpc-java **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.netty **Name:** netty-buffer **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-codec **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-codec-http **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-codec-http2 **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-codec-socks **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-common **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-handler **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-handler-proxy **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-resolver **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-transport **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.opencensus **Name:** opencensus-api **Version:** 0.18.0
+     * **POM Project URL:** [https://github.com/census-instrumentation/opencensus-java](https://github.com/census-instrumentation/opencensus-java)
+     * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** io.opencensus **Name:** opencensus-contrib-grpc-metrics **Version:** 0.18.0
+     * **POM Project URL:** [https://github.com/census-instrumentation/opencensus-java](https://github.com/census-instrumentation/opencensus-java)
+     * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** io.opencensus **Name:** opencensus-contrib-http-util **Version:** 0.18.0
+     * **POM Project URL:** [https://github.com/census-instrumentation/opencensus-java](https://github.com/census-instrumentation/opencensus-java)
+     * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** javax.servlet **Name:** javax.servlet-api **Version:** 4.0.0
+     * **Manifest Project URL:** [https://javaee.github.io](https://javaee.github.io)
+     * **Manifest license URL:** [https://oss.oracle.com/licenses/CDDL+GPL-1.1](https://oss.oracle.com/licenses/CDDL+GPL-1.1)
+     * **POM Project URL:** [https://javaee.github.io/servlet-spec/](https://javaee.github.io/servlet-spec/)
+     * **POM License: CDDL + GPLv2 with classpath exception** - [https://oss.oracle.com/licenses/CDDL+GPL-1.1](https://oss.oracle.com/licenses/CDDL+GPL-1.1)
+
+1. **Group:** junit **Name:** junit **Version:** 4.12
+     * **POM Project URL:** [http://junit.org](http://junit.org)
+     * **POM License: Eclipse Public License 1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+
+1. **Group:** net.bytebuddy **Name:** byte-buddy **Version:** 1.7.9
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** net.bytebuddy **Name:** byte-buddy-agent **Version:** 1.7.9
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** net.java.dev.javacc **Name:** javacc **Version:** 5.0
+     * **POM Project URL:** [https://javacc.dev.java.net/](https://javacc.dev.java.net/)
+     * **POM License: Berkeley Software Distribution (BSD) License** - [http://www.opensource.org/licenses/bsd-license.html](http://www.opensource.org/licenses/bsd-license.html)
+
+1. **Group:** net.sourceforge.pmd **Name:** pmd-core **Version:** 6.11.0
+     * **POM License: BSD-style** - [http://pmd.sourceforge.net/license.html](http://pmd.sourceforge.net/license.html)
+
+1. **Group:** net.sourceforge.pmd **Name:** pmd-java **Version:** 6.11.0
+     * **POM License: BSD-style** - [http://pmd.sourceforge.net/license.html](http://pmd.sourceforge.net/license.html)
+
+1. **Group:** net.sourceforge.saxon **Name:** saxon **Version:** 9.1.0.8
+     * **POM Project URL:** [http://saxon.sourceforge.net/](http://saxon.sourceforge.net/)
+     * **POM License: Mozilla Public License Version 1.0** - [http://www.mozilla.org/MPL/MPL-1.0.txt](http://www.mozilla.org/MPL/MPL-1.0.txt)
+
+1. **Group:** org.antlr **Name:** antlr4-runtime **Version:** 4.7
+     * **Manifest Project URL:** [http://www.antlr.org](http://www.antlr.org)
+     * **Manifest license URL:** [http://www.antlr.org/license.html](http://www.antlr.org/license.html)
+     * **POM License: The BSD License** - [http://www.antlr.org/license.html](http://www.antlr.org/license.html)
+
+1. **Group:** org.apache.commons **Name:** commons-lang3 **Version:** 3.8.1
+     * **Project URL:** [http://commons.apache.org/proper/commons-lang/](http://commons.apache.org/proper/commons-lang/)
+     * **Manifest license URL:** [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: Apache License, Version 2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.apache.httpcomponents **Name:** httpclient **Version:** 4.2.6
+     * **POM Project URL:** [http://hc.apache.org/httpcomponents-client](http://hc.apache.org/httpcomponents-client)
+     * **POM License: Apache License** **License:** LICENSE.txt
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.apache.httpcomponents **Name:** httpcore **Version:** 4.2.5
+     * **POM Project URL:** [http://hc.apache.org/httpcomponents-core-ga](http://hc.apache.org/httpcomponents-core-ga)
+     * **POM License: Apache License** **License:** LICENSE.txt
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.apiguardian **Name:** apiguardian-api **Version:** 1.0.0
+     * **POM Project URL:** [https://github.com/apiguardian-team/apiguardian](https://github.com/apiguardian-team/apiguardian)
+     * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.checkerframework **Name:** checker-compat-qual **Version:** 2.5.2
+     * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
+     * **POM License: GNU General Public License, version 2 (GPL2), with the classpath exception** - [http://www.gnu.org/software/classpath/license.html](http://www.gnu.org/software/classpath/license.html)
+     * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
+
+1. **Group:** org.checkerframework **Name:** checker-compat-qual **Version:** 2.5.5
+     * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
+     * **POM License: GNU General Public License, version 2 (GPL2), with the classpath exception** - [http://www.gnu.org/software/classpath/license.html](http://www.gnu.org/software/classpath/license.html)
+     * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
+
+1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.5.3
+     * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
+     * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
+
+1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.7.0
+     * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
+     * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
+
+1. **Group:** org.checkerframework **Name:** dataflow **Version:** 2.5.3
+     * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
+     * **POM License: GNU General Public License, version 2 (GPL2), with the classpath exception** - [http://www.gnu.org/software/classpath/license.html](http://www.gnu.org/software/classpath/license.html)
+     * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
+
+1. **Group:** org.checkerframework **Name:** javacutil **Version:** 2.5.3
+     * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
+     * **POM License: GNU General Public License, version 2 (GPL2), with the classpath exception** - [http://www.gnu.org/software/classpath/license.html](http://www.gnu.org/software/classpath/license.html)
+     * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
+
+1. **Group:** org.codehaus.mojo **Name:** animal-sniffer-annotations **Version:** 1.14
+     * **POM License: MIT license** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
+
+1. **Group:** org.codehaus.mojo **Name:** animal-sniffer-annotations **Version:** 1.17
+     * **POM License: MIT license** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.hamcrest **Name:** hamcrest-all **Version:** 1.3
+     * **POM License: New BSD License** - [http://www.opensource.org/licenses/bsd-license.php](http://www.opensource.org/licenses/bsd-license.php)
+
+1. **Group:** org.hamcrest **Name:** hamcrest-core **Version:** 1.3
+     * **POM License: New BSD License** - [http://www.opensource.org/licenses/bsd-license.php](http://www.opensource.org/licenses/bsd-license.php)
+
+1. **Group:** org.jacoco **Name:** org.jacoco.agent **Version:** 0.8.2
+     * **Manifest license URL:** [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+     * **POM License: Eclipse Public License v1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+
+1. **Group:** org.jacoco **Name:** org.jacoco.ant **Version:** 0.8.2
+     * **Manifest license URL:** [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+     * **POM License: Eclipse Public License v1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+
+1. **Group:** org.jacoco **Name:** org.jacoco.core **Version:** 0.8.2
+     * **Manifest license URL:** [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+     * **POM License: Eclipse Public License v1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+
+1. **Group:** org.jacoco **Name:** org.jacoco.report **Version:** 0.8.2
+     * **Manifest license URL:** [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+     * **POM License: Eclipse Public License v1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.4.0
+     * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
+     * **POM License: Eclipse Public License v2.0** - [http://www.eclipse.org/legal/epl-v20.html](http://www.eclipse.org/legal/epl-v20.html)
+
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-engine **Version:** 5.4.0
+     * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
+     * **POM License: Eclipse Public License v2.0** - [http://www.eclipse.org/legal/epl-v20.html](http://www.eclipse.org/legal/epl-v20.html)
+
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-params **Version:** 5.4.0
+     * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
+     * **POM License: Eclipse Public License v2.0** - [http://www.eclipse.org/legal/epl-v20.html](http://www.eclipse.org/legal/epl-v20.html)
+
+1. **Group:** org.junit.platform **Name:** junit-platform-commons **Version:** 1.4.0
+     * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
+     * **POM License: Eclipse Public License v2.0** - [http://www.eclipse.org/legal/epl-v20.html](http://www.eclipse.org/legal/epl-v20.html)
+
+1. **Group:** org.junit.platform **Name:** junit-platform-engine **Version:** 1.4.0
+     * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
+     * **POM License: Eclipse Public License v2.0** - [http://www.eclipse.org/legal/epl-v20.html](http://www.eclipse.org/legal/epl-v20.html)
+
+1. **Group:** org.mockito **Name:** mockito-core **Version:** 2.12.0
+     * **POM Project URL:** [https://github.com/mockito/mockito](https://github.com/mockito/mockito)
+     * **POM License: The MIT License** - [https://github.com/mockito/mockito/blob/master/LICENSE](https://github.com/mockito/mockito/blob/master/LICENSE)
+
+1. **Group:** org.objenesis **Name:** objenesis **Version:** 2.6
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM Project URL:** [http://objenesis.org](http://objenesis.org)
+     * **POM License: Apache 2** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.opentest4j **Name:** opentest4j **Version:** 1.1.1
+     * **POM Project URL:** [https://github.com/ota4j-team/opentest4j](https://github.com/ota4j-team/opentest4j)
+     * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.ow2.asm **Name:** asm **Version:** 6.2.1
+     * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
+     * **POM Project URL:** [http://asm.ow2.org/](http://asm.ow2.org/)
+     * **POM License: BSD** - [http://asm.ow2.org/license.html](http://asm.ow2.org/license.html)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.ow2.asm **Name:** asm **Version:** 7.0
+     * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
+     * **POM Project URL:** [http://asm.ow2.org/](http://asm.ow2.org/)
+     * **POM License: BSD** - [http://asm.ow2.org/license.html](http://asm.ow2.org/license.html)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.ow2.asm **Name:** asm-analysis **Version:** 6.2.1
+     * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
+     * **POM Project URL:** [http://asm.ow2.org/](http://asm.ow2.org/)
+     * **POM License: BSD** - [http://asm.ow2.org/license.html](http://asm.ow2.org/license.html)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.ow2.asm **Name:** asm-commons **Version:** 6.2.1
+     * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
+     * **POM Project URL:** [http://asm.ow2.org/](http://asm.ow2.org/)
+     * **POM License: BSD** - [http://asm.ow2.org/license.html](http://asm.ow2.org/license.html)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.ow2.asm **Name:** asm-tree **Version:** 6.2.1
+     * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
+     * **POM Project URL:** [http://asm.ow2.org/](http://asm.ow2.org/)
+     * **POM License: BSD** - [http://asm.ow2.org/license.html](http://asm.ow2.org/license.html)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.pcollections **Name:** pcollections **Version:** 2.1.2
+     * **POM Project URL:** [http://pcollections.org](http://pcollections.org)
+     * **POM License: The MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
+
+1. **Group:** org.slf4j **Name:** slf4j-api **Version:** 1.7.26
+     * **POM Project URL:** [http://www.slf4j.org](http://www.slf4j.org)
+     * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
+
+1. **Group:** org.slf4j **Name:** slf4j-jdk14 **Version:** 1.7.26
+     * **POM Project URL:** [http://www.slf4j.org](http://www.slf4j.org)
+     * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
+
+    
+        
+ The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
+
+
+This report was generated on **Tue Apr 16 20:21:35 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+
+
+
+    
+# Dependencies of `io.spine:spine-web-tests:1.0.0-SNAPSHOT`
+
+## Runtime
+1. **Group:** com.fasterxml.jackson.core **Name:** jackson-annotations **Version:** 2.9.0
+     * **Project URL:** [http://github.com/FasterXML/jackson](http://github.com/FasterXML/jackson)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.fasterxml.jackson.core **Name:** jackson-core **Version:** 2.9.6
+     * **Project URL:** [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.fasterxml.jackson.core **Name:** jackson-databind **Version:** 2.9.6
+     * **Project URL:** [http://github.com/FasterXML/jackson](http://github.com/FasterXML/jackson)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.api **Name:** api-common **Version:** 1.7.0
+     * **POM Project URL:** [https://github.com/googleapis](https://github.com/googleapis)
+     * **POM License: BSD** - [https://github.com/googleapis/api-common-java/blob/master/LICENSE](https://github.com/googleapis/api-common-java/blob/master/LICENSE)
+
+1. **Group:** com.google.api **Name:** gax **Version:** 1.30.0
+     * **POM Project URL:** [https://github.com/googleapis](https://github.com/googleapis)
+     * **POM License: BSD** - [https://github.com/googleapis/gax-java/blob/master/LICENSE](https://github.com/googleapis/gax-java/blob/master/LICENSE)
+
+1. **Group:** com.google.api **Name:** gax-grpc **Version:** 1.30.0
+     * **POM Project URL:** [https://github.com/googleapis](https://github.com/googleapis)
+     * **POM License: BSD** - [https://github.com/googleapis/gax-java/blob/master/LICENSE](https://github.com/googleapis/gax-java/blob/master/LICENSE)
+
+1. **Group:** com.google.api **Name:** gax-httpjson **Version:** 0.47.0
+     * **POM Project URL:** [https://github.com/googleapis](https://github.com/googleapis)
+     * **POM License: BSD** - [https://github.com/googleapis/gax-java/blob/master/LICENSE](https://github.com/googleapis/gax-java/blob/master/LICENSE)
+
+1. **Group:** com.google.api-client **Name:** google-api-client **Version:** 1.25.0
+     * **Manifest Project URL:** [https://developers.google.com/api-client-library/java/](https://developers.google.com/api-client-library/java/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.api-client **Name:** google-api-client-gson **Version:** 1.25.0
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.api.grpc **Name:** proto-google-cloud-firestore-v1beta1 **Version:** 0.26.0
+     * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.api.grpc **Name:** proto-google-common-protos **Version:** 1.0.0
+     * **POM Project URL:** [https://github.com/googleapis/googleapis](https://github.com/googleapis/googleapis)
+     * **POM License: Apache-2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.api.grpc **Name:** proto-google-iam-v1 **Version:** 0.1.28
+     * **POM Project URL:** [https://github.com/googleapis/googleapis](https://github.com/googleapis/googleapis)
+     * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.apis **Name:** google-api-services-storage **Version:** v1-rev135-1.24.1
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.appengine **Name:** appengine-api-1.0-sdk **Version:** 1.9.70
+     * **POM License: Google App Engine Terms of Service** - [http://code.google.com/appengine/terms.html](http://code.google.com/appengine/terms.html)
+
+1. **Group:** com.google.auth **Name:** google-auth-library-credentials **Version:** 0.11.0
+     * **POM License: BSD New license** - [http://opensource.org/licenses/BSD-3-Clause](http://opensource.org/licenses/BSD-3-Clause)
+
+1. **Group:** com.google.auth **Name:** google-auth-library-oauth2-http **Version:** 0.11.0
+     * **POM License: BSD New license** - [http://opensource.org/licenses/BSD-3-Clause](http://opensource.org/licenses/BSD-3-Clause)
+
+1. **Group:** com.google.auto.value **Name:** auto-value **Version:** 1.4
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.cloud **Name:** google-cloud-core **Version:** 1.43.0
+     * **POM Project URL:** [https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core](https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core)
+     * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.cloud **Name:** google-cloud-core-grpc **Version:** 1.43.0
+     * **POM Project URL:** [https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core-grpc](https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core-grpc)
+     * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.cloud **Name:** google-cloud-core-http **Version:** 1.43.0
+     * **POM Project URL:** [https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core-http](https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core-http)
+     * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.cloud **Name:** google-cloud-firestore **Version:** 0.61.0-beta
+     * **POM Project URL:** [https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-firestore
+  ](https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-firestore
+  )
+     * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.cloud **Name:** google-cloud-storage **Version:** 1.43.0
+     * **POM Project URL:** [https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-storage](https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-storage)
+     * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.code.gson **Name:** gson **Version:** 2.7
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.errorprone **Name:** error_prone_annotations **Version:** 2.3.2
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.firebase **Name:** firebase-admin **Version:** 6.7.0
+     * **POM Project URL:** [https://firebase.google.com/](https://firebase.google.com/)
+     * **POM License: Apache License, Version 2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.guava **Name:** failureaccess **Version:** 1.0.1
+     * **Manifest Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.guava **Name:** guava **Version:** 27.1-jre
+     * **Manifest Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.guava **Name:** listenablefuture **Version:** 9999.0-empty-to-avoid-conflict-with-guava
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.http-client **Name:** google-http-client **Version:** 1.28.0
+     * **Manifest Project URL:** [http://www.google.com/](http://www.google.com/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.http-client **Name:** google-http-client-apache **Version:** 1.28.0
+     * **Manifest Project URL:** [http://www.google.com/](http://www.google.com/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.http-client **Name:** google-http-client-appengine **Version:** 1.24.1
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.http-client **Name:** google-http-client-gson **Version:** 1.25.0
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.http-client **Name:** google-http-client-jackson **Version:** 1.24.1
+     * **Manifest Project URL:** [http://www.google.com/](http://www.google.com/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.http-client **Name:** google-http-client-jackson2 **Version:** 1.25.0
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.j2objc **Name:** j2objc-annotations **Version:** 1.1
+     * **POM Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.oauth-client **Name:** google-oauth-client **Version:** 1.25.0
+     * **Manifest Project URL:** [http://www.google.com/](http://www.google.com/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.6.1
+     * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.6.1
+     * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.squareup **Name:** javapoet **Version:** 1.9.0
+     * **POM Project URL:** [http://github.com/square/javapoet/](http://github.com/square/javapoet/)
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.squareup.okhttp **Name:** okhttp **Version:** 2.5.0
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.squareup.okio **Name:** okio **Version:** 1.13.0
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-beanutils **Name:** commons-beanutils **Version:** 1.9.2
+     * **Project URL:** [http://commons.apache.org/proper/commons-beanutils/](http://commons.apache.org/proper/commons-beanutils/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-codec **Name:** commons-codec **Version:** 1.6
+     * **Project URL:** [http://commons.apache.org/codec/](http://commons.apache.org/codec/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-collections **Name:** commons-collections **Version:** 3.2.2
+     * **Project URL:** [http://commons.apache.org/collections/](http://commons.apache.org/collections/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-digester **Name:** commons-digester **Version:** 1.8.1
+     * **Project URL:** [http://commons.apache.org/digester/](http://commons.apache.org/digester/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-logging **Name:** commons-logging **Version:** 1.2
+     * **Project URL:** [http://commons.apache.org/proper/commons-logging/](http://commons.apache.org/proper/commons-logging/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-validator **Name:** commons-validator **Version:** 1.6
+     * **Project URL:** [http://commons.apache.org/proper/commons-validator/](http://commons.apache.org/proper/commons-validator/)
+     * **Manifest license URL:** [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: Apache License, Version 2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** io.grpc **Name:** grpc-auth **Version:** 1.13.1
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-core **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-netty **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-netty-shaded **Version:** 1.13.1
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-okhttp **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-protobuf **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-protobuf-lite **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-stub **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.netty **Name:** netty-buffer **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-codec **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-codec-http **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-codec-http2 **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-codec-socks **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-common **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-handler **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-handler-proxy **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-resolver **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-transport **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.opencensus **Name:** opencensus-api **Version:** 0.18.0
+     * **POM Project URL:** [https://github.com/census-instrumentation/opencensus-java](https://github.com/census-instrumentation/opencensus-java)
+     * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** io.opencensus **Name:** opencensus-contrib-grpc-metrics **Version:** 0.18.0
+     * **POM Project URL:** [https://github.com/census-instrumentation/opencensus-java](https://github.com/census-instrumentation/opencensus-java)
+     * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** io.opencensus **Name:** opencensus-contrib-grpc-util **Version:** 0.15.0
+     * **POM Project URL:** [https://github.com/census-instrumentation/opencensus-java](https://github.com/census-instrumentation/opencensus-java)
+     * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** io.opencensus **Name:** opencensus-contrib-http-util **Version:** 0.18.0
+     * **POM Project URL:** [https://github.com/census-instrumentation/opencensus-java](https://github.com/census-instrumentation/opencensus-java)
+     * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** javax.servlet **Name:** javax.servlet-api **Version:** 4.0.0
+     * **Manifest Project URL:** [https://javaee.github.io](https://javaee.github.io)
+     * **Manifest license URL:** [https://oss.oracle.com/licenses/CDDL+GPL-1.1](https://oss.oracle.com/licenses/CDDL+GPL-1.1)
+     * **POM Project URL:** [https://javaee.github.io/servlet-spec/](https://javaee.github.io/servlet-spec/)
+     * **POM License: CDDL + GPLv2 with classpath exception** - [https://oss.oracle.com/licenses/CDDL+GPL-1.1](https://oss.oracle.com/licenses/CDDL+GPL-1.1)
+
+1. **Group:** joda-time **Name:** joda-time **Version:** 2.9.2
+     * **Project URL:** [http://www.joda.org/joda-time/](http://www.joda.org/joda-time/)
+     * **Manifest License:** Apache 2.0 (Not packaged)
+     * **POM License: Apache 2** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.apache.httpcomponents **Name:** httpclient **Version:** 4.2.6
+     * **POM Project URL:** [http://hc.apache.org/httpcomponents-client](http://hc.apache.org/httpcomponents-client)
+     * **POM License: Apache License** **License:** LICENSE.txt
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.apache.httpcomponents **Name:** httpcore **Version:** 4.2.5
+     * **POM Project URL:** [http://hc.apache.org/httpcomponents-core-ga](http://hc.apache.org/httpcomponents-core-ga)
+     * **POM License: Apache License** **License:** LICENSE.txt
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.checkerframework **Name:** checker-compat-qual **Version:** 2.5.2
+     * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
+     * **POM License: GNU General Public License, version 2 (GPL2), with the classpath exception** - [http://www.gnu.org/software/classpath/license.html](http://www.gnu.org/software/classpath/license.html)
+     * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
+
+1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.7.0
+     * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
+     * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
+
+1. **Group:** org.codehaus.jackson **Name:** jackson-core-asl **Version:** 1.9.11
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM Project URL:** [http://jackson.codehaus.org](http://jackson.codehaus.org)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.codehaus.mojo **Name:** animal-sniffer-annotations **Version:** 1.17
+     * **POM License: MIT license** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.json **Name:** json **Version:** 20160810
+     * **Manifest license URL:** [http://json.org/license.html](http://json.org/license.html)
+     * **POM Project URL:** [https://github.com/douglascrockford/JSON-java](https://github.com/douglascrockford/JSON-java)
+     * **POM License: The JSON License** - [http://json.org/license.html](http://json.org/license.html)
+
+1. **Group:** org.slf4j **Name:** slf4j-api **Version:** 1.7.26
+     * **POM Project URL:** [http://www.slf4j.org](http://www.slf4j.org)
+     * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
+
+1. **Group:** org.slf4j **Name:** slf4j-jdk14 **Version:** 1.7.26
+     * **POM Project URL:** [http://www.slf4j.org](http://www.slf4j.org)
+     * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
+
+1. **Group:** org.threeten **Name:** threetenbp **Version:** 1.3.3
+     * **Manifest Project URL:** [http://www.threeten.org](http://www.threeten.org)
+     * **Manifest license URL:** [https://raw.githubusercontent.com/ThreeTen/threetenbp/master/LICENSE.txt](https://raw.githubusercontent.com/ThreeTen/threetenbp/master/LICENSE.txt)
+     * **POM Project URL:** [https://www.threeten.org/threetenbp](https://www.threeten.org/threetenbp)
+     * **POM License: BSD 3-clause** - [https://raw.githubusercontent.com/ThreeTen/threetenbp/master/LICENSE.txt](https://raw.githubusercontent.com/ThreeTen/threetenbp/master/LICENSE.txt)
+
+## Compile, tests and tooling
+1. **Group:** com.beust **Name:** jcommander **Version:** 1.72
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM Project URL:** [http://jcommander.org](http://jcommander.org)
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** com.fasterxml.jackson.core **Name:** jackson-annotations **Version:** 2.9.0
+     * **Project URL:** [http://github.com/FasterXML/jackson](http://github.com/FasterXML/jackson)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.fasterxml.jackson.core **Name:** jackson-core **Version:** 2.9.6
+     * **Project URL:** [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.fasterxml.jackson.core **Name:** jackson-databind **Version:** 2.9.6
+     * **Project URL:** [http://github.com/FasterXML/jackson](http://github.com/FasterXML/jackson)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.github.kevinstern **Name:** software-and-algorithms **Version:** 1.0
+     * **POM Project URL:** [https://www.github.com/KevinStern/software-and-algorithms](https://www.github.com/KevinStern/software-and-algorithms)
+     * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
+
+1. **Group:** com.github.stephenc.jcip **Name:** jcip-annotations **Version:** 1.0-1
+     * **POM Project URL:** [http://stephenc.github.com/jcip-annotations](http://stephenc.github.com/jcip-annotations)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.api **Name:** api-common **Version:** 1.7.0
+     * **POM Project URL:** [https://github.com/googleapis](https://github.com/googleapis)
+     * **POM License: BSD** - [https://github.com/googleapis/api-common-java/blob/master/LICENSE](https://github.com/googleapis/api-common-java/blob/master/LICENSE)
+
+1. **Group:** com.google.api **Name:** gax **Version:** 1.30.0
+     * **POM Project URL:** [https://github.com/googleapis](https://github.com/googleapis)
+     * **POM License: BSD** - [https://github.com/googleapis/gax-java/blob/master/LICENSE](https://github.com/googleapis/gax-java/blob/master/LICENSE)
+
+1. **Group:** com.google.api **Name:** gax-grpc **Version:** 1.30.0
+     * **POM Project URL:** [https://github.com/googleapis](https://github.com/googleapis)
+     * **POM License: BSD** - [https://github.com/googleapis/gax-java/blob/master/LICENSE](https://github.com/googleapis/gax-java/blob/master/LICENSE)
+
+1. **Group:** com.google.api **Name:** gax-httpjson **Version:** 0.47.0
+     * **POM Project URL:** [https://github.com/googleapis](https://github.com/googleapis)
+     * **POM License: BSD** - [https://github.com/googleapis/gax-java/blob/master/LICENSE](https://github.com/googleapis/gax-java/blob/master/LICENSE)
+
+1. **Group:** com.google.api-client **Name:** google-api-client **Version:** 1.25.0
+     * **Manifest Project URL:** [https://developers.google.com/api-client-library/java/](https://developers.google.com/api-client-library/java/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.api-client **Name:** google-api-client-gson **Version:** 1.25.0
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.api.grpc **Name:** proto-google-cloud-firestore-v1beta1 **Version:** 0.26.0
+     * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.api.grpc **Name:** proto-google-common-protos **Version:** 1.0.0
+     * **POM Project URL:** [https://github.com/googleapis/googleapis](https://github.com/googleapis/googleapis)
+     * **POM License: Apache-2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.api.grpc **Name:** proto-google-iam-v1 **Version:** 0.1.28
+     * **POM Project URL:** [https://github.com/googleapis/googleapis](https://github.com/googleapis/googleapis)
+     * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.apis **Name:** google-api-services-storage **Version:** v1-rev135-1.24.1
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.appengine **Name:** appengine-api-1.0-sdk **Version:** 1.9.70
+     * **POM License: Google App Engine Terms of Service** - [http://code.google.com/appengine/terms.html](http://code.google.com/appengine/terms.html)
+
+1. **Group:** com.google.auth **Name:** google-auth-library-credentials **Version:** 0.11.0
+     * **POM License: BSD New license** - [http://opensource.org/licenses/BSD-3-Clause](http://opensource.org/licenses/BSD-3-Clause)
+
+1. **Group:** com.google.auth **Name:** google-auth-library-oauth2-http **Version:** 0.11.0
+     * **POM License: BSD New license** - [http://opensource.org/licenses/BSD-3-Clause](http://opensource.org/licenses/BSD-3-Clause)
+
+1. **Group:** com.google.auto **Name:** auto-common **Version:** 0.10
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.auto.value **Name:** auto-value **Version:** 1.4
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.auto.value **Name:** auto-value-annotations **Version:** 1.6.3
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.cloud **Name:** google-cloud-core **Version:** 1.43.0
+     * **POM Project URL:** [https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core](https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core)
+     * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.cloud **Name:** google-cloud-core-grpc **Version:** 1.43.0
+     * **POM Project URL:** [https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core-grpc](https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core-grpc)
+     * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.cloud **Name:** google-cloud-core-http **Version:** 1.43.0
+     * **POM Project URL:** [https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core-http](https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-core-http)
+     * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.cloud **Name:** google-cloud-firestore **Version:** 0.61.0-beta
+     * **POM Project URL:** [https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-firestore
+  ](https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-firestore
+  )
+     * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.cloud **Name:** google-cloud-storage **Version:** 1.43.0
+     * **POM Project URL:** [https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-storage](https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-storage)
+     * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.code.findbugs **Name:** jFormatString **Version:** 3.0.0
+     * **POM Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
+     * **POM License: GNU Lesser Public License** - [http://www.gnu.org/licenses/lgpl.html](http://www.gnu.org/licenses/lgpl.html)
+
+1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.0
+     * **POM Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.code.gson **Name:** gson **Version:** 2.7
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.code.gson **Name:** gson **Version:** 2.8.5
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.errorprone **Name:** error_prone_annotation **Version:** 2.3.2
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.errorprone **Name:** error_prone_annotations **Version:** 2.3.2
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.errorprone **Name:** error_prone_check_api **Version:** 2.3.2
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.errorprone **Name:** error_prone_core **Version:** 2.3.2
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.errorprone **Name:** error_prone_type_annotations **Version:** 2.3.2
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.errorprone **Name:** javac **Version:** 9+181-r4173-1
+     * **POM Project URL:** [https://github.com/google/error-prone-javac](https://github.com/google/error-prone-javac)
+     * **POM License: GNU General Public License, version 2, with the Classpath Exception** - [http://openjdk.java.net/legal/gplv2+ce.html](http://openjdk.java.net/legal/gplv2+ce.html)
+
+1. **Group:** com.google.firebase **Name:** firebase-admin **Version:** 6.7.0
+     * **POM Project URL:** [https://firebase.google.com/](https://firebase.google.com/)
+     * **POM License: Apache License, Version 2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.guava **Name:** failureaccess **Version:** 1.0.1
+     * **Manifest Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.guava **Name:** guava **Version:** 23.5-jre
+     * **Manifest Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.guava **Name:** guava **Version:** 27.1-jre
+     * **Manifest Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.guava **Name:** guava-testlib **Version:** 27.1-jre
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.guava **Name:** listenablefuture **Version:** 9999.0-empty-to-avoid-conflict-with-guava
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.http-client **Name:** google-http-client **Version:** 1.25.0
+     * **Manifest Project URL:** [http://www.google.com/](http://www.google.com/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.http-client **Name:** google-http-client **Version:** 1.28.0
+     * **Manifest Project URL:** [http://www.google.com/](http://www.google.com/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.http-client **Name:** google-http-client-apache **Version:** 1.28.0
+     * **Manifest Project URL:** [http://www.google.com/](http://www.google.com/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.http-client **Name:** google-http-client-appengine **Version:** 1.24.1
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.http-client **Name:** google-http-client-gson **Version:** 1.25.0
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.http-client **Name:** google-http-client-jackson **Version:** 1.24.1
+     * **Manifest Project URL:** [http://www.google.com/](http://www.google.com/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.http-client **Name:** google-http-client-jackson2 **Version:** 1.25.0
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.j2objc **Name:** j2objc-annotations **Version:** 1.1
+     * **POM Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.oauth-client **Name:** google-oauth-client **Version:** 1.25.0
+     * **Manifest Project URL:** [http://www.google.com/](http://www.google.com/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.4.0
+     * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.6.1
+     * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.6.1
+     * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.protobuf **Name:** protoc **Version:** 3.6.1
+     * **POM Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.truth **Name:** truth **Version:** 0.43
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.truth.extensions **Name:** truth-java8-extension **Version:** 0.43
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.truth.extensions **Name:** truth-liteproto-extension **Version:** 0.43
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.google.truth.extensions **Name:** truth-proto-extension **Version:** 0.43
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.googlecode.java-diff-utils **Name:** diffutils **Version:** 1.3.0
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM Project URL:** [http://code.google.com/p/java-diff-utils/](http://code.google.com/p/java-diff-utils/)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.squareup **Name:** javapoet **Version:** 1.9.0
+     * **POM Project URL:** [http://github.com/square/javapoet/](http://github.com/square/javapoet/)
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.squareup.okhttp **Name:** okhttp **Version:** 2.5.0
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.squareup.okio **Name:** okio **Version:** 1.13.0
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-beanutils **Name:** commons-beanutils **Version:** 1.9.2
+     * **Project URL:** [http://commons.apache.org/proper/commons-beanutils/](http://commons.apache.org/proper/commons-beanutils/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-codec **Name:** commons-codec **Version:** 1.10
+     * **Project URL:** [http://commons.apache.org/proper/commons-codec/](http://commons.apache.org/proper/commons-codec/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-codec **Name:** commons-codec **Version:** 1.6
+     * **Project URL:** [http://commons.apache.org/codec/](http://commons.apache.org/codec/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-collections **Name:** commons-collections **Version:** 3.2.2
+     * **Project URL:** [http://commons.apache.org/collections/](http://commons.apache.org/collections/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-digester **Name:** commons-digester **Version:** 1.8.1
+     * **Project URL:** [http://commons.apache.org/digester/](http://commons.apache.org/digester/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-io **Name:** commons-io **Version:** 2.6
+     * **Project URL:** [http://commons.apache.org/proper/commons-io/](http://commons.apache.org/proper/commons-io/)
+     * **Manifest license URL:** [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: Apache License, Version 2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-logging **Name:** commons-logging **Version:** 1.2
+     * **Project URL:** [http://commons.apache.org/proper/commons-logging/](http://commons.apache.org/proper/commons-logging/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** commons-validator **Name:** commons-validator **Version:** 1.6
+     * **Project URL:** [http://commons.apache.org/proper/commons-validator/](http://commons.apache.org/proper/commons-validator/)
+     * **Manifest license URL:** [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: Apache License, Version 2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** io.grpc **Name:** grpc-auth **Version:** 1.13.1
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-core **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-netty **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-netty-shaded **Version:** 1.13.1
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-okhttp **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-protobuf **Version:** 1.13.1
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-protobuf **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-protobuf-lite **Version:** 1.13.1
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-protobuf-lite **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** grpc-stub **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.grpc **Name:** protoc-gen-grpc-java **Version:** 1.18.0
+     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1. **Group:** io.netty **Name:** netty-buffer **Version:** 4.1.22.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-buffer **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-codec **Version:** 4.1.22.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-codec **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-codec-http **Version:** 4.1.22.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-codec-http **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-codec-http2 **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-codec-socks **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-common **Version:** 4.1.22.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-common **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-handler **Version:** 4.1.22.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-handler **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-handler-proxy **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-resolver **Version:** 4.1.22.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-resolver **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-transport **Version:** 4.1.22.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.netty **Name:** netty-transport **Version:** 4.1.32.Final
+     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** io.opencensus **Name:** opencensus-api **Version:** 0.18.0
+     * **POM Project URL:** [https://github.com/census-instrumentation/opencensus-java](https://github.com/census-instrumentation/opencensus-java)
+     * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** io.opencensus **Name:** opencensus-contrib-grpc-metrics **Version:** 0.18.0
+     * **POM Project URL:** [https://github.com/census-instrumentation/opencensus-java](https://github.com/census-instrumentation/opencensus-java)
+     * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** io.opencensus **Name:** opencensus-contrib-grpc-util **Version:** 0.15.0
+     * **POM Project URL:** [https://github.com/census-instrumentation/opencensus-java](https://github.com/census-instrumentation/opencensus-java)
+     * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** io.opencensus **Name:** opencensus-contrib-http-util **Version:** 0.15.0
+     * **POM Project URL:** [https://github.com/census-instrumentation/opencensus-java](https://github.com/census-instrumentation/opencensus-java)
+     * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** io.opencensus **Name:** opencensus-contrib-http-util **Version:** 0.18.0
+     * **POM Project URL:** [https://github.com/census-instrumentation/opencensus-java](https://github.com/census-instrumentation/opencensus-java)
+     * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** javax.servlet **Name:** javax.servlet-api **Version:** 4.0.0
+     * **Manifest Project URL:** [https://javaee.github.io](https://javaee.github.io)
+     * **Manifest license URL:** [https://oss.oracle.com/licenses/CDDL+GPL-1.1](https://oss.oracle.com/licenses/CDDL+GPL-1.1)
+     * **POM Project URL:** [https://javaee.github.io/servlet-spec/](https://javaee.github.io/servlet-spec/)
+     * **POM License: CDDL + GPLv2 with classpath exception** - [https://oss.oracle.com/licenses/CDDL+GPL-1.1](https://oss.oracle.com/licenses/CDDL+GPL-1.1)
+
+1. **Group:** joda-time **Name:** joda-time **Version:** 2.9.2
+     * **Project URL:** [http://www.joda.org/joda-time/](http://www.joda.org/joda-time/)
+     * **Manifest License:** Apache 2.0 (Not packaged)
+     * **POM License: Apache 2** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** junit **Name:** junit **Version:** 4.12
+     * **POM Project URL:** [http://junit.org](http://junit.org)
+     * **POM License: Eclipse Public License 1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+
+1. **Group:** net.bytebuddy **Name:** byte-buddy **Version:** 1.7.9
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** net.bytebuddy **Name:** byte-buddy-agent **Version:** 1.7.9
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** net.java.dev.javacc **Name:** javacc **Version:** 5.0
+     * **POM Project URL:** [https://javacc.dev.java.net/](https://javacc.dev.java.net/)
+     * **POM License: Berkeley Software Distribution (BSD) License** - [http://www.opensource.org/licenses/bsd-license.html](http://www.opensource.org/licenses/bsd-license.html)
+
+1. **Group:** net.sourceforge.pmd **Name:** pmd-core **Version:** 6.11.0
+     * **POM License: BSD-style** - [http://pmd.sourceforge.net/license.html](http://pmd.sourceforge.net/license.html)
+
+1. **Group:** net.sourceforge.pmd **Name:** pmd-java **Version:** 6.11.0
+     * **POM License: BSD-style** - [http://pmd.sourceforge.net/license.html](http://pmd.sourceforge.net/license.html)
+
+1. **Group:** net.sourceforge.saxon **Name:** saxon **Version:** 9.1.0.8
+     * **POM Project URL:** [http://saxon.sourceforge.net/](http://saxon.sourceforge.net/)
+     * **POM License: Mozilla Public License Version 1.0** - [http://www.mozilla.org/MPL/MPL-1.0.txt](http://www.mozilla.org/MPL/MPL-1.0.txt)
+
+1. **Group:** org.antlr **Name:** antlr4-runtime **Version:** 4.7
+     * **Manifest Project URL:** [http://www.antlr.org](http://www.antlr.org)
+     * **Manifest license URL:** [http://www.antlr.org/license.html](http://www.antlr.org/license.html)
+     * **POM License: The BSD License** - [http://www.antlr.org/license.html](http://www.antlr.org/license.html)
+
+1. **Group:** org.apache.commons **Name:** commons-lang3 **Version:** 3.8.1
+     * **Project URL:** [http://commons.apache.org/proper/commons-lang/](http://commons.apache.org/proper/commons-lang/)
+     * **Manifest license URL:** [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: Apache License, Version 2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.apache.httpcomponents **Name:** httpclient **Version:** 4.2.6
+     * **POM Project URL:** [http://hc.apache.org/httpcomponents-client](http://hc.apache.org/httpcomponents-client)
+     * **POM License: Apache License** **License:** LICENSE.txt
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.apache.httpcomponents **Name:** httpclient **Version:** 4.5.5
+     * **POM Project URL:** [http://hc.apache.org/httpcomponents-client](http://hc.apache.org/httpcomponents-client)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.apache.httpcomponents **Name:** httpcore **Version:** 4.2.5
+     * **POM Project URL:** [http://hc.apache.org/httpcomponents-core-ga](http://hc.apache.org/httpcomponents-core-ga)
+     * **POM License: Apache License** **License:** LICENSE.txt
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.apache.httpcomponents **Name:** httpcore **Version:** 4.4.9
+     * **POM Project URL:** [http://hc.apache.org/httpcomponents-core-ga](http://hc.apache.org/httpcomponents-core-ga)
+     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.apiguardian **Name:** apiguardian-api **Version:** 1.0.0
+     * **POM Project URL:** [https://github.com/apiguardian-team/apiguardian](https://github.com/apiguardian-team/apiguardian)
+     * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.checkerframework **Name:** checker-compat-qual **Version:** 2.5.2
+     * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
+     * **POM License: GNU General Public License, version 2 (GPL2), with the classpath exception** - [http://www.gnu.org/software/classpath/license.html](http://www.gnu.org/software/classpath/license.html)
+     * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
+
+1. **Group:** org.checkerframework **Name:** checker-compat-qual **Version:** 2.5.5
+     * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
+     * **POM License: GNU General Public License, version 2 (GPL2), with the classpath exception** - [http://www.gnu.org/software/classpath/license.html](http://www.gnu.org/software/classpath/license.html)
+     * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
+
+1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.5.3
+     * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
+     * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
+
+1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.7.0
+     * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
+     * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
+
+1. **Group:** org.checkerframework **Name:** dataflow **Version:** 2.5.3
+     * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
+     * **POM License: GNU General Public License, version 2 (GPL2), with the classpath exception** - [http://www.gnu.org/software/classpath/license.html](http://www.gnu.org/software/classpath/license.html)
+     * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
+
+1. **Group:** org.checkerframework **Name:** javacutil **Version:** 2.5.3
+     * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
+     * **POM License: GNU General Public License, version 2 (GPL2), with the classpath exception** - [http://www.gnu.org/software/classpath/license.html](http://www.gnu.org/software/classpath/license.html)
+     * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
+
+1. **Group:** org.codehaus.jackson **Name:** jackson-core-asl **Version:** 1.9.11
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM Project URL:** [http://jackson.codehaus.org](http://jackson.codehaus.org)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.codehaus.mojo **Name:** animal-sniffer-annotations **Version:** 1.14
+     * **POM License: MIT license** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
+
+1. **Group:** org.codehaus.mojo **Name:** animal-sniffer-annotations **Version:** 1.17
+     * **POM License: MIT license** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.hamcrest **Name:** hamcrest-all **Version:** 1.3
+     * **POM License: New BSD License** - [http://www.opensource.org/licenses/bsd-license.php](http://www.opensource.org/licenses/bsd-license.php)
+
+1. **Group:** org.hamcrest **Name:** hamcrest-core **Version:** 1.3
+     * **POM License: New BSD License** - [http://www.opensource.org/licenses/bsd-license.php](http://www.opensource.org/licenses/bsd-license.php)
+
+1. **Group:** org.jacoco **Name:** org.jacoco.agent **Version:** 0.8.2
+     * **Manifest license URL:** [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+     * **POM License: Eclipse Public License v1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+
+1. **Group:** org.jacoco **Name:** org.jacoco.ant **Version:** 0.8.2
+     * **Manifest license URL:** [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+     * **POM License: Eclipse Public License v1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+
+1. **Group:** org.jacoco **Name:** org.jacoco.core **Version:** 0.8.2
+     * **Manifest license URL:** [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+     * **POM License: Eclipse Public License v1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+
+1. **Group:** org.jacoco **Name:** org.jacoco.report **Version:** 0.8.2
+     * **Manifest license URL:** [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+     * **POM License: Eclipse Public License v1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+
+1. **Group:** org.json **Name:** json **Version:** 20160810
+     * **Manifest license URL:** [http://json.org/license.html](http://json.org/license.html)
+     * **POM Project URL:** [https://github.com/douglascrockford/JSON-java](https://github.com/douglascrockford/JSON-java)
+     * **POM License: The JSON License** - [http://json.org/license.html](http://json.org/license.html)
+
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.4.0
+     * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
+     * **POM License: Eclipse Public License v2.0** - [http://www.eclipse.org/legal/epl-v20.html](http://www.eclipse.org/legal/epl-v20.html)
+
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-engine **Version:** 5.4.0
+     * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
+     * **POM License: Eclipse Public License v2.0** - [http://www.eclipse.org/legal/epl-v20.html](http://www.eclipse.org/legal/epl-v20.html)
+
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-params **Version:** 5.4.0
+     * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
+     * **POM License: Eclipse Public License v2.0** - [http://www.eclipse.org/legal/epl-v20.html](http://www.eclipse.org/legal/epl-v20.html)
+
+1. **Group:** org.junit.platform **Name:** junit-platform-commons **Version:** 1.4.0
+     * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
+     * **POM License: Eclipse Public License v2.0** - [http://www.eclipse.org/legal/epl-v20.html](http://www.eclipse.org/legal/epl-v20.html)
+
+1. **Group:** org.junit.platform **Name:** junit-platform-engine **Version:** 1.4.0
+     * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
+     * **POM License: Eclipse Public License v2.0** - [http://www.eclipse.org/legal/epl-v20.html](http://www.eclipse.org/legal/epl-v20.html)
+
+1. **Group:** org.mockito **Name:** mockito-core **Version:** 2.12.0
+     * **POM Project URL:** [https://github.com/mockito/mockito](https://github.com/mockito/mockito)
+     * **POM License: The MIT License** - [https://github.com/mockito/mockito/blob/master/LICENSE](https://github.com/mockito/mockito/blob/master/LICENSE)
+
+1. **Group:** org.objenesis **Name:** objenesis **Version:** 2.6
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM Project URL:** [http://objenesis.org](http://objenesis.org)
+     * **POM License: Apache 2** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.opentest4j **Name:** opentest4j **Version:** 1.1.1
+     * **POM Project URL:** [https://github.com/ota4j-team/opentest4j](https://github.com/ota4j-team/opentest4j)
+     * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.ow2.asm **Name:** asm **Version:** 6.2.1
+     * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
+     * **POM Project URL:** [http://asm.ow2.org/](http://asm.ow2.org/)
+     * **POM License: BSD** - [http://asm.ow2.org/license.html](http://asm.ow2.org/license.html)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.ow2.asm **Name:** asm **Version:** 7.0
+     * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
+     * **POM Project URL:** [http://asm.ow2.org/](http://asm.ow2.org/)
+     * **POM License: BSD** - [http://asm.ow2.org/license.html](http://asm.ow2.org/license.html)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.ow2.asm **Name:** asm-analysis **Version:** 6.2.1
+     * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
+     * **POM Project URL:** [http://asm.ow2.org/](http://asm.ow2.org/)
+     * **POM License: BSD** - [http://asm.ow2.org/license.html](http://asm.ow2.org/license.html)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.ow2.asm **Name:** asm-commons **Version:** 6.2.1
+     * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
+     * **POM Project URL:** [http://asm.ow2.org/](http://asm.ow2.org/)
+     * **POM License: BSD** - [http://asm.ow2.org/license.html](http://asm.ow2.org/license.html)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.ow2.asm **Name:** asm-tree **Version:** 6.2.1
+     * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
+     * **POM Project URL:** [http://asm.ow2.org/](http://asm.ow2.org/)
+     * **POM License: BSD** - [http://asm.ow2.org/license.html](http://asm.ow2.org/license.html)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** org.pcollections **Name:** pcollections **Version:** 2.1.2
+     * **POM Project URL:** [http://pcollections.org](http://pcollections.org)
+     * **POM License: The MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
+
+1. **Group:** org.slf4j **Name:** slf4j-api **Version:** 1.7.26
+     * **POM Project URL:** [http://www.slf4j.org](http://www.slf4j.org)
+     * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
+
+1. **Group:** org.slf4j **Name:** slf4j-jdk14 **Version:** 1.7.26
+     * **POM Project URL:** [http://www.slf4j.org](http://www.slf4j.org)
+     * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
+
+1. **Group:** org.threeten **Name:** threetenbp **Version:** 1.3.3
+     * **Manifest Project URL:** [http://www.threeten.org](http://www.threeten.org)
+     * **Manifest license URL:** [https://raw.githubusercontent.com/ThreeTen/threetenbp/master/LICENSE.txt](https://raw.githubusercontent.com/ThreeTen/threetenbp/master/LICENSE.txt)
+     * **POM Project URL:** [https://www.threeten.org/threetenbp](https://www.threeten.org/threetenbp)
+     * **POM License: BSD 3-clause** - [https://raw.githubusercontent.com/ThreeTen/threetenbp/master/LICENSE.txt](https://raw.githubusercontent.com/ThreeTen/threetenbp/master/LICENSE.txt)
+
+    
+        
+ The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
+
+
+This report was generated on **Tue Apr 16 20:21:36 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/scripts/js.gradle
+++ b/scripts/js.gradle
@@ -156,6 +156,21 @@ task coverageJs {
     rootProject.check.dependsOn coverageJs
 }
 
+/**
+ * Generates the report on NPM dependencies and their licenses.
+ */
+task npmLicenseReport {
+    
+    doLast {
+        npm 'run', 'license-report'
+    }
+}
+
+/**
+ * Runs NPM license report straight after the Gradle license report.
+ */
+generateLicenseReport.finalizedBy npmLicenseReport
+
 protobuf {
     generatedFilesBaseDir = genProtoBaseDir
     protoc {

--- a/version.gradle
+++ b/version.gradle
@@ -25,7 +25,7 @@ ext {
     spineBaseVersion = SPINE_VERSION
     
     versionToPublish = SPINE_VERSION
-    versionToPublishJs = '0.15.2'
+    versionToPublishJs = '0.15.3'
 
     servletApiVersion = '4.0.0'
 }


### PR DESCRIPTION
This PR enables the reporting of dependencies along with their distribution licenses for `web` artifacts. The resulting report also includes NPM dependencies split into "production" and "development" (as per NPM classification).

In scope of this changeset the vulnerability detected in the NPM dependency tree was addressed. That caused the JS version to be bumped to `0.15.3`.