### PR TITLE
Remove firebase JS dependency

### DIFF
--- a/client-js/package.json
+++ b/client-js/package.json
@@ -42,6 +42,7 @@
     "babel-preset-env": "^1.6.1",
     "babel-register": "^6.26.0",
     "codecov": "^3.0.0",
+    "firebase": "^5.5.6",
     "license-checker": "^25.0.1",
     "mocha": "^5.2.0",
     "nyc": "^14.0.0",
@@ -49,8 +50,7 @@
     "sinon": "^7.0.0",
     "webpack": "^4.23.1",
     "webpack-cli": "^3.1.2",
-    "webpack-merge": "^4.1.4",
-    "firebase": "^5.5.6"
+    "webpack-merge": "^4.1.4"
   },
   "sideEffects": true,
   "main": "index.js"

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -28,7 +28,6 @@
   },
   "dependencies": {
     "base64-js": "^1.3.0",
-    "firebase": "^5.5.6",
     "google-protobuf": "^3.6.0",
     "isomorphic-fetch": "^2.2.1",
     "uuid": "^3.2.1"
@@ -50,7 +49,8 @@
     "sinon": "^7.0.0",
     "webpack": "^4.23.1",
     "webpack-cli": "^3.1.2",
-    "webpack-merge": "^4.1.4"
+    "webpack-merge": "^4.1.4",
+    "firebase": "^5.5.6"
   },
   "sideEffects": true,
   "main": "index.js"

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spine-web",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "license": "Apache-2.0",
   "description": "A JS client for interacting with Spine applications.",
   "homepage": "https://spine.io",

--- a/firebase-web/src/main/java/io/spine/web/firebase/DatabaseUrls.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/DatabaseUrls.java
@@ -63,6 +63,6 @@ public final class DatabaseUrls {
 
     private static void validate(String url) {
         UrlValidator urlValidator = UrlValidator.getInstance();
-        checkArgument(urlValidator.isValid(url), "The specified database URL %s is invalid");
+        checkArgument(urlValidator.isValid(url), "The specified database URL %s is invalid", url);
     }
 }

--- a/firebase-web/src/test/java/io/spine/web/firebase/query/QueryNodePathTest.java
+++ b/firebase-web/src/test/java/io/spine/web/firebase/query/QueryNodePathTest.java
@@ -126,7 +126,7 @@ class QueryNodePathTest {
 
     private static Query tenantAwareQuery(TenantId tenantId) {
         TestActorRequestFactory requestFactory =
-                TestActorRequestFactory.newInstance(QueryNodePathTest.class, tenantId);
+                new TestActorRequestFactory(QueryNodePathTest.class, tenantId);
         Query query = requestFactory.query()
                                     .all(Any.class);
         return query;

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client-js:1.0.0-SNAPSHOT`
+# Dependencies of `io.spine:spine-client-js:1.0.0-pre7`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -51,12 +51,12 @@
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.fasterxml.jackson.core **Name:** jackson-core **Version:** 2.9.6
+1. **Group:** com.fasterxml.jackson.core **Name:** jackson-core **Version:** 2.9.8
      * **Project URL:** [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.fasterxml.jackson.core **Name:** jackson-databind **Version:** 2.9.6
+1. **Group:** com.fasterxml.jackson.core **Name:** jackson-databind **Version:** 2.9.8
      * **Project URL:** [http://github.com/FasterXML/jackson](http://github.com/FasterXML/jackson)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -249,38 +249,31 @@
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.6.1
-     * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-     * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.7.1
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.6.1
+1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.7.1
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** com.google.protobuf **Name:** protoc **Version:** 3.7.1
      * **POM Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth **Name:** truth **Version:** 0.43
+1. **Group:** com.google.truth **Name:** truth **Version:** 0.44
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-java8-extension **Version:** 0.43
+1. **Group:** com.google.truth.extensions **Name:** truth-java8-extension **Version:** 0.44
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-liteproto-extension **Version:** 0.43
+1. **Group:** com.google.truth.extensions **Name:** truth-liteproto-extension **Version:** 0.44
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-proto-extension **Version:** 0.43
+1. **Group:** com.google.truth.extensions **Name:** truth-proto-extension **Version:** 0.44
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** com.googlecode.java-diff-utils **Name:** diffutils **Version:** 1.3.0
@@ -630,397 +623,52 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 02 19:31:55 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
-#NPM dependencies of `spine-web@0.15.4`
+#NPM dependencies of `spine-web@0.16.0`
 
 ## `Production` dependencies:
 
-1. **@firebase/app-types@0.3.7**
-   * Licenses: Apache-2.0
-   * Repository: https://github.com/firebase/firebase-js-sdk
-1. **@firebase/app@0.3.13**
-   * Licenses: Apache-2.0
-   * Repository: https://github.com/firebase/firebase-js-sdk
-1. **@firebase/auth-types@0.5.5**
-   * Licenses: Apache-2.0
-   * Repository: https://github.com/firebase/firebase-js-sdk
-1. **@firebase/auth@0.9.6**
-   * Licenses: Apache-2.0
-   * Repository: https://github.com/firebase/firebase-js-sdk
-1. **@firebase/database-types@0.3.8**
-   * Licenses: Apache-2.0
-   * Repository: https://github.com/firebase/firebase-js-sdk
-1. **@firebase/database@0.3.16**
-   * Licenses: Apache-2.0
-   * Repository: https://github.com/firebase/firebase-js-sdk
-1. **@firebase/firestore-types@1.1.1**
-   * Licenses: Apache-2.0
-   * Repository: https://github.com/firebase/firebase-js-sdk
-1. **@firebase/firestore@1.1.1**
-   * Licenses: Apache-2.0
-   * Repository: https://github.com/firebase/firebase-js-sdk
-1. **@firebase/functions-types@0.3.2**
-   * Licenses: Apache-2.0
-   * Repository: https://github.com/firebase/firebase-js-sdk
-1. **@firebase/functions@0.4.3**
-   * Licenses: Apache-2.0
-   * Repository: https://github.com/firebase/firebase-js-sdk
-1. **@firebase/logger@0.1.10**
-   * Licenses: Apache-2.0
-   * Repository: https://github.com/firebase/firebase-js-sdk
-1. **@firebase/messaging-types@0.2.8**
-   * Licenses: Apache-2.0
-   * Repository: https://github.com/firebase/firebase-js-sdk
-1. **@firebase/messaging@0.3.15**
-   * Licenses: Apache-2.0
-   * Repository: https://github.com/firebase/firebase-js-sdk
-1. **@firebase/polyfill@0.3.9**
-   * Licenses: Apache-2.0
-   * Repository: https://github.com/firebase/firebase-js-sdk
-1. **@firebase/storage-types@0.2.8**
-   * Licenses: Apache-2.0
-   * Repository: https://github.com/firebase/firebase-js-sdk
-1. **@firebase/storage@0.2.12**
-   * Licenses: Apache-2.0
-   * Repository: https://github.com/firebase/firebase-js-sdk
-1. **@firebase/util@0.2.11**
-   * Licenses: Apache-2.0
-   * Repository: https://github.com/firebase/firebase-js-sdk
-1. **@firebase/webchannel-wrapper@0.2.16**
-   * Licenses: Apache-2.0
-   * Repository: https://github.com/firebase/firebase-js-sdk
-1. **abbrev@1.1.1**
-   * Licenses: ISC
-   * Repository: https://github.com/isaacs/abbrev-js
-1. **ansi-regex@2.1.1**
-   * Licenses: MIT
-   * Repository: https://github.com/chalk/ansi-regex
-1. **aproba@1.2.0**
-   * Licenses: ISC
-   * Repository: https://github.com/iarna/aproba
-1. **are-we-there-yet@1.1.5**
-   * Licenses: ISC
-   * Repository: https://github.com/iarna/are-we-there-yet
-1. **ascli@1.0.1**
-   * Licenses: Apache-2.0
-   * Repository: https://github.com/dcodeIO/ascli
-1. **balanced-match@1.0.0**
-   * Licenses: MIT
-   * Repository: https://github.com/juliangruber/balanced-match
 1. **base64-js@1.3.0**
    * Licenses: MIT
    * Repository: https://github.com/beatgammit/base64-js
-1. **brace-expansion@1.1.11**
-   * Licenses: MIT
-   * Repository: https://github.com/juliangruber/brace-expansion
-1. **bytebuffer@5.0.1**
-   * Licenses: Apache-2.0
-   * Repository: https://github.com/dcodeIO/bytebuffer.js
-1. **camelcase@2.1.1**
-   * Licenses: MIT
-   * Repository: https://github.com/sindresorhus/camelcase
-1. **chownr@1.1.1**
-   * Licenses: ISC
-   * Repository: https://github.com/isaacs/chownr
-1. **cliui@3.2.0**
-   * Licenses: ISC
-   * Repository: https://github.com/yargs/cliui
-1. **code-point-at@1.1.0**
-   * Licenses: MIT
-   * Repository: https://github.com/sindresorhus/code-point-at
-1. **colour@0.7.1**
-   * Licenses: MIT
-   * Repository: https://github.com/dcodeIO/colour.js
-1. **concat-map@0.0.1**
-   * Licenses: MIT
-   * Repository: https://github.com/substack/node-concat-map
-1. **console-control-strings@1.1.0**
-   * Licenses: ISC
-   * Repository: https://github.com/iarna/console-control-strings
-1. **core-js@2.6.5**
-   * Licenses: MIT
-   * Repository: https://github.com/zloirock/core-js
-1. **core-util-is@1.0.2**
-   * Licenses: MIT
-   * Repository: https://github.com/isaacs/core-util-is
-1. **debug@2.6.9**
-   * Licenses: MIT
-   * Repository: https://github.com/visionmedia/debug
-1. **decamelize@1.2.0**
-   * Licenses: MIT
-   * Repository: https://github.com/sindresorhus/decamelize
-1. **deep-extend@0.6.0**
-   * Licenses: MIT
-   * Repository: https://github.com/unclechu/node-deep-extend
-1. **delegates@1.0.0**
-   * Licenses: MIT
-   * Repository: https://github.com/visionmedia/node-delegates
-1. **detect-libc@1.0.3**
-   * Licenses: Apache-2.0
-   * Repository: https://github.com/lovell/detect-libc
-1. **dom-storage@2.1.0**
-   * Licenses: MIT*
-   * Repository: git://git.coolaj86.com/coolaj86/dom-storage.js
 1. **encoding@0.1.12**
    * Licenses: MIT
    * Repository: https://github.com/andris9/encoding
-1. **faye-websocket@0.11.1**
-   * Licenses: MIT
-   * Repository: https://github.com/faye/faye-websocket-node
-1. **firebase@5.9.1**
-   * Licenses: Apache-2.0
-   * Repository: https://github.com/firebase/firebase-js-sdk
-1. **fs-minipass@1.2.5**
-   * Licenses: ISC
-   * Repository: https://github.com/npm/fs-minipass
-1. **fs.realpath@1.0.0**
-   * Licenses: ISC
-   * Repository: https://github.com/isaacs/fs.realpath
-1. **gauge@2.7.4**
-   * Licenses: ISC
-   * Repository: https://github.com/iarna/gauge
-1. **glob@7.1.2**
-   * Licenses: ISC
-   * Repository: https://github.com/isaacs/node-glob
-1. **glob@7.1.3**
-   * Licenses: ISC
-   * Repository: https://github.com/isaacs/node-glob
-1. **google-protobuf@3.6.1**
+1. **google-protobuf@3.7.1**
    * Licenses: BSD-3-Clause
-   * Repository: https://github.com/google/protobuf/tree/master/js
-1. **grpc@1.19.0**
-   * Licenses: Apache-2.0
-   * Repository: https://github.com/grpc/grpc-node
-1. **has-unicode@2.0.1**
-   * Licenses: ISC
-   * Repository: https://github.com/iarna/has-unicode
-1. **http-parser-js@0.5.0**
-   * Licenses: MIT
-   * Repository: https://github.com/creationix/http-parser-js
-1. **iconv-lite@0.4.23**
-   * Licenses: MIT
-   * Repository: https://github.com/ashtuchkin/iconv-lite
+   * Repository: https://github.com/protocolbuffers/protobuf/tree/master/js
 1. **iconv-lite@0.4.24**
    * Licenses: MIT
    * Repository: https://github.com/ashtuchkin/iconv-lite
-1. **ignore-walk@3.0.1**
-   * Licenses: ISC
-   * Repository: https://github.com/isaacs/ignore-walk
-1. **inflight@1.0.6**
-   * Licenses: ISC
-   * Repository: https://github.com/npm/inflight
-1. **inherits@2.0.3**
-   * Licenses: ISC
-   * Repository: https://github.com/isaacs/inherits
-1. **ini@1.3.5**
-   * Licenses: ISC
-   * Repository: https://github.com/isaacs/ini
-1. **invert-kv@1.0.0**
-   * Licenses: MIT
-   * Repository: https://github.com/sindresorhus/invert-kv
-1. **is-fullwidth-code-point@1.0.0**
-   * Licenses: MIT
-   * Repository: https://github.com/sindresorhus/is-fullwidth-code-point
 1. **is-stream@1.1.0**
    * Licenses: MIT
    * Repository: https://github.com/sindresorhus/is-stream
-1. **isarray@1.0.0**
-   * Licenses: MIT
-   * Repository: https://github.com/juliangruber/isarray
 1. **isomorphic-fetch@2.2.1**
    * Licenses: MIT
    * Repository: https://github.com/matthew-andrews/isomorphic-fetch
-1. **lcid@1.0.0**
-   * Licenses: MIT
-   * Repository: https://github.com/sindresorhus/lcid
-1. **lodash.camelcase@4.3.0**
-   * Licenses: MIT
-   * Repository: https://github.com/lodash/lodash
-1. **lodash.clone@4.5.0**
-   * Licenses: MIT
-   * Repository: https://github.com/lodash/lodash
-1. **long@3.2.0**
-   * Licenses: Apache-2.0
-   * Repository: https://github.com/dcodeIO/long.js
-1. **minimatch@3.0.4**
-   * Licenses: ISC
-   * Repository: https://github.com/isaacs/minimatch
-1. **minimist@0.0.8**
-   * Licenses: MIT
-   * Repository: https://github.com/substack/minimist
-1. **minimist@1.2.0**
-   * Licenses: MIT
-   * Repository: https://github.com/substack/minimist
-1. **minipass@2.3.5**
-   * Licenses: ISC
-   * Repository: https://github.com/isaacs/minipass
-1. **minizlib@1.1.1**
-   * Licenses: MIT
-   * Repository: https://github.com/isaacs/minizlib
-1. **mkdirp@0.5.1**
-   * Licenses: MIT
-   * Repository: https://github.com/substack/node-mkdirp
-1. **ms@2.0.0**
-   * Licenses: MIT
-   * Repository: https://github.com/zeit/ms
-1. **nan@2.12.1**
-   * Licenses: MIT
-   * Repository: https://github.com/nodejs/nan
-1. **needle@2.2.4**
-   * Licenses: MIT
-   * Repository: https://github.com/tomas/needle
 1. **node-fetch@1.7.3**
    * Licenses: MIT
    * Repository: https://github.com/bitinn/node-fetch
-1. **node-pre-gyp@0.12.0**
-   * Licenses: BSD-3-Clause
-   * Repository: https://github.com/mapbox/node-pre-gyp
-1. **nopt@4.0.1**
-   * Licenses: ISC
-   * Repository: https://github.com/npm/nopt
-1. **npm-bundled@1.0.5**
-   * Licenses: ISC
-   * Repository: https://github.com/npm/npm-bundled
-1. **npm-packlist@1.1.12**
-   * Licenses: ISC
-   * Repository: https://github.com/npm/npm-packlist
-1. **npmlog@4.1.2**
-   * Licenses: ISC
-   * Repository: https://github.com/npm/npmlog
-1. **number-is-nan@1.0.1**
-   * Licenses: MIT
-   * Repository: https://github.com/sindresorhus/number-is-nan
-1. **object-assign@4.1.1**
-   * Licenses: MIT
-   * Repository: https://github.com/sindresorhus/object-assign
-1. **once@1.4.0**
-   * Licenses: ISC
-   * Repository: https://github.com/isaacs/once
-1. **optjs@3.2.2**
-   * Licenses: MIT
-   * Repository: https://github.com/dcodeIO/opt.js
-1. **os-homedir@1.0.2**
-   * Licenses: MIT
-   * Repository: https://github.com/sindresorhus/os-homedir
-1. **os-locale@1.4.0**
-   * Licenses: MIT
-   * Repository: https://github.com/sindresorhus/os-locale
-1. **os-tmpdir@1.0.2**
-   * Licenses: MIT
-   * Repository: https://github.com/sindresorhus/os-tmpdir
-1. **osenv@0.1.5**
-   * Licenses: ISC
-   * Repository: https://github.com/npm/osenv
-1. **path-is-absolute@1.0.1**
-   * Licenses: MIT
-   * Repository: https://github.com/sindresorhus/path-is-absolute
-1. **process-nextick-args@2.0.0**
-   * Licenses: MIT
-   * Repository: https://github.com/calvinmetcalf/process-nextick-args
-1. **promise-polyfill@8.1.0**
-   * Licenses: MIT
-   * Repository: https://github.com/taylorhakes/promise-polyfill
-1. **protobufjs@5.0.3**
-   * Licenses: Apache-2.0
-   * Repository: https://github.com/dcodeIO/protobuf.js
-1. **rc@1.2.8**
-   * Licenses: (BSD-2-Clause OR MIT OR Apache-2.0)
-   * Repository: https://github.com/dominictarr/rc
-1. **readable-stream@2.3.6**
-   * Licenses: MIT
-   * Repository: https://github.com/nodejs/readable-stream
-1. **rimraf@2.6.2**
-   * Licenses: ISC
-   * Repository: https://github.com/isaacs/rimraf
-1. **rxjs@6.3.3**
+1. **rxjs@6.5.1**
    * Licenses: Apache-2.0
    * Repository: https://github.com/reactivex/rxjs
-1. **safe-buffer@5.1.2**
-   * Licenses: MIT
-   * Repository: https://github.com/feross/safe-buffer
 1. **safer-buffer@2.1.2**
    * Licenses: MIT
    * Repository: https://github.com/ChALkeR/safer-buffer
-1. **sax@1.2.4**
-   * Licenses: ISC
-   * Repository: https://github.com/isaacs/sax-js
-1. **semver@5.6.0**
-   * Licenses: ISC
-   * Repository: https://github.com/npm/node-semver
-1. **set-blocking@2.0.0**
-   * Licenses: ISC
-   * Repository: https://github.com/yargs/set-blocking
-1. **signal-exit@3.0.2**
-   * Licenses: ISC
-   * Repository: https://github.com/tapjs/signal-exit
-1. **spine-web@0.15.4**
+1. **spine-web@0.16.0**
    * Licenses: Apache-2.0
    * Repository: https://github.com/SpineEventEngine/web
-1. **string-width@1.0.2**
-   * Licenses: MIT
-   * Repository: https://github.com/sindresorhus/string-width
-1. **string_decoder@1.1.1**
-   * Licenses: MIT
-   * Repository: https://github.com/nodejs/string_decoder
-1. **strip-ansi@3.0.1**
-   * Licenses: MIT
-   * Repository: https://github.com/chalk/strip-ansi
-1. **strip-json-comments@2.0.1**
-   * Licenses: MIT
-   * Repository: https://github.com/sindresorhus/strip-json-comments
-1. **tar@4.4.8**
-   * Licenses: ISC
-   * Repository: https://github.com/npm/node-tar
-1. **tslib@1.9.0**
-   * Licenses: Apache-2.0
-   * Repository: https://github.com/Microsoft/tslib
 1. **tslib@1.9.3**
    * Licenses: Apache-2.0
    * Repository: https://github.com/Microsoft/tslib
-1. **util-deprecate@1.0.2**
-   * Licenses: MIT
-   * Repository: https://github.com/TooTallNate/util-deprecate
 1. **uuid@3.3.2**
    * Licenses: MIT
    * Repository: https://github.com/kelektiv/node-uuid
-1. **websocket-driver@0.7.0**
-   * Licenses: MIT
-   * Repository: https://github.com/faye/websocket-driver-node
-1. **websocket-extensions@0.1.3**
-   * Licenses: MIT
-   * Repository: https://github.com/faye/websocket-extensions-node
-1. **whatwg-fetch@2.0.4**
-   * Licenses: MIT
-   * Repository: https://github.com/github/fetch
 1. **whatwg-fetch@3.0.0**
    * Licenses: MIT
    * Repository: https://github.com/github/fetch
-1. **wide-align@1.1.3**
-   * Licenses: ISC
-   * Repository: https://github.com/iarna/wide-align
-1. **window-size@0.1.4**
-   * Licenses: MIT
-   * Repository: https://github.com/jonschlinkert/window-size
-1. **wrap-ansi@2.1.0**
-   * Licenses: MIT
-   * Repository: https://github.com/chalk/wrap-ansi
-1. **wrappy@1.0.2**
-   * Licenses: ISC
-   * Repository: https://github.com/npm/wrappy
-1. **xmlhttprequest@1.8.0**
-   * Licenses: MIT
-   * Repository: https://github.com/driverdan/node-XMLHttpRequest
-1. **y18n@3.2.1**
-   * Licenses: ISC
-   * Repository: https://github.com/yargs/y18n
-1. **yallist@3.0.3**
-   * Licenses: ISC
-   * Repository: https://github.com/isaacs/yallist
-1. **yargs@3.32.0**
-   * Licenses: MIT
-   * Repository: https://github.com/bcoe/yargs
 
 
 
@@ -1029,7 +677,7 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **@babel/code-frame@7.0.0**
    * Licenses: MIT
    * Repository: https://github.com/babel/babel/tree/master/packages/babel-code-frame
-1. **@babel/generator@7.4.0**
+1. **@babel/generator@7.4.4**
    * Licenses: MIT
    * Repository: https://github.com/babel/babel/tree/master/packages/babel-generator
 1. **@babel/helper-function-name@7.1.0**
@@ -1038,91 +686,160 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **@babel/helper-get-function-arity@7.0.0**
    * Licenses: MIT
    * Repository: https://github.com/babel/babel/tree/master/packages/babel-helper-get-function-arity
-1. **@babel/helper-split-export-declaration@7.4.0**
+1. **@babel/helper-split-export-declaration@7.4.4**
    * Licenses: MIT
    * Repository: https://github.com/babel/babel/tree/master/packages/babel-helper-split-export-declaration
 1. **@babel/highlight@7.0.0**
    * Licenses: MIT
    * Repository: https://github.com/babel/babel/tree/master/packages/babel-highlight
-1. **@babel/parser@7.4.3**
+1. **@babel/parser@7.4.4**
    * Licenses: MIT
    * Repository: https://github.com/babel/babel/tree/master/packages/babel-parser
-1. **@babel/template@7.4.0**
+1. **@babel/template@7.4.4**
    * Licenses: MIT
    * Repository: https://github.com/babel/babel/tree/master/packages/babel-template
-1. **@babel/traverse@7.4.3**
+1. **@babel/traverse@7.4.4**
    * Licenses: MIT
    * Repository: https://github.com/babel/babel/tree/master/packages/babel-traverse
-1. **@babel/types@7.4.0**
+1. **@babel/types@7.4.4**
    * Licenses: MIT
    * Repository: https://github.com/babel/babel/tree/master/packages/babel-types
-1. **@sinonjs/commons@1.3.0**
+1. **@firebase/app-types@0.3.10**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk
+1. **@firebase/app@0.3.17**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk
+1. **@firebase/auth-types@0.6.1**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk
+1. **@firebase/auth@0.10.2**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk
+1. **@firebase/database-types@0.3.11**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk
+1. **@firebase/database@0.3.20**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk
+1. **@firebase/firestore-types@1.2.1**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk
+1. **@firebase/firestore@1.2.2**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk
+1. **@firebase/functions-types@0.3.5**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk
+1. **@firebase/functions@0.4.6**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk
+1. **@firebase/installations-types@0.1.0**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk
+1. **@firebase/installations@0.1.0**
+   * Licenses: Apache-2.0
+   * Repository: unknown
+1. **@firebase/logger@0.1.13**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk
+1. **@firebase/messaging-types@0.2.11**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk
+1. **@firebase/messaging@0.3.19**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk
+1. **@firebase/performance-types@0.0.1**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk/tree/master/packages/performance-types
+1. **@firebase/performance@0.2.0**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk/tree/master/packages/performance
+1. **@firebase/polyfill@0.3.13**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk
+1. **@firebase/storage-types@0.2.11**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk
+1. **@firebase/storage@0.2.15**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk
+1. **@firebase/util@0.2.14**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk
+1. **@firebase/webchannel-wrapper@0.2.19**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk
+1. **@sinonjs/commons@1.4.0**
    * Licenses: BSD-3-Clause
    * Repository: https://github.com/sinonjs/commons
-1. **@sinonjs/formatio@3.1.0**
+1. **@sinonjs/formatio@3.2.1**
    * Licenses: BSD-3-Clause
    * Repository: https://github.com/sinonjs/formatio
-1. **@sinonjs/samsam@3.0.2**
+1. **@sinonjs/samsam@3.3.1**
    * Licenses: BSD-3-Clause
    * Repository: https://github.com/sinonjs/samsam
-1. **@webassemblyjs/ast@1.7.11**
+1. **@sinonjs/text-encoding@0.7.1**
+   * Licenses: (Unlicense OR Apache-2.0)
+   * Repository: https://github.com/inexorabletash/text-encoding
+1. **@webassemblyjs/ast@1.8.5**
    * Licenses: MIT
    * Repository: https://github.com/xtuc/webassemblyjs
-1. **@webassemblyjs/floating-point-hex-parser@1.7.11**
+1. **@webassemblyjs/floating-point-hex-parser@1.8.5**
    * Licenses: MIT
    * Repository: https://github.com/xtuc/webassemblyjs
-1. **@webassemblyjs/helper-api-error@1.7.11**
+1. **@webassemblyjs/helper-api-error@1.8.5**
    * Licenses: MIT
    * Repository: unknown
-1. **@webassemblyjs/helper-buffer@1.7.11**
+1. **@webassemblyjs/helper-buffer@1.8.5**
    * Licenses: MIT
    * Repository: https://github.com/xtuc/webassemblyjs
-1. **@webassemblyjs/helper-code-frame@1.7.11**
+1. **@webassemblyjs/helper-code-frame@1.8.5**
    * Licenses: MIT
    * Repository: https://github.com/xtuc/webassemblyjs
-1. **@webassemblyjs/helper-fsm@1.7.11**
+1. **@webassemblyjs/helper-fsm@1.8.5**
    * Licenses: ISC
    * Repository: unknown
-1. **@webassemblyjs/helper-module-context@1.7.11**
+1. **@webassemblyjs/helper-module-context@1.8.5**
    * Licenses: MIT
    * Repository: https://github.com/xtuc/webassemblyjs
-1. **@webassemblyjs/helper-wasm-bytecode@1.7.11**
+1. **@webassemblyjs/helper-wasm-bytecode@1.8.5**
    * Licenses: MIT
    * Repository: https://github.com/xtuc/webassemblyjs
-1. **@webassemblyjs/helper-wasm-section@1.7.11**
+1. **@webassemblyjs/helper-wasm-section@1.8.5**
    * Licenses: MIT
    * Repository: https://github.com/xtuc/webassemblyjs
-1. **@webassemblyjs/ieee754@1.7.11**
+1. **@webassemblyjs/ieee754@1.8.5**
    * Licenses: MIT
    * Repository: unknown
-1. **@webassemblyjs/leb128@1.7.11**
+1. **@webassemblyjs/leb128@1.8.5**
    * Licenses: MIT
    * Repository: unknown
-1. **@webassemblyjs/utf8@1.7.11**
+1. **@webassemblyjs/utf8@1.8.5**
    * Licenses: MIT
    * Repository: https://github.com/xtuc/webassemblyjs
-1. **@webassemblyjs/wasm-edit@1.7.11**
+1. **@webassemblyjs/wasm-edit@1.8.5**
    * Licenses: MIT
    * Repository: https://github.com/xtuc/webassemblyjs
-1. **@webassemblyjs/wasm-gen@1.7.11**
+1. **@webassemblyjs/wasm-gen@1.8.5**
    * Licenses: MIT
    * Repository: https://github.com/xtuc/webassemblyjs
-1. **@webassemblyjs/wasm-opt@1.7.11**
+1. **@webassemblyjs/wasm-opt@1.8.5**
    * Licenses: MIT
    * Repository: https://github.com/xtuc/webassemblyjs
-1. **@webassemblyjs/wasm-parser@1.7.11**
+1. **@webassemblyjs/wasm-parser@1.8.5**
    * Licenses: MIT
    * Repository: https://github.com/xtuc/webassemblyjs
-1. **@webassemblyjs/wast-parser@1.7.11**
+1. **@webassemblyjs/wast-parser@1.8.5**
    * Licenses: MIT
    * Repository: https://github.com/xtuc/webassemblyjs
-1. **@webassemblyjs/wast-printer@1.7.11**
+1. **@webassemblyjs/wast-printer@1.8.5**
    * Licenses: MIT
    * Repository: https://github.com/xtuc/webassemblyjs
 1. **@xtuc/ieee754@1.2.0**
    * Licenses: BSD-3-Clause
    * Repository: https://github.com/feross/ieee754
-1. **@xtuc/long@4.2.1**
+1. **@xtuc/long@4.2.2**
    * Licenses: Apache-2.0
    * Repository: https://github.com/dcodeIO/long.js
 1. **abbrev@1.1.1**
@@ -1131,18 +848,24 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **acorn-dynamic-import@4.0.0**
    * Licenses: MIT
    * Repository: https://github.com/kesne/acorn-dynamic-import
-1. **acorn@6.0.5**
+1. **acorn@6.1.1**
    * Licenses: MIT
    * Repository: https://github.com/acornjs/acorn
+1. **agent-base@4.2.1**
+   * Licenses: MIT
+   * Repository: https://github.com/TooTallNate/node-agent-base
 1. **ajv-errors@1.0.1**
    * Licenses: MIT
    * Repository: https://github.com/epoberezkin/ajv-errors
-1. **ajv-keywords@3.2.0**
+1. **ajv-keywords@3.4.0**
    * Licenses: MIT
    * Repository: https://github.com/epoberezkin/ajv-keywords
-1. **ajv@6.7.0**
+1. **ajv@6.10.0**
    * Licenses: MIT
    * Repository: https://github.com/epoberezkin/ajv
+1. **ansi-regex@2.1.1**
+   * Licenses: MIT
+   * Repository: https://github.com/chalk/ansi-regex
 1. **ansi-regex@3.0.0**
    * Licenses: MIT
    * Repository: https://github.com/chalk/ansi-regex
@@ -1170,6 +893,9 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **archy@1.0.0**
    * Licenses: MIT
    * Repository: https://github.com/substack/node-archy
+1. **are-we-there-yet@1.1.5**
+   * Licenses: ISC
+   * Repository: https://github.com/iarna/are-we-there-yet
 1. **argparse@1.0.10**
    * Licenses: MIT
    * Repository: https://github.com/nodeca/argparse
@@ -1203,36 +929,24 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **asap@2.0.6**
    * Licenses: MIT
    * Repository: https://github.com/kriskowal/asap
+1. **ascli@1.0.1**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/dcodeIO/ascli
 1. **asn1.js@4.10.1**
    * Licenses: MIT
    * Repository: https://github.com/indutny/asn1.js
-1. **asn1@0.2.4**
-   * Licenses: MIT
-   * Repository: https://github.com/joyent/node-asn1
-1. **assert-plus@1.0.0**
-   * Licenses: MIT
-   * Repository: https://github.com/mcavage/node-assert-plus
 1. **assert@1.4.1**
    * Licenses: MIT
    * Repository: https://github.com/defunctzombie/commonjs-assert
 1. **assign-symbols@1.0.0**
    * Licenses: MIT
    * Repository: https://github.com/jonschlinkert/assign-symbols
-1. **async-each@1.0.1**
+1. **async-each@1.0.3**
    * Licenses: MIT
    * Repository: https://github.com/paulmillr/async-each
-1. **asynckit@0.4.0**
-   * Licenses: MIT
-   * Repository: https://github.com/alexindigo/asynckit
 1. **atob@2.1.2**
    * Licenses: (MIT OR Apache-2.0)
    * Repository: git://git.coolaj86.com/coolaj86/atob.js
-1. **aws-sign2@0.7.0**
-   * Licenses: Apache-2.0
-   * Repository: https://github.com/mikeal/aws-sign
-1. **aws4@1.8.0**
-   * Licenses: MIT
-   * Repository: https://github.com/mhart/aws4
 1. **babel-cli@6.26.0**
    * Licenses: MIT
    * Repository: https://github.com/babel/babel/tree/master/packages/babel-cli
@@ -1290,7 +1004,7 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **babel-plugin-check-es2015-constants@6.22.0**
    * Licenses: MIT
    * Repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-check-es2015-constants
-1. **babel-plugin-module-resolver@3.1.2**
+1. **babel-plugin-module-resolver@3.2.0**
    * Licenses: MIT
    * Repository: https://github.com/tleunen/babel-plugin-module-resolver
 1. **babel-plugin-syntax-async-functions@6.13.0**
@@ -1407,24 +1121,27 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **babylon@6.18.0**
    * Licenses: MIT
    * Repository: https://github.com/babel/babylon
+1. **balanced-match@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/juliangruber/balanced-match
 1. **base@0.11.2**
    * Licenses: MIT
    * Repository: https://github.com/node-base/base
-1. **bcrypt-pbkdf@1.0.2**
-   * Licenses: BSD-3-Clause
-   * Repository: https://github.com/joyent/node-bcrypt-pbkdf
 1. **big.js@5.2.2**
    * Licenses: MIT
    * Repository: https://github.com/MikeMcl/big.js
-1. **binary-extensions@1.12.0**
+1. **binary-extensions@1.13.1**
    * Licenses: MIT
    * Repository: https://github.com/sindresorhus/binary-extensions
-1. **bluebird@3.5.3**
+1. **bluebird@3.5.4**
    * Licenses: MIT
    * Repository: https://github.com/petkaantonov/bluebird
 1. **bn.js@4.11.8**
    * Licenses: MIT
    * Repository: https://github.com/indutny/bn.js
+1. **brace-expansion@1.1.11**
+   * Licenses: MIT
+   * Repository: https://github.com/juliangruber/brace-expansion
 1. **braces@1.8.5**
    * Licenses: MIT
    * Repository: https://github.com/jonschlinkert/braces
@@ -1470,6 +1187,9 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **builtin-status-codes@3.0.0**
    * Licenses: MIT
    * Repository: https://github.com/bendrucker/builtin-status-codes
+1. **bytebuffer@5.0.1**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/dcodeIO/bytebuffer.js
 1. **cacache@11.3.2**
    * Licenses: ISC
    * Repository: https://github.com/zkat/cacache
@@ -1479,18 +1199,15 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **caching-transform@3.0.2**
    * Licenses: MIT
    * Repository: https://github.com/istanbuljs/caching-transform
-1. **camelcase@5.0.0**
+1. **camelcase@2.1.1**
    * Licenses: MIT
    * Repository: https://github.com/sindresorhus/camelcase
 1. **camelcase@5.3.1**
    * Licenses: MIT
    * Repository: https://github.com/sindresorhus/camelcase
-1. **caniuse-lite@1.0.30000929**
+1. **caniuse-lite@1.0.30000963**
    * Licenses: CC-BY-4.0
    * Repository: https://github.com/ben-eb/caniuse-lite
-1. **caseless@0.12.0**
-   * Licenses: Apache-2.0
-   * Repository: https://github.com/mikeal/caseless
 1. **chalk@1.1.3**
    * Licenses: MIT
    * Repository: https://github.com/chalk/chalk
@@ -1500,7 +1217,7 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **chokidar@1.7.0**
    * Licenses: MIT
    * Repository: https://github.com/paulmillr/chokidar
-1. **chokidar@2.0.4**
+1. **chokidar@2.1.5**
    * Licenses: MIT
    * Repository: https://github.com/paulmillr/chokidar
 1. **chownr@1.1.1**
@@ -1515,10 +1232,16 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **class-utils@0.3.6**
    * Licenses: MIT
    * Repository: https://github.com/jonschlinkert/class-utils
+1. **cliui@3.2.0**
+   * Licenses: ISC
+   * Repository: https://github.com/yargs/cliui
 1. **cliui@4.1.0**
    * Licenses: ISC
    * Repository: https://github.com/yargs/cliui
-1. **codecov@3.1.0**
+1. **code-point-at@1.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/code-point-at
+1. **codecov@3.3.0**
    * Licenses: MIT
    * Repository: https://github.com/codecov/codecov-node
 1. **collection-visit@1.0.0**
@@ -1530,16 +1253,10 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **color-name@1.1.3**
    * Licenses: MIT
    * Repository: https://github.com/dfcreative/color-name
-1. **combined-stream@1.0.7**
+1. **colour@0.7.1**
    * Licenses: MIT
-   * Repository: https://github.com/felixge/node-combined-stream
+   * Repository: https://github.com/dcodeIO/colour.js
 1. **commander@2.15.1**
-   * Licenses: MIT
-   * Repository: https://github.com/tj/commander.js
-1. **commander@2.17.1**
-   * Licenses: MIT
-   * Repository: https://github.com/tj/commander.js
-1. **commander@2.19.0**
    * Licenses: MIT
    * Repository: https://github.com/tj/commander.js
 1. **commander@2.20.0**
@@ -1548,15 +1265,21 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **commondir@1.0.1**
    * Licenses: MIT
    * Repository: https://github.com/substack/node-commondir
-1. **component-emitter@1.2.1**
+1. **component-emitter@1.3.0**
    * Licenses: MIT
    * Repository: https://github.com/component/emitter
+1. **concat-map@0.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/substack/node-concat-map
 1. **concat-stream@1.6.2**
    * Licenses: MIT
    * Repository: https://github.com/maxogden/concat-stream
 1. **console-browserify@1.1.0**
    * Licenses: MIT
    * Repository: https://github.com/Raynos/console-browserify
+1. **console-control-strings@1.1.0**
+   * Licenses: ISC
+   * Repository: https://github.com/iarna/console-control-strings
 1. **constants-browserify@1.0.0**
    * Licenses: MIT
    * Repository: https://github.com/juliangruber/constants-browserify
@@ -1569,7 +1292,10 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **copy-descriptor@0.1.1**
    * Licenses: MIT
    * Repository: https://github.com/jonschlinkert/copy-descriptor
-1. **core-js@2.5.5**
+1. **core-js@2.6.5**
+   * Licenses: MIT
+   * Repository: https://github.com/zloirock/core-js
+1. **core-js@3.0.1**
    * Licenses: MIT
    * Repository: https://github.com/zloirock/core-js
 1. **core-util-is@1.0.2**
@@ -1599,9 +1325,6 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **cyclist@0.2.2**
    * Licenses: MIT*
    * Repository: https://github.com/mafintosh/cyclist
-1. **dashdash@1.14.1**
-   * Licenses: MIT
-   * Repository: https://github.com/trentm/node-dashdash
 1. **date-now@0.1.4**
    * Licenses: MIT
    * Repository: https://github.com/Colingo/date-now
@@ -1620,9 +1343,15 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **debuglog@1.0.1**
    * Licenses: MIT
    * Repository: https://github.com/sam-github/node-debuglog
+1. **decamelize@1.2.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/decamelize
 1. **decode-uri-component@0.2.0**
    * Licenses: MIT
    * Repository: https://github.com/SamVerschueren/decode-uri-component
+1. **deep-extend@0.6.0**
+   * Licenses: MIT
+   * Repository: https://github.com/unclechu/node-deep-extend
 1. **default-require-extensions@2.0.0**
    * Licenses: MIT
    * Repository: https://github.com/avajs/default-require-extensions
@@ -1635,9 +1364,9 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **define-property@2.0.2**
    * Licenses: MIT
    * Repository: https://github.com/jonschlinkert/define-property
-1. **delayed-stream@1.0.0**
+1. **delegates@1.0.0**
    * Licenses: MIT
-   * Repository: https://github.com/felixge/node-delayed-stream
+   * Repository: https://github.com/visionmedia/node-delegates
 1. **des.js@1.0.0**
    * Licenses: MIT
    * Repository: https://github.com/indutny/des.js
@@ -1647,6 +1376,9 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **detect-indent@4.0.0**
    * Licenses: MIT
    * Repository: https://github.com/sindresorhus/detect-indent
+1. **detect-libc@1.0.3**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/lovell/detect-libc
 1. **dezalgo@1.0.3**
    * Licenses: ISC
    * Repository: https://github.com/npm/dezalgo
@@ -1656,16 +1388,16 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **diffie-hellman@5.0.3**
    * Licenses: MIT
    * Repository: https://github.com/crypto-browserify/diffie-hellman
+1. **dom-storage@2.1.0**
+   * Licenses: MIT*
+   * Repository: git://git.coolaj86.com/coolaj86/dom-storage.js
 1. **domain-browser@1.2.0**
    * Licenses: MIT
    * Repository: https://github.com/bevry/domain-browser
-1. **duplexify@3.6.1**
+1. **duplexify@3.7.1**
    * Licenses: MIT
    * Repository: https://github.com/mafintosh/duplexify
-1. **ecc-jsbn@0.1.2**
-   * Licenses: MIT
-   * Repository: https://github.com/quartzjer/ecc-jsbn
-1. **electron-to-chromium@1.3.103**
+1. **electron-to-chromium@1.3.129**
    * Licenses: ISC
    * Repository: https://github.com/kilian/electron-to-chromium
 1. **elliptic@6.4.1**
@@ -1692,10 +1424,16 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **es6-error@4.1.1**
    * Licenses: MIT
    * Repository: https://github.com/bjyoungblood/es6-error
+1. **es6-promise@4.2.6**
+   * Licenses: MIT
+   * Repository: https://github.com/stefanpenner/es6-promise
+1. **es6-promisify@5.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/digitaldesignlabs/es6-promisify
 1. **escape-string-regexp@1.0.5**
    * Licenses: MIT
    * Repository: https://github.com/sindresorhus/escape-string-regexp
-1. **eslint-scope@4.0.0**
+1. **eslint-scope@4.0.3**
    * Licenses: BSD-2-Clause
    * Repository: https://github.com/eslint/eslint-scope
 1. **esprima@4.0.1**
@@ -1737,24 +1475,21 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **extend-shallow@3.0.2**
    * Licenses: MIT
    * Repository: https://github.com/jonschlinkert/extend-shallow
-1. **extend@3.0.2**
-   * Licenses: MIT
-   * Repository: https://github.com/justmoon/node-extend
 1. **extglob@0.3.2**
    * Licenses: MIT
    * Repository: https://github.com/jonschlinkert/extglob
 1. **extglob@2.0.4**
    * Licenses: MIT
    * Repository: https://github.com/micromatch/extglob
-1. **extsprintf@1.3.0**
-   * Licenses: MIT
-   * Repository: https://github.com/davepacheco/node-extsprintf
 1. **fast-deep-equal@2.0.1**
    * Licenses: MIT
    * Repository: https://github.com/epoberezkin/fast-deep-equal
 1. **fast-json-stable-stringify@2.0.0**
    * Licenses: MIT
    * Repository: https://github.com/epoberezkin/fast-json-stable-stringify
+1. **faye-websocket@0.11.1**
+   * Licenses: MIT
+   * Repository: https://github.com/faye/faye-websocket-node
 1. **figgy-pudding@3.5.1**
    * Licenses: ISC
    * Repository: https://github.com/zkat/figgy-pudding
@@ -1767,13 +1502,10 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **fill-range@4.0.0**
    * Licenses: MIT
    * Repository: https://github.com/jonschlinkert/fill-range
-1. **find-babel-config@1.1.0**
+1. **find-babel-config@1.2.0**
    * Licenses: MIT
    * Repository: https://github.com/tleunen/find-babel-config
 1. **find-cache-dir@1.0.0**
-   * Licenses: MIT
-   * Repository: https://github.com/avajs/find-cache-dir
-1. **find-cache-dir@2.0.0**
    * Licenses: MIT
    * Repository: https://github.com/avajs/find-cache-dir
 1. **find-cache-dir@2.1.0**
@@ -1788,7 +1520,10 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **findup-sync@2.0.0**
    * Licenses: MIT
    * Repository: https://github.com/js-cli/node-findup-sync
-1. **flush-write-stream@1.0.3**
+1. **firebase@5.11.0**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/firebase/firebase-js-sdk
+1. **flush-write-stream@1.1.1**
    * Licenses: MIT
    * Repository: https://github.com/mafintosh/flush-write-stream
 1. **for-in@1.0.2**
@@ -1800,24 +1535,30 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **foreground-child@1.5.6**
    * Licenses: ISC
    * Repository: https://github.com/tapjs/foreground-child
-1. **forever-agent@0.6.1**
-   * Licenses: Apache-2.0
-   * Repository: https://github.com/mikeal/forever-agent
-1. **form-data@2.3.3**
-   * Licenses: MIT
-   * Repository: https://github.com/form-data/form-data
 1. **fragment-cache@0.2.1**
    * Licenses: MIT
    * Repository: https://github.com/jonschlinkert/fragment-cache
 1. **from2@2.3.0**
    * Licenses: MIT
    * Repository: https://github.com/hughsk/from2
+1. **fs-minipass@1.2.5**
+   * Licenses: ISC
+   * Repository: https://github.com/npm/fs-minipass
 1. **fs-readdir-recursive@1.1.0**
    * Licenses: MIT
    * Repository: https://github.com/fs-utils/fs-readdir-recursive
 1. **fs-write-stream-atomic@1.0.10**
    * Licenses: ISC
    * Repository: https://github.com/npm/fs-write-stream-atomic
+1. **fs.realpath@1.0.0**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/fs.realpath
+1. **fsevents@1.2.9**
+   * Licenses: MIT
+   * Repository: https://github.com/strongloop/fsevents
+1. **gauge@2.7.4**
+   * Licenses: ISC
+   * Repository: https://github.com/iarna/gauge
 1. **get-caller-file@1.0.3**
    * Licenses: ISC
    * Repository: https://github.com/stefanpenner/get-caller-file
@@ -1830,9 +1571,6 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **get-value@2.0.6**
    * Licenses: MIT
    * Repository: https://github.com/jonschlinkert/get-value
-1. **getpass@0.1.7**
-   * Licenses: MIT
-   * Repository: https://github.com/arekinath/node-getpass
 1. **glob-base@0.3.0**
    * Licenses: MIT
    * Repository: https://github.com/jonschlinkert/glob-base
@@ -1845,16 +1583,16 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **glob@7.1.2**
    * Licenses: ISC
    * Repository: https://github.com/isaacs/node-glob
-1. **global-modules-path@2.3.1**
-   * Licenses: Apache-2.0
-   * Repository: https://github.com/rosen-vladimirov/global-modules-path
+1. **glob@7.1.3**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/node-glob
 1. **global-modules@1.0.0**
    * Licenses: MIT
    * Repository: https://github.com/jonschlinkert/global-modules
 1. **global-prefix@1.0.2**
    * Licenses: MIT
    * Repository: https://github.com/jonschlinkert/global-prefix
-1. **globals@11.11.0**
+1. **globals@11.12.0**
    * Licenses: MIT
    * Repository: https://github.com/sindresorhus/globals
 1. **globals@9.18.0**
@@ -1866,21 +1604,21 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **growl@1.10.5**
    * Licenses: MIT
    * Repository: https://github.com/tj/node-growl
+1. **grpc@1.20.0**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/grpc/grpc-node
 1. **handlebars@4.1.2**
    * Licenses: MIT
    * Repository: https://github.com/wycats/handlebars.js
-1. **har-schema@2.0.0**
-   * Licenses: ISC
-   * Repository: https://github.com/ahmadnassri/har-schema
-1. **har-validator@5.1.3**
-   * Licenses: MIT
-   * Repository: https://github.com/ahmadnassri/node-har-validator
 1. **has-ansi@2.0.0**
    * Licenses: MIT
    * Repository: https://github.com/sindresorhus/has-ansi
 1. **has-flag@3.0.0**
    * Licenses: MIT
    * Repository: https://github.com/sindresorhus/has-flag
+1. **has-unicode@2.0.1**
+   * Licenses: ISC
+   * Repository: https://github.com/iarna/has-unicode
 1. **has-value@0.3.1**
    * Licenses: MIT
    * Repository: https://github.com/jonschlinkert/has-value
@@ -1911,19 +1649,31 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **home-or-tmp@2.0.0**
    * Licenses: MIT
    * Repository: https://github.com/sindresorhus/home-or-tmp
-1. **homedir-polyfill@1.0.1**
+1. **homedir-polyfill@1.0.3**
    * Licenses: MIT
    * Repository: https://github.com/doowb/homedir-polyfill
 1. **hosted-git-info@2.7.1**
    * Licenses: ISC
    * Repository: https://github.com/npm/hosted-git-info
-1. **http-signature@1.2.0**
+1. **http-parser-js@0.5.0**
    * Licenses: MIT
-   * Repository: https://github.com/joyent/node-http-signature
+   * Repository: https://github.com/creationix/http-parser-js
 1. **https-browserify@1.0.0**
    * Licenses: MIT
    * Repository: https://github.com/substack/https-browserify
-1. **ieee754@1.1.12**
+1. **https-proxy-agent@2.2.1**
+   * Licenses: MIT
+   * Repository: https://github.com/TooTallNate/node-https-proxy-agent
+1. **iconv-lite@0.4.23**
+   * Licenses: MIT
+   * Repository: https://github.com/ashtuchkin/iconv-lite
+1. **iconv-lite@0.4.24**
+   * Licenses: MIT
+   * Repository: https://github.com/ashtuchkin/iconv-lite
+1. **idb@3.0.2**
+   * Licenses: ISC
+   * Repository: https://github.com/jakearchibald/indexeddb-promised
+1. **ieee754@1.1.13**
    * Licenses: BSD-3-Clause
    * Repository: https://github.com/feross/ieee754
 1. **iferr@0.1.5**
@@ -1941,7 +1691,13 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **indexof@0.0.1**
    * Licenses: MIT*
    * Repository: unknown
+1. **inflight@1.0.6**
+   * Licenses: ISC
+   * Repository: https://github.com/npm/inflight
 1. **inherits@2.0.1**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/inherits
+1. **inherits@2.0.3**
    * Licenses: ISC
    * Repository: https://github.com/isaacs/inherits
 1. **ini@1.3.5**
@@ -1953,6 +1709,9 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **invariant@2.2.4**
    * Licenses: MIT
    * Repository: https://github.com/zertosh/invariant
+1. **invert-kv@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/invert-kv
 1. **invert-kv@2.0.0**
    * Licenses: MIT
    * Repository: https://github.com/sindresorhus/invert-kv
@@ -2004,6 +1763,9 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **is-finite@1.0.2**
    * Licenses: MIT
    * Repository: https://github.com/sindresorhus/is-finite
+1. **is-fullwidth-code-point@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/is-fullwidth-code-point
 1. **is-fullwidth-code-point@2.0.0**
    * Licenses: MIT
    * Repository: https://github.com/sindresorhus/is-fullwidth-code-point
@@ -2013,9 +1775,9 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **is-glob@3.1.0**
    * Licenses: MIT
    * Repository: https://github.com/jonschlinkert/is-glob
-1. **is-glob@4.0.0**
+1. **is-glob@4.0.1**
    * Licenses: MIT
-   * Repository: https://github.com/jonschlinkert/is-glob
+   * Repository: https://github.com/micromatch/is-glob
 1. **is-number@2.1.0**
    * Licenses: MIT
    * Repository: https://github.com/jonschlinkert/is-number
@@ -2034,9 +1796,6 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **is-primitive@2.0.0**
    * Licenses: MIT
    * Repository: https://github.com/jonschlinkert/is-primitive
-1. **is-typedarray@1.0.0**
-   * Licenses: MIT
-   * Repository: https://github.com/hughsk/is-typedarray
 1. **is-windows@1.0.2**
    * Licenses: MIT
    * Repository: https://github.com/jonschlinkert/is-windows
@@ -2055,25 +1814,22 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **isobject@3.0.1**
    * Licenses: MIT
    * Repository: https://github.com/jonschlinkert/isobject
-1. **isstream@0.1.2**
-   * Licenses: MIT
-   * Repository: https://github.com/rvagg/isstream
-1. **istanbul-lib-coverage@2.0.4**
+1. **istanbul-lib-coverage@2.0.5**
    * Licenses: BSD-3-Clause
    * Repository: https://github.com/istanbuljs/istanbuljs
-1. **istanbul-lib-hook@2.0.6**
+1. **istanbul-lib-hook@2.0.7**
    * Licenses: BSD-3-Clause
    * Repository: https://github.com/istanbuljs/istanbuljs
-1. **istanbul-lib-instrument@3.2.0**
+1. **istanbul-lib-instrument@3.3.0**
    * Licenses: BSD-3-Clause
    * Repository: https://github.com/istanbuljs/istanbuljs
-1. **istanbul-lib-report@2.0.7**
+1. **istanbul-lib-report@2.0.8**
    * Licenses: BSD-3-Clause
    * Repository: https://github.com/istanbuljs/istanbuljs
-1. **istanbul-lib-source-maps@3.0.5**
+1. **istanbul-lib-source-maps@3.0.6**
    * Licenses: BSD-3-Clause
    * Repository: https://github.com/istanbuljs/istanbuljs
-1. **istanbul-reports@2.2.3**
+1. **istanbul-reports@2.2.4**
    * Licenses: BSD-3-Clause
    * Repository: https://github.com/istanbuljs/istanbuljs
 1. **js-tokens@3.0.2**
@@ -2085,9 +1841,6 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **js-yaml@3.13.1**
    * Licenses: MIT
    * Repository: https://github.com/nodeca/js-yaml
-1. **jsbn@0.1.1**
-   * Licenses: MIT
-   * Repository: https://github.com/andyperlitch/jsbn
 1. **jsesc@0.5.0**
    * Licenses: MIT
    * Repository: https://github.com/mathiasbynens/jsesc
@@ -2103,21 +1856,12 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **json-schema-traverse@0.4.1**
    * Licenses: MIT
    * Repository: https://github.com/epoberezkin/json-schema-traverse
-1. **json-schema@0.2.3**
-   * Licenses: AFLv2.1,BSD
-   * Repository: https://github.com/kriszyp/json-schema
-1. **json-stringify-safe@5.0.1**
-   * Licenses: ISC
-   * Repository: https://github.com/isaacs/json-stringify-safe
 1. **json5@0.5.1**
    * Licenses: MIT
    * Repository: https://github.com/aseemk/json5
 1. **json5@1.0.1**
    * Licenses: MIT
    * Repository: https://github.com/json5/json5
-1. **jsprim@1.4.1**
-   * Licenses: MIT
-   * Repository: https://github.com/joyent/node-jsprim
 1. **just-extend@4.0.2**
    * Licenses: MIT
    * Repository: https://github.com/angus-c/just
@@ -2133,15 +1877,15 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **kind-of@6.0.2**
    * Licenses: MIT
    * Repository: https://github.com/jonschlinkert/kind-of
+1. **lcid@1.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/lcid
 1. **lcid@2.0.0**
    * Licenses: MIT
    * Repository: https://github.com/sindresorhus/lcid
 1. **license-checker@25.0.1**
    * Licenses: BSD-3-Clause
    * Repository: https://github.com/davglass/license-checker
-1. **lightercollective@0.1.0**
-   * Licenses: ISC
-   * Repository: unknown
 1. **load-json-file@4.0.0**
    * Licenses: MIT
    * Repository: https://github.com/sindresorhus/load-json-file
@@ -2157,13 +1901,13 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **locate-path@3.0.0**
    * Licenses: MIT
    * Repository: https://github.com/sindresorhus/locate-path
-1. **lodash.debounce@4.0.8**
+1. **lodash.camelcase@4.3.0**
+   * Licenses: MIT
+   * Repository: https://github.com/lodash/lodash
+1. **lodash.clone@4.5.0**
    * Licenses: MIT
    * Repository: https://github.com/lodash/lodash
 1. **lodash.flattendeep@4.4.0**
-   * Licenses: MIT
-   * Repository: https://github.com/lodash/lodash
-1. **lodash.get@4.4.2**
    * Licenses: MIT
    * Repository: https://github.com/lodash/lodash
 1. **lodash@4.17.11**
@@ -2172,9 +1916,12 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **lolex@2.7.5**
    * Licenses: BSD-3-Clause
    * Repository: https://github.com/sinonjs/lolex
-1. **lolex@3.0.0**
+1. **lolex@4.0.1**
    * Licenses: BSD-3-Clause
    * Repository: https://github.com/sinonjs/lolex
+1. **long@3.2.0**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/dcodeIO/long.js
 1. **loose-envify@1.4.0**
    * Licenses: MIT
    * Repository: https://github.com/zertosh/loose-envify
@@ -2190,6 +1937,9 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **make-dir@2.1.0**
    * Licenses: MIT
    * Repository: https://github.com/sindresorhus/make-dir
+1. **mamacro@0.0.3**
+   * Licenses: MIT
+   * Repository: unknown
 1. **map-age-cleaner@0.1.3**
    * Licenses: MIT
    * Repository: https://github.com/SamVerschueren/map-age-cleaner
@@ -2205,7 +1955,7 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **md5.js@1.3.5**
    * Licenses: MIT
    * Repository: https://github.com/crypto-browserify/md5.js
-1. **mem@4.0.0**
+1. **mem@4.3.0**
    * Licenses: MIT
    * Repository: https://github.com/sindresorhus/mem
 1. **memory-fs@0.4.1**
@@ -2223,13 +1973,7 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **miller-rabin@4.0.1**
    * Licenses: MIT
    * Repository: https://github.com/indutny/miller-rabin
-1. **mime-db@1.37.0**
-   * Licenses: MIT
-   * Repository: https://github.com/jshttp/mime-db
-1. **mime-types@2.1.21**
-   * Licenses: MIT
-   * Repository: https://github.com/jshttp/mime-types
-1. **mimic-fn@1.2.0**
+1. **mimic-fn@2.1.0**
    * Licenses: MIT
    * Repository: https://github.com/sindresorhus/mimic-fn
 1. **minimalistic-assert@1.0.1**
@@ -2238,12 +1982,24 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **minimalistic-crypto-utils@1.0.1**
    * Licenses: MIT
    * Repository: https://github.com/indutny/minimalistic-crypto-utils
+1. **minimatch@3.0.4**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/minimatch
 1. **minimist@0.0.8**
    * Licenses: MIT
    * Repository: https://github.com/substack/minimist
 1. **minimist@1.2.0**
    * Licenses: MIT
    * Repository: https://github.com/substack/minimist
+1. **minipass@2.3.5**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/minipass
+1. **minizlib@1.1.1**
+   * Licenses: MIT
+   * Repository: https://github.com/isaacs/minizlib
+1. **minizlib@1.2.1**
+   * Licenses: MIT
+   * Repository: https://github.com/isaacs/minizlib
 1. **mississippi@3.0.0**
    * Licenses: BSD-2-Clause
    * Repository: https://github.com/maxogden/mississippi
@@ -2265,9 +2021,18 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **ms@2.1.1**
    * Licenses: MIT
    * Repository: https://github.com/zeit/ms
+1. **nan@2.13.2**
+   * Licenses: MIT
+   * Repository: https://github.com/nodejs/nan
 1. **nanomatch@1.2.13**
    * Licenses: MIT
    * Repository: https://github.com/micromatch/nanomatch
+1. **needle@2.2.4**
+   * Licenses: MIT
+   * Repository: https://github.com/tomas/needle
+1. **needle@2.3.0**
+   * Licenses: MIT
+   * Repository: https://github.com/tomas/needle
 1. **neo-async@2.6.0**
    * Licenses: MIT
    * Repository: https://github.com/suguru03/neo-async
@@ -2277,12 +2042,18 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **nice-try@1.0.5**
    * Licenses: MIT
    * Repository: https://github.com/electerious/nice-try
-1. **nise@1.4.8**
+1. **nise@1.4.10**
    * Licenses: BSD-3-Clause
    * Repository: https://github.com/sinonjs/nise
+1. **node-fetch@2.5.0**
+   * Licenses: MIT
+   * Repository: https://github.com/bitinn/node-fetch
 1. **node-libs-browser@2.2.0**
    * Licenses: MIT
    * Repository: https://github.com/webpack/node-libs-browser
+1. **node-pre-gyp@0.12.0**
+   * Licenses: BSD-3-Clause
+   * Repository: https://github.com/mapbox/node-pre-gyp
 1. **nopt@4.0.1**
    * Licenses: ISC
    * Repository: https://github.com/npm/nopt
@@ -2292,15 +2063,33 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **normalize-path@2.1.1**
    * Licenses: MIT
    * Repository: https://github.com/jonschlinkert/normalize-path
+1. **normalize-path@3.0.0**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/normalize-path
+1. **npm-bundled@1.0.5**
+   * Licenses: ISC
+   * Repository: https://github.com/npm/npm-bundled
+1. **npm-bundled@1.0.6**
+   * Licenses: ISC
+   * Repository: https://github.com/npm/npm-bundled
+1. **npm-packlist@1.1.12**
+   * Licenses: ISC
+   * Repository: https://github.com/npm/npm-packlist
+1. **npm-packlist@1.4.1**
+   * Licenses: ISC
+   * Repository: https://github.com/npm/npm-packlist
 1. **npm-run-path@2.0.2**
    * Licenses: MIT
    * Repository: https://github.com/sindresorhus/npm-run-path
-1. **nyc@14.0.0**
+1. **npmlog@4.1.2**
+   * Licenses: ISC
+   * Repository: https://github.com/npm/npmlog
+1. **number-is-nan@1.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/number-is-nan
+1. **nyc@14.1.0**
    * Licenses: ISC
    * Repository: https://github.com/istanbuljs/nyc
-1. **oauth-sign@0.9.0**
-   * Licenses: Apache-2.0
-   * Repository: https://github.com/mikeal/oauth-sign
 1. **object-assign@4.1.1**
    * Licenses: MIT
    * Repository: https://github.com/sindresorhus/object-assign
@@ -2316,15 +2105,24 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **object.pick@1.3.0**
    * Licenses: MIT
    * Repository: https://github.com/jonschlinkert/object.pick
+1. **once@1.4.0**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/once
 1. **optimist@0.6.1**
    * Licenses: MIT*
    * Repository: https://github.com/substack/node-optimist
+1. **optjs@3.2.2**
+   * Licenses: MIT
+   * Repository: https://github.com/dcodeIO/opt.js
 1. **os-browserify@0.3.0**
    * Licenses: MIT
    * Repository: https://github.com/CoderPuppy/os-browserify
 1. **os-homedir@1.0.2**
    * Licenses: MIT
    * Repository: https://github.com/sindresorhus/os-homedir
+1. **os-locale@1.4.0**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/os-locale
 1. **os-locale@3.1.0**
    * Licenses: MIT
    * Repository: https://github.com/sindresorhus/os-locale
@@ -2343,13 +2141,10 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **p-finally@1.0.0**
    * Licenses: MIT
    * Repository: https://github.com/sindresorhus/p-finally
-1. **p-is-promise@1.1.0**
+1. **p-is-promise@2.1.0**
    * Licenses: MIT
    * Repository: https://github.com/sindresorhus/p-is-promise
 1. **p-limit@1.3.0**
-   * Licenses: MIT
-   * Repository: https://github.com/sindresorhus/p-limit
-1. **p-limit@2.1.0**
    * Licenses: MIT
    * Repository: https://github.com/sindresorhus/p-limit
 1. **p-limit@2.2.0**
@@ -2364,22 +2159,19 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **p-try@1.0.0**
    * Licenses: MIT
    * Repository: https://github.com/sindresorhus/p-try
-1. **p-try@2.0.0**
-   * Licenses: MIT
-   * Repository: https://github.com/sindresorhus/p-try
 1. **p-try@2.2.0**
    * Licenses: MIT
    * Repository: https://github.com/sindresorhus/p-try
 1. **package-hash@3.0.0**
    * Licenses: ISC
    * Repository: https://github.com/novemberborn/package-hash
-1. **pako@1.0.8**
+1. **pako@1.0.10**
    * Licenses: (MIT AND Zlib)
    * Repository: https://github.com/nodeca/pako
 1. **parallel-transform@1.1.0**
    * Licenses: MIT
    * Repository: https://github.com/mafintosh/parallel-transform
-1. **parse-asn1@5.1.3**
+1. **parse-asn1@5.1.4**
    * Licenses: ISC
    * Repository: https://github.com/crypto-browserify/parse-asn1
 1. **parse-glob@3.0.4**
@@ -2403,6 +2195,9 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **path-exists@3.0.0**
    * Licenses: MIT
    * Repository: https://github.com/sindresorhus/path-exists
+1. **path-is-absolute@1.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/path-is-absolute
 1. **path-key@2.0.1**
    * Licenses: MIT
    * Repository: https://github.com/sindresorhus/path-key
@@ -2418,9 +2213,6 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **pbkdf2@3.0.17**
    * Licenses: MIT
    * Repository: https://github.com/crypto-browserify/pbkdf2
-1. **performance-now@2.1.0**
-   * Licenses: MIT
-   * Repository: https://github.com/braveg1rl/performance-now
 1. **pify@3.0.0**
    * Licenses: MIT
    * Repository: https://github.com/sindresorhus/pify
@@ -2454,15 +2246,18 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **promise-inflight@1.0.1**
    * Licenses: ISC
    * Repository: https://github.com/iarna/promise-inflight
+1. **promise-polyfill@8.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/taylorhakes/promise-polyfill
+1. **protobufjs@5.0.3**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/dcodeIO/protobuf.js
 1. **prr@1.0.1**
    * Licenses: MIT
    * Repository: https://github.com/rvagg/prr
 1. **pseudomap@1.0.2**
    * Licenses: ISC
    * Repository: https://github.com/isaacs/pseudomap
-1. **psl@1.1.31**
-   * Licenses: MIT
-   * Repository: https://github.com/wrangr/psl
 1. **public-encrypt@4.0.3**
    * Licenses: MIT
    * Repository: https://github.com/crypto-browserify/publicEncrypt
@@ -2484,9 +2279,6 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **punycode@2.1.1**
    * Licenses: MIT
    * Repository: https://github.com/bestiejs/punycode.js
-1. **qs@6.5.2**
-   * Licenses: BSD-3-Clause
-   * Repository: https://github.com/ljharb/qs
 1. **querystring-es3@0.2.1**
    * Licenses: MIT
    * Repository: https://github.com/mike-spainhower/querystring
@@ -2496,12 +2288,15 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **randomatic@3.1.1**
    * Licenses: MIT
    * Repository: https://github.com/jonschlinkert/randomatic
-1. **randombytes@2.0.6**
+1. **randombytes@2.1.0**
    * Licenses: MIT
    * Repository: https://github.com/crypto-browserify/randombytes
 1. **randomfill@1.0.4**
    * Licenses: MIT
    * Repository: https://github.com/crypto-browserify/randomfill
+1. **rc@1.2.8**
+   * Licenses: (BSD-2-Clause OR MIT OR Apache-2.0)
+   * Repository: https://github.com/dominictarr/rc
 1. **read-installed@4.0.3**
    * Licenses: ISC
    * Repository: https://github.com/isaacs/read-installed
@@ -2565,9 +2360,6 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **repeating@2.0.1**
    * Licenses: MIT
    * Repository: https://github.com/sindresorhus/repeating
-1. **request@2.88.0**
-   * Licenses: Apache-2.0
-   * Repository: https://github.com/request/request
 1. **require-directory@2.1.1**
    * Licenses: MIT
    * Repository: https://github.com/troygoode/node-require-directory
@@ -2598,12 +2390,12 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **resolve@1.10.1**
    * Licenses: MIT
    * Repository: https://github.com/browserify/resolve
-1. **resolve@1.9.0**
-   * Licenses: MIT
-   * Repository: https://github.com/browserify/resolve
 1. **ret@0.1.15**
    * Licenses: MIT
    * Repository: https://github.com/fent/ret.js
+1. **rimraf@2.6.2**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/rimraf
 1. **rimraf@2.6.3**
    * Licenses: ISC
    * Repository: https://github.com/isaacs/rimraf
@@ -2619,19 +2411,25 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **safe-regex@1.1.0**
    * Licenses: MIT
    * Repository: https://github.com/substack/safe-regex
-1. **schema-utils@0.4.7**
+1. **safer-buffer@2.1.2**
    * Licenses: MIT
-   * Repository: https://github.com/webpack-contrib/schema-utils
+   * Repository: https://github.com/ChALkeR/safer-buffer
+1. **sax@1.2.4**
+   * Licenses: ISC
+   * Repository: https://github.com/isaacs/sax-js
 1. **schema-utils@1.0.0**
    * Licenses: MIT
    * Repository: https://github.com/webpack-contrib/schema-utils
 1. **semver@5.6.0**
    * Licenses: ISC
    * Repository: https://github.com/npm/node-semver
+1. **semver@5.7.0**
+   * Licenses: ISC
+   * Repository: https://github.com/npm/node-semver
 1. **semver@6.0.0**
    * Licenses: ISC
    * Repository: https://github.com/npm/node-semver
-1. **serialize-javascript@1.6.1**
+1. **serialize-javascript@1.7.0**
    * Licenses: BSD-3-Clause
    * Repository: https://github.com/yahoo/serialize-javascript
 1. **set-blocking@2.0.0**
@@ -2658,7 +2456,7 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **signal-exit@3.0.2**
    * Licenses: ISC
    * Repository: https://github.com/tapjs/signal-exit
-1. **sinon@7.2.3**
+1. **sinon@7.3.2**
    * Licenses: BSD-3-Clause
    * Repository: https://github.com/sinonjs/sinon
 1. **slash@1.0.0**
@@ -2685,7 +2483,7 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **source-map-support@0.4.18**
    * Licenses: MIT
    * Repository: https://github.com/evanw/node-source-map-support
-1. **source-map-support@0.5.10**
+1. **source-map-support@0.5.12**
    * Licenses: MIT
    * Repository: https://github.com/evanw/node-source-map-support
 1. **source-map-url@0.4.0**
@@ -2721,7 +2519,7 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **spdx-satisfies@4.0.1**
    * Licenses: MIT
    * Repository: https://github.com/kemitchell/spdx-satisfies.js
-1. **spine-web@0.15.4**
+1. **spine-web@0.16.0**
    * Licenses: Apache-2.0
    * Repository: https://github.com/SpineEventEngine/web
 1. **split-string@3.1.0**
@@ -2730,18 +2528,15 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **sprintf-js@1.0.3**
    * Licenses: BSD-3-Clause
    * Repository: https://github.com/alexei/sprintf.js
-1. **sshpk@1.16.0**
-   * Licenses: MIT
-   * Repository: https://github.com/joyent/node-sshpk
 1. **ssri@6.0.1**
    * Licenses: ISC
    * Repository: https://github.com/zkat/ssri
 1. **static-extend@0.1.2**
    * Licenses: MIT
    * Repository: https://github.com/jonschlinkert/static-extend
-1. **stream-browserify@2.0.1**
+1. **stream-browserify@2.0.2**
    * Licenses: MIT
-   * Repository: https://github.com/substack/stream-browserify
+   * Repository: https://github.com/browserify/stream-browserify
 1. **stream-each@1.2.3**
    * Licenses: MIT
    * Repository: https://github.com/mafintosh/stream-each
@@ -2751,6 +2546,9 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **stream-shift@1.0.0**
    * Licenses: MIT
    * Repository: https://github.com/mafintosh/stream-shift
+1. **string-width@1.0.2**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/string-width
 1. **string-width@2.1.1**
    * Licenses: MIT
    * Repository: https://github.com/sindresorhus/string-width
@@ -2760,6 +2558,9 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **string_decoder@1.1.1**
    * Licenses: MIT
    * Repository: https://github.com/nodejs/string_decoder
+1. **strip-ansi@3.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/chalk/strip-ansi
 1. **strip-ansi@4.0.0**
    * Licenses: MIT
    * Repository: https://github.com/chalk/strip-ansi
@@ -2772,6 +2573,9 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **strip-eof@1.0.0**
    * Licenses: MIT
    * Repository: https://github.com/sindresorhus/strip-eof
+1. **strip-json-comments@2.0.1**
+   * Licenses: MIT
+   * Repository: https://github.com/sindresorhus/strip-json-comments
 1. **supports-color@2.0.0**
    * Licenses: MIT
    * Repository: https://github.com/chalk/supports-color
@@ -2784,21 +2588,24 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **supports-color@6.1.0**
    * Licenses: MIT
    * Repository: https://github.com/chalk/supports-color
-1. **tapable@1.1.1**
+1. **tapable@1.1.3**
    * Licenses: MIT
    * Repository: https://github.com/webpack/tapable
-1. **terser-webpack-plugin@1.2.1**
+1. **tar@4.4.8**
+   * Licenses: ISC
+   * Repository: https://github.com/npm/node-tar
+1. **teeny-request@3.11.3**
+   * Licenses: Apache-2.0
+   * Repository: https://github.com/fhinkel/teeny-request
+1. **terser-webpack-plugin@1.2.3**
    * Licenses: MIT
    * Repository: https://github.com/webpack-contrib/terser-webpack-plugin
-1. **terser@3.14.1**
+1. **terser@3.17.0**
    * Licenses: BSD-2-Clause
    * Repository: https://github.com/fabiosantoscode/terser
-1. **test-exclude@5.2.2**
+1. **test-exclude@5.2.3**
    * Licenses: ISC
    * Repository: https://github.com/istanbuljs/istanbuljs
-1. **text-encoding@0.6.4**
-   * Licenses: Unlicense
-   * Repository: https://github.com/inexorabletash/text-encoding
 1. **through2@2.0.5**
    * Licenses: MIT
    * Repository: https://github.com/rvagg/through2
@@ -2823,9 +2630,6 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **to-regex@3.0.2**
    * Licenses: MIT
    * Repository: https://github.com/jonschlinkert/to-regex
-1. **tough-cookie@2.4.3**
-   * Licenses: BSD-3-Clause
-   * Repository: https://github.com/salesforce/tough-cookie
 1. **treeify@1.1.0**
    * Licenses: MIT
    * Repository: https://github.com/notatestuser/treeify
@@ -2835,19 +2639,13 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **tty-browserify@0.0.0**
    * Licenses: MIT
    * Repository: https://github.com/substack/tty-browserify
-1. **tunnel-agent@0.6.0**
-   * Licenses: Apache-2.0
-   * Repository: https://github.com/mikeal/tunnel-agent
-1. **tweetnacl@0.14.5**
-   * Licenses: Unlicense
-   * Repository: https://github.com/dchest/tweetnacl-js
 1. **type-detect@4.0.8**
    * Licenses: MIT
    * Repository: https://github.com/chaijs/type-detect
 1. **typedarray@0.0.6**
    * Licenses: MIT
    * Repository: https://github.com/substack/typedarray
-1. **uglify-js@3.5.8**
+1. **uglify-js@3.5.10**
    * Licenses: BSD-2-Clause
    * Repository: https://github.com/mishoo/UglifyJS2
 1. **union-value@1.0.0**
@@ -2862,7 +2660,7 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **unset-value@1.0.0**
    * Licenses: MIT
    * Repository: https://github.com/jonschlinkert/unset-value
-1. **upath@1.1.0**
+1. **upath@1.1.2**
    * Licenses: MIT
    * Repository: https://github.com/anodynos/upath
 1. **uri-js@4.2.2**
@@ -2904,16 +2702,13 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **validate-npm-package-license@3.0.4**
    * Licenses: Apache-2.0
    * Repository: https://github.com/kemitchell/validate-npm-package-license.js
-1. **verror@1.10.0**
-   * Licenses: MIT
-   * Repository: https://github.com/davepacheco/node-verror
 1. **vm-browserify@0.0.4**
    * Licenses: MIT
    * Repository: https://github.com/substack/vm-browserify
 1. **watchpack@1.6.0**
    * Licenses: MIT
    * Repository: https://github.com/webpack/watchpack
-1. **webpack-cli@3.2.1**
+1. **webpack-cli@3.3.1**
    * Licenses: MIT
    * Repository: https://github.com/webpack/webpack-cli
 1. **webpack-merge@4.2.1**
@@ -2922,27 +2717,54 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **webpack-sources@1.3.0**
    * Licenses: MIT
    * Repository: https://github.com/webpack/webpack-sources
-1. **webpack@4.29.0**
+1. **webpack@4.30.0**
    * Licenses: MIT
    * Repository: https://github.com/webpack/webpack
+1. **websocket-driver@0.7.0**
+   * Licenses: MIT
+   * Repository: https://github.com/faye/websocket-driver-node
+1. **websocket-extensions@0.1.3**
+   * Licenses: MIT
+   * Repository: https://github.com/faye/websocket-extensions-node
+1. **whatwg-fetch@2.0.4**
+   * Licenses: MIT
+   * Repository: https://github.com/github/fetch
 1. **which-module@2.0.0**
    * Licenses: ISC
    * Repository: https://github.com/nexdrew/which-module
 1. **which@1.3.1**
    * Licenses: ISC
    * Repository: https://github.com/isaacs/node-which
+1. **wide-align@1.1.3**
+   * Licenses: ISC
+   * Repository: https://github.com/iarna/wide-align
+1. **window-size@0.1.4**
+   * Licenses: MIT
+   * Repository: https://github.com/jonschlinkert/window-size
 1. **wordwrap@0.0.3**
    * Licenses: MIT
    * Repository: https://github.com/substack/node-wordwrap
 1. **worker-farm@1.6.0**
    * Licenses: MIT
    * Repository: https://github.com/rvagg/node-worker-farm
+1. **wrap-ansi@2.1.0**
+   * Licenses: MIT
+   * Repository: https://github.com/chalk/wrap-ansi
+1. **wrappy@1.0.2**
+   * Licenses: ISC
+   * Repository: https://github.com/npm/wrappy
 1. **write-file-atomic@2.4.2**
    * Licenses: ISC
    * Repository: https://github.com/iarna/write-file-atomic
+1. **xmlhttprequest@1.8.0**
+   * Licenses: MIT
+   * Repository: https://github.com/driverdan/node-XMLHttpRequest
 1. **xtend@4.0.1**
    * Licenses: MIT
    * Repository: https://github.com/Raynos/xtend
+1. **y18n@3.2.1**
+   * Licenses: ISC
+   * Repository: https://github.com/yargs/y18n
 1. **y18n@4.0.0**
    * Licenses: ISC
    * Repository: https://github.com/yargs/y18n
@@ -2964,14 +2786,17 @@ This report was generated on **Thu Apr 25 14:59:03 EEST 2019** using [Gradle-Lic
 1. **yargs@13.2.2**
    * Licenses: MIT
    * Repository: https://github.com/yargs/yargs
+1. **yargs@3.32.0**
+   * Licenses: MIT
+   * Repository: https://github.com/bcoe/yargs
 
 
-This report was generated on **Thu Apr 25 2019 14:59:06 GMT+0300 (FLE Daylight Time)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
+This report was generated on **Thu May 02 2019 19:31:58 GMT+0300 (EEST)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
 
 
 
     
-# Dependencies of `io.spine.gcloud:spine-firebase-web:1.0.0-SNAPSHOT`
+# Dependencies of `io.spine.gcloud:spine-firebase-web:1.0.0-pre7`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson.core **Name:** jackson-annotations **Version:** 2.9.0
@@ -2979,12 +2804,12 @@ This report was generated on **Thu Apr 25 2019 14:59:06 GMT+0300 (FLE Daylight T
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.fasterxml.jackson.core **Name:** jackson-core **Version:** 2.9.6
+1. **Group:** com.fasterxml.jackson.core **Name:** jackson-core **Version:** 2.9.8
      * **Project URL:** [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.fasterxml.jackson.core **Name:** jackson-databind **Version:** 2.9.6
+1. **Group:** com.fasterxml.jackson.core **Name:** jackson-databind **Version:** 2.9.8
      * **Project URL:** [http://github.com/FasterXML/jackson](http://github.com/FasterXML/jackson)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -3131,11 +2956,10 @@ This report was generated on **Thu Apr 25 2019 14:59:06 GMT+0300 (FLE Daylight T
      * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.6.1
+1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.7.1
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** com.squareup.okhttp **Name:** okhttp **Version:** 2.5.0
      * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -3328,12 +3152,12 @@ This report was generated on **Thu Apr 25 2019 14:59:06 GMT+0300 (FLE Daylight T
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.fasterxml.jackson.core **Name:** jackson-core **Version:** 2.9.6
+1. **Group:** com.fasterxml.jackson.core **Name:** jackson-core **Version:** 2.9.8
      * **Project URL:** [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.fasterxml.jackson.core **Name:** jackson-databind **Version:** 2.9.6
+1. **Group:** com.fasterxml.jackson.core **Name:** jackson-databind **Version:** 2.9.8
      * **Project URL:** [http://github.com/FasterXML/jackson](http://github.com/FasterXML/jackson)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -3526,38 +3350,31 @@ This report was generated on **Thu Apr 25 2019 14:59:06 GMT+0300 (FLE Daylight T
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.6.1
-     * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-     * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.7.1
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.6.1
+1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.7.1
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** com.google.protobuf **Name:** protoc **Version:** 3.7.1
      * **POM Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth **Name:** truth **Version:** 0.43
+1. **Group:** com.google.truth **Name:** truth **Version:** 0.44
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-java8-extension **Version:** 0.43
+1. **Group:** com.google.truth.extensions **Name:** truth-java8-extension **Version:** 0.44
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-liteproto-extension **Version:** 0.43
+1. **Group:** com.google.truth.extensions **Name:** truth-liteproto-extension **Version:** 0.44
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-proto-extension **Version:** 0.43
+1. **Group:** com.google.truth.extensions **Name:** truth-proto-extension **Version:** 0.44
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** com.googlecode.java-diff-utils **Name:** diffutils **Version:** 1.3.0
@@ -3565,7 +3382,7 @@ This report was generated on **Thu Apr 25 2019 14:59:06 GMT+0300 (FLE Daylight T
      * **POM Project URL:** [http://code.google.com/p/java-diff-utils/](http://code.google.com/p/java-diff-utils/)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.squareup **Name:** javapoet **Version:** 1.9.0
+1. **Group:** com.squareup **Name:** javapoet **Version:** 1.11.0
      * **POM Project URL:** [http://github.com/square/javapoet/](http://github.com/square/javapoet/)
      * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -3654,7 +3471,7 @@ This report was generated on **Thu Apr 25 2019 14:59:06 GMT+0300 (FLE Daylight T
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** protoc-gen-grpc-java **Version:** 1.18.0
+1. **Group:** io.grpc **Name:** protoc-gen-grpc-java **Version:** 1.20.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -3827,10 +3644,6 @@ This report was generated on **Thu Apr 25 2019 14:59:06 GMT+0300 (FLE Daylight T
      * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
      * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
 
-1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.7.0
-     * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
-     * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
-
 1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.8.0
      * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
      * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
@@ -3962,12 +3775,12 @@ This report was generated on **Thu Apr 25 2019 14:59:06 GMT+0300 (FLE Daylight T
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Apr 25 14:59:21 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 02 19:31:59 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-web:1.0.0-SNAPSHOT`
+# Dependencies of `io.spine:spine-web:1.0.0-pre7`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -4021,11 +3834,10 @@ This report was generated on **Thu Apr 25 14:59:21 EEST 2019** using [Gradle-Lic
      * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.6.1
+1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.7.1
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** com.squareup.okhttp **Name:** okhttp **Version:** 2.5.0
      * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -4262,38 +4074,31 @@ This report was generated on **Thu Apr 25 14:59:21 EEST 2019** using [Gradle-Lic
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.6.1
-     * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-     * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.7.1
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.6.1
+1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.7.1
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** com.google.protobuf **Name:** protoc **Version:** 3.7.1
      * **POM Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth **Name:** truth **Version:** 0.43
+1. **Group:** com.google.truth **Name:** truth **Version:** 0.44
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-java8-extension **Version:** 0.43
+1. **Group:** com.google.truth.extensions **Name:** truth-java8-extension **Version:** 0.44
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-liteproto-extension **Version:** 0.43
+1. **Group:** com.google.truth.extensions **Name:** truth-liteproto-extension **Version:** 0.44
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-proto-extension **Version:** 0.43
+1. **Group:** com.google.truth.extensions **Name:** truth-proto-extension **Version:** 0.44
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** com.googlecode.java-diff-utils **Name:** diffutils **Version:** 1.3.0
@@ -4301,7 +4106,7 @@ This report was generated on **Thu Apr 25 14:59:21 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [http://code.google.com/p/java-diff-utils/](http://code.google.com/p/java-diff-utils/)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.squareup **Name:** javapoet **Version:** 1.9.0
+1. **Group:** com.squareup **Name:** javapoet **Version:** 1.11.0
      * **POM Project URL:** [http://github.com/square/javapoet/](http://github.com/square/javapoet/)
      * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -4354,7 +4159,7 @@ This report was generated on **Thu Apr 25 14:59:21 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** protoc-gen-grpc-java **Version:** 1.18.0
+1. **Group:** io.grpc **Name:** protoc-gen-grpc-java **Version:** 1.20.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -4483,10 +4288,6 @@ This report was generated on **Thu Apr 25 14:59:21 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
      * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
 
-1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.7.0
-     * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
-     * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
-
 1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.8.0
      * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
      * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
@@ -4607,12 +4408,12 @@ This report was generated on **Thu Apr 25 14:59:21 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Apr 25 14:59:30 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 02 19:32:00 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-web-tests:1.0.0-SNAPSHOT`
+# Dependencies of `io.spine:spine-web-tests:1.0.0-pre7`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson.core **Name:** jackson-annotations **Version:** 2.9.0
@@ -4620,12 +4421,12 @@ This report was generated on **Thu Apr 25 14:59:30 EEST 2019** using [Gradle-Lic
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.fasterxml.jackson.core **Name:** jackson-core **Version:** 2.9.6
+1. **Group:** com.fasterxml.jackson.core **Name:** jackson-core **Version:** 2.9.8
      * **Project URL:** [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.fasterxml.jackson.core **Name:** jackson-databind **Version:** 2.9.6
+1. **Group:** com.fasterxml.jackson.core **Name:** jackson-databind **Version:** 2.9.8
      * **Project URL:** [http://github.com/FasterXML/jackson](http://github.com/FasterXML/jackson)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -4772,11 +4573,10 @@ This report was generated on **Thu Apr 25 14:59:30 EEST 2019** using [Gradle-Lic
      * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.6.1
+1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.7.1
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** com.squareup.okhttp **Name:** okhttp **Version:** 2.5.0
      * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -4978,7 +4778,12 @@ This report was generated on **Thu Apr 25 14:59:30 EEST 2019** using [Gradle-Lic
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.fasterxml.jackson.core **Name:** jackson-databind **Version:** 2.9.6
+1. **Group:** com.fasterxml.jackson.core **Name:** jackson-core **Version:** 2.9.8
+     * **Project URL:** [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** com.fasterxml.jackson.core **Name:** jackson-databind **Version:** 2.9.8
      * **Project URL:** [http://github.com/FasterXML/jackson](http://github.com/FasterXML/jackson)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -5176,38 +4981,31 @@ This report was generated on **Thu Apr 25 14:59:30 EEST 2019** using [Gradle-Lic
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.6.1
-     * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-     * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.7.1
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.6.1
+1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.7.1
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.protobuf **Name:** protoc **Version:** 3.6.1
+1. **Group:** com.google.protobuf **Name:** protoc **Version:** 3.7.1
      * **POM Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth **Name:** truth **Version:** 0.43
+1. **Group:** com.google.truth **Name:** truth **Version:** 0.44
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-java8-extension **Version:** 0.43
+1. **Group:** com.google.truth.extensions **Name:** truth-java8-extension **Version:** 0.44
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-liteproto-extension **Version:** 0.43
+1. **Group:** com.google.truth.extensions **Name:** truth-liteproto-extension **Version:** 0.44
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-proto-extension **Version:** 0.43
+1. **Group:** com.google.truth.extensions **Name:** truth-proto-extension **Version:** 0.44
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** com.googlecode.java-diff-utils **Name:** diffutils **Version:** 1.3.0
@@ -5215,7 +5013,7 @@ This report was generated on **Thu Apr 25 14:59:30 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [http://code.google.com/p/java-diff-utils/](http://code.google.com/p/java-diff-utils/)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.squareup **Name:** javapoet **Version:** 1.9.0
+1. **Group:** com.squareup **Name:** javapoet **Version:** 1.11.0
      * **POM Project URL:** [http://github.com/square/javapoet/](http://github.com/square/javapoet/)
      * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -5304,7 +5102,7 @@ This report was generated on **Thu Apr 25 14:59:30 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** protoc-gen-grpc-java **Version:** 1.18.0
+1. **Group:** io.grpc **Name:** protoc-gen-grpc-java **Version:** 1.20.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -5481,10 +5279,6 @@ This report was generated on **Thu Apr 25 14:59:30 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
      * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
 
-1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.7.0
-     * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
-     * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
-
 1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.8.0
      * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
      * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
@@ -5616,4 +5410,4 @@ This report was generated on **Thu Apr 25 14:59:30 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Apr 25 14:59:43 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 02 19:32:01 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -623,10 +623,10 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu May 02 19:31:55 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 02 19:55:27 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
-#NPM dependencies of `spine-web@0.16.0`
+#NPM dependencies of `spine-web@0.16.1`
 
 ## `Production` dependencies:
 
@@ -657,7 +657,7 @@ This report was generated on **Thu May 02 19:31:55 EEST 2019** using [Gradle-Lic
 1. **safer-buffer@2.1.2**
    * Licenses: MIT
    * Repository: https://github.com/ChALkeR/safer-buffer
-1. **spine-web@0.16.0**
+1. **spine-web@0.16.1**
    * Licenses: Apache-2.0
    * Repository: https://github.com/SpineEventEngine/web
 1. **tslib@1.9.3**
@@ -2519,7 +2519,7 @@ This report was generated on **Thu May 02 19:31:55 EEST 2019** using [Gradle-Lic
 1. **spdx-satisfies@4.0.1**
    * Licenses: MIT
    * Repository: https://github.com/kemitchell/spdx-satisfies.js
-1. **spine-web@0.16.0**
+1. **spine-web@0.16.1**
    * Licenses: Apache-2.0
    * Repository: https://github.com/SpineEventEngine/web
 1. **split-string@3.1.0**
@@ -2791,7 +2791,7 @@ This report was generated on **Thu May 02 19:31:55 EEST 2019** using [Gradle-Lic
    * Repository: https://github.com/bcoe/yargs
 
 
-This report was generated on **Thu May 02 2019 19:31:58 GMT+0300 (EEST)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
+This report was generated on **Thu May 02 2019 19:55:29 GMT+0300 (EEST)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
 
 
 
@@ -3775,7 +3775,7 @@ This report was generated on **Thu May 02 2019 19:31:58 GMT+0300 (EEST)** using 
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu May 02 19:31:59 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 02 19:55:31 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4408,7 +4408,7 @@ This report was generated on **Thu May 02 19:31:59 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu May 02 19:32:00 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 02 19:55:31 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5410,4 +5410,4 @@ This report was generated on **Thu May 02 19:32:00 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu May 02 19:32:01 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 02 19:55:32 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/version.gradle
+++ b/version.gradle
@@ -25,7 +25,7 @@ ext {
     spineBaseVersion = SPINE_VERSION
     
     versionToPublish = SPINE_VERSION
-    versionToPublishJs = '0.16.0'
+    versionToPublishJs = '0.16.1'
 
     servletApiVersion = '4.0.0'
 }


### PR DESCRIPTION
Currently, `spine-web` module has a dependency on the whole `firebase` namespace.
The dependency is not actually used, as JS does not require importing types of objects in use. Thus the `firebase` dependency is removed.

JS version is advanced to `0.16.1`.
Java version is unchanged.