### PR TITLE
Restore artifacts publishing during Travis CI build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,10 @@ before_install:
 script:
   - ./gradlew check --stacktrace
 
+  # The publishing script should be executed in `script` section in order to
+  # fail the Travis build if execution of this script is failed.
+  - chmod +x ./config/scripts/publish-artifacts.sh
+  - ./config/scripts/publish-artifacts.sh
+
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
In this PR publishing of Spine-web artifacts during Travis CI build on `master` branch was restored.

Note, that `spine-web` NPM package publishing version wasn't changed. The artifacts publication was disabled during the previous Travis build on `master` branch. The `spine-web@0.16.0` will be published after merging of this PR.