### PR TITLE
Update query API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,11 +124,6 @@ subprojects {
     }
 
     forceConfiguration(project)
-    configurations.all {
-        resolutionStrategy {
-            force("io.netty:netty-codec:4.1.35.Final")
-        }
-    }
     configurations.all({
         resolutionStrategy {
 

--- a/build.gradle
+++ b/build.gradle
@@ -124,6 +124,11 @@ subprojects {
     }
 
     forceConfiguration(project)
+    configurations.all {
+        resolutionStrategy {
+            force("io.netty:netty-codec:4.1.35.Final")
+        }
+    }
     configurations.all({
         resolutionStrategy {
 

--- a/client-js/main/client/actor-request-factory.js
+++ b/client-js/main/client/actor-request-factory.js
@@ -24,21 +24,21 @@ import uuid from 'uuid';
 
 import {Message} from 'google-protobuf';
 import {Timestamp} from '../proto/google/protobuf/timestamp_pb';
-import {Query, QueryId} from '../proto/spine/client/query_pb';
+import {Query, QueryId, ResponseFormat} from '../proto/spine/client/query_pb';
 import {Topic, TopicId} from '../proto/spine/client/subscription_pb';
 import {
-  Filter,
   CompositeFilter,
-  TargetFilters,
+  Filter,
   IdFilter,
-  Target
+  Target,
+  TargetFilters
 } from '../proto/spine/client/filters_pb';
 import {ActorContext} from '../proto/spine/core/actor_context_pb';
 import {Command, CommandContext, CommandId} from '../proto/spine/core/command_pb';
 import {UserId} from '../proto/spine/core/user_id_pb';
 import {ZoneId, ZoneOffset} from '../proto/spine/time/time_pb';
 import {FieldMask} from '../proto/google/protobuf/field_mask_pb';
-import {Type, TypedMessage, isProtobufMessage} from './typed-message';
+import {isProtobufMessage, Type, TypedMessage} from './typed-message';
 import {AnyPacker} from './any-packer';
 import {FieldPaths} from './field-paths';
 
@@ -671,24 +671,29 @@ class QueryFactory {
    * @param {?FieldMask} withMask a specification of fields to be returned by executing `Query`
    * @return {Query}
    */
-  compose({forTarget: target, withMask: fieldMask}) {
-    return this._newQuery(target, fieldMask);
+  compose({forTarget: target, withMask: fieldMask, limit: limit}) {
+    return this._newQuery(target, fieldMask, limit);
   }
 
   /**
    * @param {!Target} target a specification of type and filters for `Query` result to match
    * @param {?FieldMask} fieldMask a specification of fields to be returned by executing `Query`
+   * @param {?Number} limit the maximum number of the requested entities
    * @return {Query} a new query instance
    * @private
    */
-  _newQuery(target, fieldMask) {
+  _newQuery(target, fieldMask, limit) {
     const id = QueryFactory._newId();
     const actorContext = this._requestFactory._actorContext();
+
+    const format = new ResponseFormat();
+    format.setFieldMask(fieldMask);
+    format.setLimit(limit);
 
     const result = new Query();
     result.setId(id);
     result.setTarget(target);
-    result.setFieldMask(fieldMask);
+    result.setFormat(format);
     result.setContext(actorContext);
 
     return result;

--- a/client-js/main/client/actor-request-factory.js
+++ b/client-js/main/client/actor-request-factory.js
@@ -27,11 +27,11 @@ import {Timestamp} from '../proto/google/protobuf/timestamp_pb';
 import {Query, QueryId, ResponseFormat} from '../proto/spine/client/query_pb';
 import {Topic, TopicId} from '../proto/spine/client/subscription_pb';
 import {
-  CompositeFilter,
-  Filter,
-  IdFilter,
-  Target,
-  TargetFilters
+    CompositeFilter,
+    Filter,
+    IdFilter,
+    Target,
+    TargetFilters
 } from '../proto/spine/client/filters_pb';
 import {ActorContext} from '../proto/spine/core/actor_context_pb';
 import {Command, CommandContext, CommandId} from '../proto/spine/core/command_pb';
@@ -625,10 +625,6 @@ class QueryBuilder extends AbstractTargetBuilder {
     this._factory = queryFactory;
 
     /**
-     * Max number of entities to retrieve as the query response.
-     *
-     * The value must be non-negative. If set to `0`, all the available entities are retrieved.
-     *
      * @type {number}
      * @private
      */
@@ -637,6 +633,9 @@ class QueryBuilder extends AbstractTargetBuilder {
 
   /**
    * Limits the query response to the given number of entities.
+   *
+   * The value must be non-negative, otherwise an error occurs. If set to `0`, all the available
+   * entities are retrieved.
    *
    * @param {number} limit the max number of response entities
    */

--- a/client-js/main/client/actor-request-factory.js
+++ b/client-js/main/client/actor-request-factory.js
@@ -623,6 +623,29 @@ class QueryBuilder extends AbstractTargetBuilder {
      * @private
      */
     this._factory = queryFactory;
+
+    /**
+     * Max number of entities to retrieve as the query response.
+     *
+     * The value must be non-negative. If set to `0`, all the available entities are retrieved.
+     *
+     * @type {number}
+     * @private
+     */
+    this._limit = 0;
+  }
+
+  /**
+   * Limits the query response to the given number of entities.
+   *
+   * @param {number} limit the max number of response entities
+   */
+  limit(limit) {
+    if (limit < 0) {
+      throw new Error("Query limit must not be negative.");
+    }
+    this._limit = limit;
+    return this;
   }
 
   /**
@@ -633,7 +656,8 @@ class QueryBuilder extends AbstractTargetBuilder {
   build() {
     const target = this.getTarget();
     const fieldMask = this.getMask();
-    return this._factory.compose({forTarget: target, withMask: fieldMask});
+    const limit = this._limit;
+    return this._factory.compose({forTarget: target, withMask: fieldMask, limit: limit});
   }
 }
 
@@ -668,7 +692,8 @@ class QueryFactory {
    * An optional field mask can be provided to specify particular fields to be returned for `Query`
    *
    * @param {!Target} forTarget a specification of type and filters for `Query` result to match
-   * @param {?FieldMask} withMask a specification of fields to be returned by executing `Query`
+   * @param {?FieldMask} fieldMask a specification of fields to be returned by executing `Query`
+   * @param {number} limit max number of entities to fetch
    * @return {Query}
    */
   compose({forTarget: target, withMask: fieldMask, limit: limit}) {

--- a/client-js/test/client/query-builder-test.js
+++ b/client-js/test/client/query-builder-test.js
@@ -23,15 +23,11 @@ import assert from 'assert';
 
 import {Message} from 'google-protobuf';
 import {Type} from '@lib/client/typed-message';
-import {ActorRequestFactory, ActorProvider, Filters} from '@lib/client/actor-request-factory';
+import {ActorProvider, ActorRequestFactory, Filters} from '@lib/client/actor-request-factory';
 import {AnyPacker} from '@lib/client/any-packer';
 import {Duration} from '@lib/client/time-utils';
 import {Task, TaskId} from '@testProto/spine/web/test/given/task_pb';
-import {
-  Filter,
-  CompositeFilter,
-  TargetFilters
-} from '@proto/spine/client/filters_pb';
+import {CompositeFilter, Filter, TargetFilters} from '@proto/spine/client/filters_pb';
 
 class Given {
 
@@ -482,7 +478,7 @@ describe('QueryBuilder', function () {
     assert.ok(target.getIncludeAll());
     Given.assertTargetTypeEqual(target, Given.TYPE.TASK);
 
-    Given.assertUnorderedEqual(query.getFieldMask().getPathsList(), maskedFields);
+    Given.assertUnorderedEqual(query.getFormat().getFieldMask().getPathsList(), maskedFields);
 
     done();
   });

--- a/client-js/test/client/query-builder-test.js
+++ b/client-js/test/client/query-builder-test.js
@@ -286,7 +286,7 @@ describe('QueryBuilder', function () {
 
   /********* FILTERS *********/
 
-  it('creates a Query with a no filters', done => {
+  it('creates a Query with no filters', done => {
     const query = Given.requestFactory()
       .query()
       .select(Given.ENTITY_CLASS.TASK)
@@ -518,5 +518,25 @@ describe('QueryBuilder', function () {
     } catch (e) {
       done();
     }
+  });
+
+  /********* LIMIT *********/
+
+  it('creates a Query with a limit', done => {
+    const limit = 42;
+    const query = Given.requestFactory()
+        .query()
+        .select(Given.ENTITY_CLASS.TASK)
+        .limit(limit)
+        .build();
+
+    assert.ok(query.getId());
+
+    Given.assertActorContextCorrect(query.getContext());
+
+    const format = query.getFormat();
+    assert.equal(limit, format.getLimit());
+
+    done();
   });
 });

--- a/firebase-web/build.gradle
+++ b/firebase-web/build.gradle
@@ -43,10 +43,6 @@ dependencies {
     implementation "io.spine:spine-client:$spineVersion"
 }
 
-modelCompiler {
-    generateValidatingBuilders = true
-}
-
 task compileProtoToJs {
     description = "Compiles Protobuf sources into JavaScript."
 }

--- a/firebase-web/build.gradle
+++ b/firebase-web/build.gradle
@@ -38,7 +38,6 @@ dependencies {
     implementation deps.build.googleHttpClient
     implementation deps.build.googleHttpClientApache
     implementation deps.build.appengineApi
-    implementation deps.build.apacheValidator
 
     implementation "io.spine:spine-server:$spineVersion"
     implementation "io.spine:spine-client:$spineVersion"

--- a/firebase-web/src/main/java/io/spine/web/firebase/DatabaseUrls.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/DatabaseUrls.java
@@ -20,6 +20,8 @@
 
 package io.spine.web.firebase;
 
+import io.spine.net.Urls;
+
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -43,6 +45,6 @@ public final class DatabaseUrls {
         return DatabaseUrl
                 .newBuilder()
                 .setUrl(Urls.create(url))
-                .build();
+                .vBuild();
     }
 }

--- a/firebase-web/src/main/java/io/spine/web/firebase/DatabaseUrls.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/DatabaseUrls.java
@@ -20,10 +20,6 @@
 
 package io.spine.web.firebase;
 
-import io.spine.net.Urls;
-import org.apache.commons.validator.routines.UrlValidator;
-
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -38,31 +34,15 @@ public final class DatabaseUrls {
     /**
      * Creates a {@code DatabaseUrls} instance from the given string.
      *
-     * <p>The given string should be a valid URL by the Apache
-     * {@link org.apache.commons.validator.routines.UrlValidator} standards.
-     *
      * @param url
      *         a {@code String} containing database URL
      * @return a new instance of {@code DatabaseUrls}
      */
     public static DatabaseUrl from(String url) {
         checkNotNull(url);
-        validate(url);
-        return DatabaseUrlVBuilder
+        return DatabaseUrl
                 .newBuilder()
                 .setUrl(Urls.create(url))
                 .build();
-    }
-
-    public static void checkSpec(DatabaseUrl url) {
-        checkNotNull(url);
-        String spec = url.getUrl()
-                         .getSpec();
-        validate(spec);
-    }
-
-    private static void validate(String url) {
-        UrlValidator urlValidator = UrlValidator.getInstance();
-        checkArgument(urlValidator.isValid(url), "The specified database URL %s is invalid", url);
     }
 }

--- a/firebase-web/src/main/java/io/spine/web/firebase/NodePaths.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/NodePaths.java
@@ -33,9 +33,9 @@ public final class NodePaths {
 
     public static NodePath of(String path) {
         checkNotNull(path);
-        return NodePathVBuilder
+        return NodePath
                 .newBuilder()
                 .setValue(path)
-                .build();
+                .vBuild();
     }
 }

--- a/firebase-web/src/main/java/io/spine/web/firebase/query/QueryResult.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/query/QueryResult.java
@@ -49,12 +49,13 @@ final class QueryResult implements QueryProcessingResult {
 
     @Override
     public void writeTo(ServletResponse response) throws IOException {
-        FirebaseQueryResponse queryResponse =
-                FirebaseQueryResponseVBuilder.newBuilder()
-                                             .setPath(path.getValue())
-                                             .setCount(count)
-                                             .build();
-        response.getWriter().append(toCompactJson(queryResponse));
+        FirebaseQueryResponse queryResponse = FirebaseQueryResponse
+                .newBuilder()
+                .setPath(path.getValue())
+                .setCount(count)
+                .vBuild();
+        response.getWriter()
+                .append(toCompactJson(queryResponse));
         response.setContentType(JSON_MIME_TYPE);
     }
 }

--- a/firebase-web/src/main/java/io/spine/web/firebase/rest/RestNodeUrls.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/rest/RestNodeUrls.java
@@ -4,7 +4,6 @@ import com.google.api.client.http.GenericUrl;
 import io.spine.net.Url;
 import io.spine.net.Urls;
 import io.spine.web.firebase.DatabaseUrl;
-import io.spine.web.firebase.DatabaseUrls;
 import io.spine.web.firebase.NodePath;
 
 import static java.lang.String.format;
@@ -18,7 +17,6 @@ final class RestNodeUrls {
     private final String template;
 
     RestNodeUrls(DatabaseUrl url) {
-        DatabaseUrls.checkSpec(url);
         this.template = Urls.toString(url.getUrl()) + "/%s.json";
     }
 

--- a/firebase-web/src/main/java/io/spine/web/firebase/rest/RestNodeUrls.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/rest/RestNodeUrls.java
@@ -25,10 +25,10 @@ final class RestNodeUrls {
      */
     RestNodeUrl with(NodePath path) {
         Url url = Urls.create(format(template, path.getValue()));
-        RestNodeUrl node = RestNodeUrlVBuilder
+        RestNodeUrl node = RestNodeUrl
                 .newBuilder()
                 .setUrl(url)
-                .build();
+                .vBuild();
         return node;
     }
 

--- a/firebase-web/src/main/java/io/spine/web/firebase/subscription/FirebaseSubscriptionBridge.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/subscription/FirebaseSubscriptionBridge.java
@@ -75,7 +75,7 @@ public final class FirebaseSubscriptionBridge implements SubscriptionBridge {
         ResponseFormat format = ResponseFormat
                 .newBuilder()
                 .setFieldMask(topic.getFieldMask())
-                .buildPartial();
+                .build();
         return Query
                 .newBuilder()
                 .setId(generateId())

--- a/firebase-web/src/main/java/io/spine/web/firebase/subscription/FirebaseSubscriptionBridge.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/subscription/FirebaseSubscriptionBridge.java
@@ -22,6 +22,7 @@ package io.spine.web.firebase.subscription;
 
 import io.spine.client.Query;
 import io.spine.client.QueryResponse;
+import io.spine.client.ResponseFormat;
 import io.spine.client.Subscription;
 import io.spine.client.SubscriptionId;
 import io.spine.client.Topic;
@@ -71,12 +72,16 @@ public final class FirebaseSubscriptionBridge implements SubscriptionBridge {
     }
 
     private static Query newQueryForTopic(Topic topic) {
+        ResponseFormat format = ResponseFormat
+                .newBuilder()
+                .setFieldMask(topic.getFieldMask())
+                .buildPartial();
         return Query
                 .newBuilder()
                 .setId(generateId())
                 .setTarget(topic.getTarget())
-                .setFieldMask(topic.getFieldMask())
                 .setContext(topic.getContext())
+                .setFormat(format)
                 .vBuild();
     }
 

--- a/firebase-web/src/main/java/io/spine/web/firebase/subscription/diff/DiffCalculator.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/subscription/diff/DiffCalculator.java
@@ -72,23 +72,20 @@ public final class DiffCalculator {
         updates.forEach(update -> {
             switch (update.getOperation()) {
                 case ADD:
-                    added.add(AddedItemVBuilder
-                                      .newBuilder()
-                                      .setData(update.getData())
-                                      .build());
+                    added.add(AddedItem.newBuilder()
+                                       .setData(update.getData())
+                                       .vBuild());
                     break;
                 case REMOVE:
-                    removed.add(RemovedItemVBuilder
-                                        .newBuilder()
-                                        .setKey(update.getKey())
-                                        .build());
+                    removed.add(RemovedItem.newBuilder()
+                                           .setKey(update.getKey())
+                                           .vBuild());
                     break;
                 case CHANGE:
-                    changed.add(ChangedItemVBuilder
-                                        .newBuilder()
-                                        .setKey(update.getKey())
-                                        .setData(update.getData())
-                                        .build());
+                    changed.add(ChangedItem.newBuilder()
+                                           .setKey(update.getKey())
+                                           .setData(update.getData())
+                                           .vBuild());
                     break;
                 case PASS:
                 case UNRECOGNIZED:
@@ -102,11 +99,11 @@ public final class DiffCalculator {
     private static Diff diff(List<AddedItem> added,
                              List<ChangedItem> changed,
                              List<RemovedItem> removed) {
-        return DiffVBuilder
+        return Diff
                 .newBuilder()
                 .addAllAdded(added)
                 .addAllChanged(changed)
                 .addAllRemoved(removed)
-                .build();
+                .vBuild();
     }
 }

--- a/firebase-web/src/main/java/io/spine/web/firebase/subscription/diff/EntryUpdates.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/subscription/diff/EntryUpdates.java
@@ -37,37 +37,37 @@ final class EntryUpdates {
     }
 
     static EntryUpdate changeEntry(UpToDateEntry entry, ExistingEntry matchingEntry) {
-        return EntryUpdateVBuilder
+        return EntryUpdate
                 .newBuilder()
                 .setKey(matchingEntry.key())
                 .setData(entry.data())
                 .setOperation(CHANGE)
-                .build();
+                .vBuild();
     }
 
     static EntryUpdate passEntry(UpToDateEntry entry, ExistingEntry matchingEntry) {
-        return EntryUpdateVBuilder
+        return EntryUpdate
                 .newBuilder()
                 .setKey(matchingEntry.key())
                 .setData(entry.data())
                 .setOperation(PASS)
-                .build();
+                .vBuild();
     }
 
     static EntryUpdate addEntry(UpToDateEntry entry) {
-        return EntryUpdateVBuilder
+        return EntryUpdate
                 .newBuilder()
                 .setData(entry.data())
                 .setOperation(ADD)
-                .build();
+                .vBuild();
     }
 
     static EntryUpdate removeEntry(ExistingEntry existing) {
-        return EntryUpdateVBuilder
+        return EntryUpdate
                 .newBuilder()
                 .setKey(existing.key())
                 .setData(existing.data())
                 .setOperation(REMOVE)
-                .build();
+                .vBuild();
     }
 }

--- a/firebase-web/src/test/java/io/spine/web/firebase/DatabaseUrlsTest.java
+++ b/firebase-web/src/test/java/io/spine/web/firebase/DatabaseUrlsTest.java
@@ -25,13 +25,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DisplayName("DatabaseUrls should")
 class DatabaseUrlsTest extends UtilityClassTest<DatabaseUrls> {
 
     private static final String VALID_URL = "https://spine-dev.appspot.com/";
-    private static final String INVALID_URL = "invalid_url";
 
     DatabaseUrlsTest() {
         super(DatabaseUrls.class);
@@ -43,12 +41,5 @@ class DatabaseUrlsTest extends UtilityClassTest<DatabaseUrls> {
         DatabaseUrl url = DatabaseUrls.from(VALID_URL);
         assertEquals(VALID_URL, url.getUrl()
                                    .getSpec());
-    }
-
-    @SuppressWarnings({"ResultOfMethodCallIgnored", "CheckReturnValue"}) // Method called to throw.
-    @Test
-    @DisplayName("throw IAE when invalid URL passed on construction")
-    void rejectInvalidUrl() {
-        assertThrows(IllegalArgumentException.class, () -> DatabaseUrls.from(INVALID_URL));
     }
 }

--- a/firebase-web/src/test/java/io/spine/web/firebase/NodePathsTest.java
+++ b/firebase-web/src/test/java/io/spine/web/firebase/NodePathsTest.java
@@ -34,10 +34,10 @@ class NodePathsTest extends UtilityClassTest<NodePaths> {
     @Test
     void createsNodePath() {
         String testPath = "test-path";
-        NodePath expected = NodePathVBuilder
+        NodePath expected = NodePath
                 .newBuilder()
                 .setValue(testPath)
-                .build();
+                .buildPartial();
         assertEquals(expected, NodePaths.of(testPath));
     }
 }

--- a/firebase-web/src/test/java/io/spine/web/firebase/NodePathsTest.java
+++ b/firebase-web/src/test/java/io/spine/web/firebase/NodePathsTest.java
@@ -37,7 +37,7 @@ class NodePathsTest extends UtilityClassTest<NodePaths> {
         NodePath expected = NodePath
                 .newBuilder()
                 .setValue(testPath)
-                .buildPartial();
+                .build();
         assertEquals(expected, NodePaths.of(testPath));
     }
 }

--- a/firebase-web/src/test/java/io/spine/web/firebase/given/FirebaseSubscriptionRecordTestEnv.java
+++ b/firebase-web/src/test/java/io/spine/web/firebase/given/FirebaseSubscriptionRecordTestEnv.java
@@ -43,7 +43,7 @@ public final class FirebaseSubscriptionRecordTestEnv {
     }
 
     public static Book updateAuthors(Book designPatterns, List<Author> gangOfFour) {
-        BookVBuilder builder = BookVBuilder.newBuilder();
+        Book.Builder builder = Book.newBuilder();
         builder.mergeFrom(designPatterns);
         return builder.clearAuthors()
                       .addAllAuthors(gangOfFour)
@@ -95,17 +95,17 @@ public final class FirebaseSubscriptionRecordTestEnv {
         }
 
         private static Book book(BookId id, String name, Author author) {
-            return BookVBuilder.newBuilder()
-                               .setId(id)
-                               .setName(name)
-                               .addAuthors(author)
-                               .build();
+            return Book.newBuilder()
+                       .setId(id)
+                       .setName(name)
+                       .addAuthors(author)
+                       .build();
         }
 
         private static BookId bookId() {
-            return BookIdVBuilder.newBuilder()
-                                 .setValue(newUuid())
-                                 .build();
+            return BookId.newBuilder()
+                         .setValue(newUuid())
+                         .build();
         }
     }
 

--- a/firebase-web/src/test/java/io/spine/web/firebase/query/QueryResultTest.java
+++ b/firebase-web/src/test/java/io/spine/web/firebase/query/QueryResultTest.java
@@ -77,10 +77,11 @@ class QueryResultTest {
 
     private static FirebaseQueryResponse toQueryResponse(NodePath path, long count) {
         FirebaseQueryResponse response =
-                FirebaseQueryResponseVBuilder.newBuilder()
-                                             .setPath(path.getValue())
-                                             .setCount(count)
-                                             .build();
+                FirebaseQueryResponse
+                        .newBuilder()
+                        .setPath(path.getValue())
+                        .setCount(count)
+                        .vBuild();
         return response;
     }
 }

--- a/firebase-web/src/test/java/io/spine/web/firebase/subscription/diff/EntryUpdatesTest.java
+++ b/firebase-web/src/test/java/io/spine/web/firebase/subscription/diff/EntryUpdatesTest.java
@@ -71,7 +71,7 @@ class EntryUpdatesTest extends UtilityClassTest<EntryUpdates> {
                                             .setKey(OLD_ENTRY.key())
                                             .setData(NEW_ENTRY.data())
                                             .setOperation(CHANGE)
-                                            .buildPartial());
+                                            .build());
     }
 
     @Test
@@ -83,7 +83,7 @@ class EntryUpdatesTest extends UtilityClassTest<EntryUpdates> {
                                             .setKey(EXISTING_ENTRY.key())
                                             .setData(UP_TO_DATE_ENTRY.data())
                                             .setOperation(PASS)
-                                            .buildPartial());
+                                            .build());
     }
 
     @Test
@@ -94,7 +94,7 @@ class EntryUpdatesTest extends UtilityClassTest<EntryUpdates> {
                                             .newBuilder()
                                             .setData(UP_TO_DATE_ENTRY.data())
                                             .setOperation(ADD)
-                                            .buildPartial());
+                                            .build());
     }
 
     @Test
@@ -106,7 +106,7 @@ class EntryUpdatesTest extends UtilityClassTest<EntryUpdates> {
                                             .setKey(EXISTING_ENTRY.key())
                                             .setData(EXISTING_ENTRY.data())
                                             .setOperation(REMOVE)
-                                            .buildPartial());
+                                            .build());
     }
 
     private static ExistingEntry existingEntry(String value) {

--- a/firebase-web/src/test/java/io/spine/web/firebase/subscription/diff/EntryUpdatesTest.java
+++ b/firebase-web/src/test/java/io/spine/web/firebase/subscription/diff/EntryUpdatesTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.truth.extensions.proto.ProtoTruth.assertThat;
 import static io.spine.web.firebase.subscription.diff.EntryUpdate.Operation.ADD;
 import static io.spine.web.firebase.subscription.diff.EntryUpdate.Operation.CHANGE;
 import static io.spine.web.firebase.subscription.diff.EntryUpdate.Operation.PASS;
@@ -38,7 +39,6 @@ import static io.spine.web.firebase.subscription.diff.EntryUpdates.removeEntry;
 import static io.spine.web.firebase.subscription.diff.ExistingEntry.fromJson;
 import static io.spine.web.firebase.subscription.given.HasChildren.anyKey;
 import static java.lang.String.format;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test for {@link EntryUpdates}.
@@ -66,47 +66,47 @@ class EntryUpdatesTest extends UtilityClassTest<EntryUpdates> {
     void createsChangeEntry() {
         EntryUpdate entry = changeEntry(NEW_ENTRY, OLD_ENTRY);
 
-        assertEquals(EntryUpdateVBuilder
-                             .newBuilder()
-                             .setKey(OLD_ENTRY.key())
-                             .setData(NEW_ENTRY.data())
-                             .setOperation(CHANGE)
-                             .build(), entry);
+        assertThat(entry).isEqualTo(EntryUpdate
+                                            .newBuilder()
+                                            .setKey(OLD_ENTRY.key())
+                                            .setData(NEW_ENTRY.data())
+                                            .setOperation(CHANGE)
+                                            .buildPartial());
     }
 
     @Test
     void createsPassEntry() {
         EntryUpdate entry = passEntry(UP_TO_DATE_ENTRY, EXISTING_ENTRY);
 
-        assertEquals(EntryUpdateVBuilder
-                             .newBuilder()
-                             .setKey(EXISTING_ENTRY.key())
-                             .setData(UP_TO_DATE_ENTRY.data())
-                             .setOperation(PASS)
-                             .build(), entry);
+        assertThat(entry).isEqualTo(EntryUpdate
+                                            .newBuilder()
+                                            .setKey(EXISTING_ENTRY.key())
+                                            .setData(UP_TO_DATE_ENTRY.data())
+                                            .setOperation(PASS)
+                                            .buildPartial());
     }
 
     @Test
     void createsAddEntry() {
         EntryUpdate entry = addEntry(UP_TO_DATE_ENTRY);
 
-        assertEquals(EntryUpdateVBuilder
-                             .newBuilder()
-                             .setData(UP_TO_DATE_ENTRY.data())
-                             .setOperation(ADD)
-                             .build(), entry);
+        assertThat(entry).isEqualTo(EntryUpdate
+                                            .newBuilder()
+                                            .setData(UP_TO_DATE_ENTRY.data())
+                                            .setOperation(ADD)
+                                            .buildPartial());
     }
 
     @Test
     void createsRemoveEntry() {
         EntryUpdate entry = removeEntry(EXISTING_ENTRY);
 
-        assertEquals(EntryUpdateVBuilder
-                             .newBuilder()
-                             .setKey(EXISTING_ENTRY.key())
-                             .setData(EXISTING_ENTRY.data())
-                             .setOperation(REMOVE)
-                             .build(), entry);
+        assertThat(entry).isEqualTo(EntryUpdate
+                                            .newBuilder()
+                                            .setKey(EXISTING_ENTRY.key())
+                                            .setData(EXISTING_ENTRY.data())
+                                            .setOperation(REMOVE)
+                                            .buildPartial());
     }
 
     private static ExistingEntry existingEntry(String value) {

--- a/gradlew
+++ b/gradlew
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -5,7 +5,7 @@
 @rem you may not use this file except in compliance with the License.
 @rem You may obtain a copy of the License at
 @rem
-@rem      http://www.apache.org/licenses/LICENSE-2.0
+@rem      https://www.apache.org/licenses/LICENSE-2.0
 @rem
 @rem Unless required by applicable law or agreed to in writing, software
 @rem distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -69,4 +69,4 @@ To run the integration tests do the following:
        two-step package linking see `npm-link` [documentation](https://docs.npmjs.com/cli/link);
      - runs the local backend server from the `test-app` module;
      - performs integration tests;
-     - stops the local server when test complete or fail;
+     - stops the local server when test complete or fail.

--- a/license-report.md
+++ b/license-report.md
@@ -59,7 +59,7 @@
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.fasterxml.jackson.core **Name:** jackson-databind **Version:** 2.9.9
+1. **Group:** com.fasterxml.jackson.core **Name:** jackson-databind **Version:** 2.9.9.1
      * **Project URL:** [http://github.com/FasterXML/jackson](http://github.com/FasterXML/jackson)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -588,7 +588,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Jul 23 12:16:17 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 23 18:13:45 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 #NPM dependencies of `spine-web@0.18.0`
@@ -2709,7 +2709,7 @@ This report was generated on **Tue Jul 23 12:16:17 EEST 2019** using [Gradle-Lic
 1. **webpack-sources@1.3.0**
      * Licenses: MIT
      * Repository: [https://github.com/webpack/webpack-sources](https://github.com/webpack/webpack-sources)
-1. **webpack@4.36.1**
+1. **webpack@4.37.0**
      * Licenses: MIT
      * Repository: [https://github.com/webpack/webpack](https://github.com/webpack/webpack)
 1. **websocket-driver@0.7.3**
@@ -2783,7 +2783,7 @@ This report was generated on **Tue Jul 23 12:16:17 EEST 2019** using [Gradle-Lic
      * Repository: [https://github.com/bcoe/yargs](https://github.com/bcoe/yargs)
 
 
-This report was generated on **Tue Jul 23 2019 12:16:20 GMT+0300 (EEST)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
+This report was generated on **Tue Jul 23 2019 18:13:48 GMT+0300 (EEST)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
 
 
 
@@ -2801,7 +2801,7 @@ This report was generated on **Tue Jul 23 2019 12:16:20 GMT+0300 (EEST)** using 
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.fasterxml.jackson.core **Name:** jackson-databind **Version:** 2.9.9
+1. **Group:** com.fasterxml.jackson.core **Name:** jackson-databind **Version:** 2.9.9.1
      * **Project URL:** [http://github.com/FasterXML/jackson](http://github.com/FasterXML/jackson)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -3133,7 +3133,7 @@ This report was generated on **Tue Jul 23 2019 12:16:20 GMT+0300 (EEST)** using 
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.fasterxml.jackson.core **Name:** jackson-databind **Version:** 2.9.9
+1. **Group:** com.fasterxml.jackson.core **Name:** jackson-databind **Version:** 2.9.9.1
      * **Project URL:** [http://github.com/FasterXML/jackson](http://github.com/FasterXML/jackson)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -3725,7 +3725,7 @@ This report was generated on **Tue Jul 23 2019 12:16:20 GMT+0300 (EEST)** using 
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Jul 23 12:16:21 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 23 18:13:49 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3743,7 +3743,7 @@ This report was generated on **Tue Jul 23 12:16:21 EEST 2019** using [Gradle-Lic
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.fasterxml.jackson.core **Name:** jackson-databind **Version:** 2.9.9
+1. **Group:** com.fasterxml.jackson.core **Name:** jackson-databind **Version:** 2.9.9.1
      * **Project URL:** [http://github.com/FasterXML/jackson](http://github.com/FasterXML/jackson)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -4099,7 +4099,7 @@ This report was generated on **Tue Jul 23 12:16:21 EEST 2019** using [Gradle-Lic
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.fasterxml.jackson.core **Name:** jackson-databind **Version:** 2.9.9
+1. **Group:** com.fasterxml.jackson.core **Name:** jackson-databind **Version:** 2.9.9.1
      * **Project URL:** [http://github.com/FasterXML/jackson](http://github.com/FasterXML/jackson)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -5596,7 +5596,7 @@ This report was generated on **Tue Jul 23 12:16:21 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Jul 23 12:18:03 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 23 18:13:51 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6200,7 +6200,7 @@ This report was generated on **Tue Jul 23 12:18:03 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Jul 23 12:18:03 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 23 18:13:52 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6264,7 +6264,7 @@ This report was generated on **Tue Jul 23 12:18:03 EEST 2019** using [Gradle-Lic
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.fasterxml.jackson.core **Name:** jackson-databind **Version:** 2.9.9
+1. **Group:** com.fasterxml.jackson.core **Name:** jackson-databind **Version:** 2.9.9.1
      * **Project URL:** [http://github.com/FasterXML/jackson](http://github.com/FasterXML/jackson)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -6793,4 +6793,4 @@ This report was generated on **Tue Jul 23 12:18:03 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Jul 23 12:18:04 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 23 18:13:53 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -31,7 +31,7 @@
      * **POM Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.8.2
+1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.9.0
      * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
      * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
 
@@ -246,17 +246,17 @@
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.8.0
+1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.9.0
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.8.0
+1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.9.0
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1. **Group:** com.google.protobuf **Name:** protoc **Version:** 3.8.0
+1. **Group:** com.google.protobuf **Name:** protoc **Version:** 3.9.0
      * **POM Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -284,25 +284,10 @@
 1. **Group:** com.squareup.okio **Name:** okio **Version:** 1.13.0
      * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** commons-beanutils **Name:** commons-beanutils **Version:** 1.9.2
-     * **Project URL:** [http://commons.apache.org/proper/commons-beanutils/](http://commons.apache.org/proper/commons-beanutils/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1. **Group:** commons-codec **Name:** commons-codec **Version:** 1.10
      * **Project URL:** [http://commons.apache.org/proper/commons-codec/](http://commons.apache.org/proper/commons-codec/)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1. **Group:** commons-collections **Name:** commons-collections **Version:** 3.2.2
-     * **Project URL:** [http://commons.apache.org/collections/](http://commons.apache.org/collections/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1. **Group:** commons-digester **Name:** commons-digester **Version:** 1.8.1
-     * **Project URL:** [http://commons.apache.org/digester/](http://commons.apache.org/digester/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** commons-io **Name:** commons-io **Version:** 2.6
      * **Project URL:** [http://commons.apache.org/proper/commons-io/](http://commons.apache.org/proper/commons-io/)
@@ -314,12 +299,7 @@
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** commons-validator **Name:** commons-validator **Version:** 1.6
-     * **Project URL:** [http://commons.apache.org/proper/commons-validator/](http://commons.apache.org/proper/commons-validator/)
-     * **Manifest license URL:** [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **POM License: Apache License, Version 2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1. **Group:** io.grpc **Name:** grpc-api **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-api **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -327,15 +307,11 @@
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-core **Version:** 1.21.0
-     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
-     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
-
-1. **Group:** io.grpc **Name:** grpc-netty **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-core **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -343,19 +319,19 @@
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-okhttp **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-okhttp **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-protobuf **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-protobuf **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-protobuf-lite **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-protobuf-lite **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-stub **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-stub **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -374,27 +350,12 @@
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
-1. **Group:** io.netty **Name:** netty-codec-http2 **Version:** 4.1.34.Final
-     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
-1. **Group:** io.netty **Name:** netty-codec-socks **Version:** 4.1.34.Final
-     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
 1. **Group:** io.netty **Name:** netty-common **Version:** 4.1.34.Final
      * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
 1. **Group:** io.netty **Name:** netty-handler **Version:** 4.1.34.Final
-     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
-1. **Group:** io.netty **Name:** netty-handler-proxy **Version:** 4.1.34.Final
      * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
@@ -424,6 +385,10 @@
 1. **Group:** io.opencensus **Name:** opencensus-contrib-http-util **Version:** 0.18.0
      * **POM Project URL:** [https://github.com/census-instrumentation/opencensus-java](https://github.com/census-instrumentation/opencensus-java)
      * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** io.perfmark **Name:** perfmark-api **Version:** 0.16.0
+     * **POM Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
 1. **Group:** javax.servlet **Name:** javax.servlet-api **Version:** 3.1.0
      * **Manifest Project URL:** [https://glassfish.dev.java.net](https://glassfish.dev.java.net)
@@ -460,10 +425,10 @@
      * **POM Project URL:** [https://javacc.dev.java.net/](https://javacc.dev.java.net/)
      * **POM License: Berkeley Software Distribution (BSD) License** - [http://www.opensource.org/licenses/bsd-license.html](http://www.opensource.org/licenses/bsd-license.html)
 
-1. **Group:** net.sourceforge.pmd **Name:** pmd-core **Version:** 6.13.0
+1. **Group:** net.sourceforge.pmd **Name:** pmd-core **Version:** 6.16.0
      * **POM License: BSD-style** - [http://pmd.sourceforge.net/license.html](http://pmd.sourceforge.net/license.html)
 
-1. **Group:** net.sourceforge.pmd **Name:** pmd-java **Version:** 6.13.0
+1. **Group:** net.sourceforge.pmd **Name:** pmd-java **Version:** 6.16.0
      * **POM License: BSD-style** - [http://pmd.sourceforge.net/license.html](http://pmd.sourceforge.net/license.html)
 
 1. **Group:** net.sourceforge.saxon **Name:** saxon **Version:** 9.1.0.8
@@ -497,7 +462,7 @@
      * **POM License: GNU General Public License, version 2 (GPL2), with the classpath exception** - [http://www.gnu.org/software/classpath/license.html](http://www.gnu.org/software/classpath/license.html)
      * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
 
-1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.8.2
+1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.9.0
      * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
      * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
 
@@ -623,7 +588,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 23 12:16:17 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 #NPM dependencies of `spine-web@0.18.0`
@@ -636,7 +601,7 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **encoding@0.1.12**
      * Licenses: MIT
      * Repository: [https://github.com/andris9/encoding](https://github.com/andris9/encoding)
-1. **google-protobuf@3.8.0**
+1. **google-protobuf@3.9.0**
      * Licenses: BSD-3-Clause
      * Repository: [https://github.com/protocolbuffers/protobuf/tree/master/js](https://github.com/protocolbuffers/protobuf/tree/master/js)
 1. **iconv-lite@0.4.24**
@@ -660,7 +625,7 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **spine-web@0.18.0**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/SpineEventEngine/web](https://github.com/SpineEventEngine/web)
-1. **tslib@1.9.3**
+1. **tslib@1.10.0**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/Microsoft/tslib](https://github.com/Microsoft/tslib)
 1. **uuid@3.3.2**
@@ -674,16 +639,16 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 
 ## `Development` dependencies:
 
-1. **@babel/cli@7.4.4**
+1. **@babel/cli@7.5.5**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-cli](https://github.com/babel/babel/tree/master/packages/babel-cli)
-1. **@babel/code-frame@7.0.0**
+1. **@babel/code-frame@7.5.5**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-code-frame](https://github.com/babel/babel/tree/master/packages/babel-code-frame)
-1. **@babel/core@7.4.5**
+1. **@babel/core@7.5.5**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-core](https://github.com/babel/babel/tree/master/packages/babel-core)
-1. **@babel/generator@7.4.4**
+1. **@babel/generator@7.5.5**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-generator](https://github.com/babel/babel/tree/master/packages/babel-generator)
 1. **@babel/helper-annotate-as-pure@7.0.0**
@@ -695,7 +660,7 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **@babel/helper-call-delegate@7.4.4**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-helper-call-delegate](https://github.com/babel/babel/tree/master/packages/babel-helper-call-delegate)
-1. **@babel/helper-define-map@7.4.4**
+1. **@babel/helper-define-map@7.5.5**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-helper-define-map](https://github.com/babel/babel/tree/master/packages/babel-helper-define-map)
 1. **@babel/helper-explode-assignable-expression@7.1.0**
@@ -710,13 +675,13 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **@babel/helper-hoist-variables@7.4.4**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-helper-hoist-variables](https://github.com/babel/babel/tree/master/packages/babel-helper-hoist-variables)
-1. **@babel/helper-member-expression-to-functions@7.0.0**
+1. **@babel/helper-member-expression-to-functions@7.5.5**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-helper-member-expression-to-functions](https://github.com/babel/babel/tree/master/packages/babel-helper-member-expression-to-functions)
 1. **@babel/helper-module-imports@7.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-helper-module-imports](https://github.com/babel/babel/tree/master/packages/babel-helper-module-imports)
-1. **@babel/helper-module-transforms@7.4.4**
+1. **@babel/helper-module-transforms@7.5.5**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-helper-module-transforms](https://github.com/babel/babel/tree/master/packages/babel-helper-module-transforms)
 1. **@babel/helper-optimise-call-expression@7.0.0**
@@ -725,13 +690,13 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **@babel/helper-plugin-utils@7.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-helper-plugin-utils](https://github.com/babel/babel/tree/master/packages/babel-helper-plugin-utils)
-1. **@babel/helper-regex@7.4.4**
+1. **@babel/helper-regex@7.5.5**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-helper-regex](https://github.com/babel/babel/tree/master/packages/babel-helper-regex)
 1. **@babel/helper-remap-async-to-generator@7.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-helper-remap-async-to-generator](https://github.com/babel/babel/tree/master/packages/babel-helper-remap-async-to-generator)
-1. **@babel/helper-replace-supers@7.4.4**
+1. **@babel/helper-replace-supers@7.5.5**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-helper-replace-supers](https://github.com/babel/babel/tree/master/packages/babel-helper-replace-supers)
 1. **@babel/helper-simple-access@7.1.0**
@@ -743,22 +708,25 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **@babel/helper-wrap-function@7.2.0**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-helper-wrap-function](https://github.com/babel/babel/tree/master/packages/babel-helper-wrap-function)
-1. **@babel/helpers@7.4.4**
+1. **@babel/helpers@7.5.5**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-helpers](https://github.com/babel/babel/tree/master/packages/babel-helpers)
-1. **@babel/highlight@7.0.0**
+1. **@babel/highlight@7.5.0**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-highlight](https://github.com/babel/babel/tree/master/packages/babel-highlight)
-1. **@babel/parser@7.4.5**
+1. **@babel/parser@7.5.5**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-parser](https://github.com/babel/babel/tree/master/packages/babel-parser)
 1. **@babel/plugin-proposal-async-generator-functions@7.2.0**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-async-generator-functions](https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-async-generator-functions)
+1. **@babel/plugin-proposal-dynamic-import@7.5.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-dynamic-import](https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-dynamic-import)
 1. **@babel/plugin-proposal-json-strings@7.2.0**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-json-strings](https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-json-strings)
-1. **@babel/plugin-proposal-object-rest-spread@7.4.4**
+1. **@babel/plugin-proposal-object-rest-spread@7.5.5**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-object-rest-spread](https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-object-rest-spread)
 1. **@babel/plugin-proposal-optional-catch-binding@7.2.0**
@@ -770,6 +738,9 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **@babel/plugin-syntax-async-generators@7.2.0**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-async-generators](https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-async-generators)
+1. **@babel/plugin-syntax-dynamic-import@7.2.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-dynamic-import](https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-dynamic-import)
 1. **@babel/plugin-syntax-json-strings@7.2.0**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-json-strings](https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-json-strings)
@@ -782,28 +753,28 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **@babel/plugin-transform-arrow-functions@7.2.0**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-arrow-functions](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-arrow-functions)
-1. **@babel/plugin-transform-async-to-generator@7.4.4**
+1. **@babel/plugin-transform-async-to-generator@7.5.0**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-async-to-generator](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-async-to-generator)
 1. **@babel/plugin-transform-block-scoped-functions@7.2.0**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-block-scoped-functions](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-block-scoped-functions)
-1. **@babel/plugin-transform-block-scoping@7.4.4**
+1. **@babel/plugin-transform-block-scoping@7.5.5**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-block-scoping](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-block-scoping)
-1. **@babel/plugin-transform-classes@7.4.4**
+1. **@babel/plugin-transform-classes@7.5.5**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-classes](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-classes)
 1. **@babel/plugin-transform-computed-properties@7.2.0**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-computed-properties](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-computed-properties)
-1. **@babel/plugin-transform-destructuring@7.4.4**
+1. **@babel/plugin-transform-destructuring@7.5.0**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-destructuring](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-destructuring)
 1. **@babel/plugin-transform-dotall-regex@7.4.4**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-dotall-regex](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-dotall-regex)
-1. **@babel/plugin-transform-duplicate-keys@7.2.0**
+1. **@babel/plugin-transform-duplicate-keys@7.5.0**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-duplicate-keys](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-duplicate-keys)
 1. **@babel/plugin-transform-exponentiation-operator@7.2.0**
@@ -821,13 +792,13 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **@babel/plugin-transform-member-expression-literals@7.2.0**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-member-expression-literals](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-member-expression-literals)
-1. **@babel/plugin-transform-modules-amd@7.2.0**
+1. **@babel/plugin-transform-modules-amd@7.5.0**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-amd](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-amd)
-1. **@babel/plugin-transform-modules-commonjs@7.4.4**
+1. **@babel/plugin-transform-modules-commonjs@7.5.0**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-commonjs](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-commonjs)
-1. **@babel/plugin-transform-modules-systemjs@7.4.4**
+1. **@babel/plugin-transform-modules-systemjs@7.5.0**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-systemjs](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-systemjs)
 1. **@babel/plugin-transform-modules-umd@7.2.0**
@@ -839,7 +810,7 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **@babel/plugin-transform-new-target@7.4.4**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-new-target](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-new-target)
-1. **@babel/plugin-transform-object-super@7.2.0**
+1. **@babel/plugin-transform-object-super@7.5.5**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-object-super](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-object-super)
 1. **@babel/plugin-transform-parameters@7.4.4**
@@ -872,85 +843,85 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **@babel/plugin-transform-unicode-regex@7.4.4**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-unicode-regex](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-unicode-regex)
-1. **@babel/preset-env@7.4.5**
+1. **@babel/preset-env@7.5.5**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-preset-env](https://github.com/babel/babel/tree/master/packages/babel-preset-env)
-1. **@babel/register@7.4.4**
+1. **@babel/register@7.5.5**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-register](https://github.com/babel/babel/tree/master/packages/babel-register)
 1. **@babel/template@7.4.4**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-template](https://github.com/babel/babel/tree/master/packages/babel-template)
-1. **@babel/traverse@7.4.5**
+1. **@babel/traverse@7.5.5**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-traverse](https://github.com/babel/babel/tree/master/packages/babel-traverse)
-1. **@babel/types@7.4.4**
+1. **@babel/types@7.5.5**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-types](https://github.com/babel/babel/tree/master/packages/babel-types)
-1. **@firebase/app-types@0.4.0**
+1. **@firebase/app-types@0.4.1**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/app@0.4.5**
+1. **@firebase/app@0.4.11**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/auth-types@0.7.0**
+1. **@firebase/auth-types@0.7.1**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/auth@0.11.3**
+1. **@firebase/auth@0.11.5**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/database-types@0.4.0**
+1. **@firebase/database-types@0.4.1**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/database@0.4.5**
+1. **@firebase/database@0.4.8**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/firestore-types@1.4.0**
+1. **@firebase/firestore-types@1.4.3**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/firestore@1.4.0**
+1. **@firebase/firestore@1.4.5**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/functions-types@0.3.5**
+1. **@firebase/functions-types@0.3.7**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/functions@0.4.9**
+1. **@firebase/functions@0.4.12**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/installations-types@0.1.1**
+1. **@firebase/installations-types@0.1.2**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/installations@0.1.6**
+1. **@firebase/installations@0.2.1**
      * Licenses: Apache-2.0
      * Repository: unknown
-1. **@firebase/logger@0.1.16**
+1. **@firebase/logger@0.1.19**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/messaging-types@0.3.0**
+1. **@firebase/messaging-types@0.3.1**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/messaging@0.4.2**
+1. **@firebase/messaging@0.4.5**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/performance-types@0.0.2**
+1. **@firebase/performance-types@0.0.3**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk/tree/master/packages/performance-types](https://github.com/firebase/firebase-js-sdk/tree/master/packages/performance-types)
-1. **@firebase/performance@0.2.7**
+1. **@firebase/performance@0.2.12**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk/tree/master/packages/performance](https://github.com/firebase/firebase-js-sdk/tree/master/packages/performance)
-1. **@firebase/polyfill@0.3.14**
+1. **@firebase/polyfill@0.3.16**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/storage-types@0.3.1**
+1. **@firebase/storage-types@0.3.2**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/storage@0.3.2**
+1. **@firebase/storage@0.3.6**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/util@0.2.19**
+1. **@firebase/util@0.2.22**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/webchannel-wrapper@0.2.20**
+1. **@firebase/webchannel-wrapper@0.2.22**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
 1. **@grpc/proto-loader@0.5.1**
@@ -1001,7 +972,7 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **@types/long@4.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/DefinitelyTyped/DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped)
-1. **@types/node@10.14.9**
+1. **@types/node@10.14.13**
      * Licenses: MIT
      * Repository: [https://github.com/DefinitelyTyped/DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped)
 1. **@webassemblyjs/ast@1.8.5**
@@ -1067,10 +1038,7 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **abbrev@1.1.1**
      * Licenses: ISC
      * Repository: [https://github.com/isaacs/abbrev-js](https://github.com/isaacs/abbrev-js)
-1. **acorn-dynamic-import@4.0.0**
-     * Licenses: MIT
-     * Repository: [https://github.com/kesne/acorn-dynamic-import](https://github.com/kesne/acorn-dynamic-import)
-1. **acorn@6.1.1**
+1. **acorn@6.2.1**
      * Licenses: MIT
      * Repository: [https://github.com/acornjs/acorn](https://github.com/acornjs/acorn)
 1. **agent-base@4.3.0**
@@ -1079,16 +1047,13 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **ajv-errors@1.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/epoberezkin/ajv-errors](https://github.com/epoberezkin/ajv-errors)
-1. **ajv-keywords@3.4.0**
+1. **ajv-keywords@3.4.1**
      * Licenses: MIT
      * Repository: [https://github.com/epoberezkin/ajv-keywords](https://github.com/epoberezkin/ajv-keywords)
-1. **ajv@6.10.0**
+1. **ajv@6.10.2**
      * Licenses: MIT
      * Repository: [https://github.com/epoberezkin/ajv](https://github.com/epoberezkin/ajv)
 1. **ansi-regex@2.1.1**
-     * Licenses: MIT
-     * Repository: [https://github.com/chalk/ansi-regex](https://github.com/chalk/ansi-regex)
-1. **ansi-regex@3.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/chalk/ansi-regex](https://github.com/chalk/ansi-regex)
 1. **ansi-regex@4.1.0**
@@ -1169,6 +1134,9 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **babel-messages@6.23.0**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-messages](https://github.com/babel/babel/tree/master/packages/babel-messages)
+1. **babel-plugin-dynamic-import-node@2.3.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/airbnb/babel-plugin-dynamic-import-node](https://github.com/airbnb/babel-plugin-dynamic-import-node)
 1. **babel-plugin-module-resolver@3.2.0**
      * Licenses: MIT
      * Repository: [https://github.com/tleunen/babel-plugin-module-resolver](https://github.com/tleunen/babel-plugin-module-resolver)
@@ -1238,7 +1206,7 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **browserify-zlib@0.2.0**
      * Licenses: MIT
      * Repository: [https://github.com/devongovett/browserify-zlib](https://github.com/devongovett/browserify-zlib)
-1. **browserslist@4.6.3**
+1. **browserslist@4.6.6**
      * Licenses: MIT
      * Repository: [https://github.com/browserslist/browserslist](https://github.com/browserslist/browserslist)
 1. **buffer-from@1.1.1**
@@ -1271,7 +1239,7 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **camelcase@5.3.1**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/camelcase](https://github.com/sindresorhus/camelcase)
-1. **caniuse-lite@1.0.30000975**
+1. **caniuse-lite@1.0.30000985**
      * Licenses: CC-BY-4.0
      * Repository: [https://github.com/ben-eb/caniuse-lite](https://github.com/ben-eb/caniuse-lite)
 1. **chalk@1.1.3**
@@ -1286,6 +1254,9 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **chownr@1.1.1**
      * Licenses: ISC
      * Repository: [https://github.com/isaacs/chownr](https://github.com/isaacs/chownr)
+1. **chownr@1.1.2**
+     * Licenses: ISC
+     * Repository: [https://github.com/isaacs/chownr](https://github.com/isaacs/chownr)
 1. **chrome-trace-event@1.0.2**
      * Licenses: MIT
      * Repository: [github.com:samccone/chrome-trace-event](github.com:samccone/chrome-trace-event)
@@ -1296,9 +1267,6 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/class-utils](https://github.com/jonschlinkert/class-utils)
 1. **cliui@3.2.0**
-     * Licenses: ISC
-     * Repository: [https://github.com/yargs/cliui](https://github.com/yargs/cliui)
-1. **cliui@4.1.0**
      * Licenses: ISC
      * Repository: [https://github.com/yargs/cliui](https://github.com/yargs/cliui)
 1. **cliui@5.0.0**
@@ -1367,9 +1335,6 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **core-js@2.6.9**
      * Licenses: MIT
      * Repository: [https://github.com/zloirock/core-js](https://github.com/zloirock/core-js)
-1. **core-js@3.0.1**
-     * Licenses: MIT
-     * Repository: [https://github.com/zloirock/core-js](https://github.com/zloirock/core-js)
 1. **core-js@3.1.4**
      * Licenses: MIT
      * Repository: [https://github.com/zloirock/core-js](https://github.com/zloirock/core-js)
@@ -1430,6 +1395,9 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **default-require-extensions@2.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/avajs/default-require-extensions](https://github.com/avajs/default-require-extensions)
+1. **define-properties@1.1.3**
+     * Licenses: MIT
+     * Repository: [https://github.com/ljharb/define-properties](https://github.com/ljharb/define-properties)
 1. **define-property@0.2.5**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/define-property](https://github.com/jonschlinkert/define-property)
@@ -1469,10 +1437,10 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **duplexify@3.7.1**
      * Licenses: MIT
      * Repository: [https://github.com/mafintosh/duplexify](https://github.com/mafintosh/duplexify)
-1. **electron-to-chromium@1.3.166**
+1. **electron-to-chromium@1.3.199**
      * Licenses: ISC
      * Repository: [https://github.com/kilian/electron-to-chromium](https://github.com/kilian/electron-to-chromium)
-1. **elliptic@6.4.1**
+1. **elliptic@6.5.0**
      * Licenses: MIT
      * Repository: [https://github.com/indutny/elliptic](https://github.com/indutny/elliptic)
 1. **emoji-regex@7.0.3**
@@ -1550,8 +1518,8 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **fast-json-stable-stringify@2.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/epoberezkin/fast-json-stable-stringify](https://github.com/epoberezkin/fast-json-stable-stringify)
-1. **faye-websocket@0.11.1**
-     * Licenses: MIT
+1. **faye-websocket@0.11.3**
+     * Licenses: Apache-2.0
      * Repository: [https://github.com/faye/faye-websocket-node](https://github.com/faye/faye-websocket-node)
 1. **figgy-pudding@3.5.1**
      * Licenses: ISC
@@ -1571,10 +1539,10 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **find-up@3.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/find-up](https://github.com/sindresorhus/find-up)
-1. **findup-sync@2.0.0**
+1. **findup-sync@3.0.0**
      * Licenses: MIT
-     * Repository: [https://github.com/js-cli/node-findup-sync](https://github.com/js-cli/node-findup-sync)
-1. **firebase@6.2.0**
+     * Repository: [https://github.com/gulpjs/findup-sync](https://github.com/gulpjs/findup-sync)
+1. **firebase@6.3.1**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
 1. **flush-write-stream@1.1.1**
@@ -1595,6 +1563,9 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **fs-minipass@1.2.5**
      * Licenses: ISC
      * Repository: [https://github.com/npm/fs-minipass](https://github.com/npm/fs-minipass)
+1. **fs-minipass@1.2.6**
+     * Licenses: ISC
+     * Repository: [https://github.com/npm/fs-minipass](https://github.com/npm/fs-minipass)
 1. **fs-readdir-recursive@1.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/fs-utils/fs-readdir-recursive](https://github.com/fs-utils/fs-readdir-recursive)
@@ -1607,12 +1578,12 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **fsevents@1.2.9**
      * Licenses: MIT
      * Repository: [https://github.com/strongloop/fsevents](https://github.com/strongloop/fsevents)
+1. **function-bind@1.1.1**
+     * Licenses: MIT
+     * Repository: [https://github.com/Raynos/function-bind](https://github.com/Raynos/function-bind)
 1. **gauge@2.7.4**
      * Licenses: ISC
      * Repository: [https://github.com/iarna/gauge](https://github.com/iarna/gauge)
-1. **get-caller-file@1.0.3**
-     * Licenses: ISC
-     * Repository: [https://github.com/stefanpenner/get-caller-file](https://github.com/stefanpenner/get-caller-file)
 1. **get-caller-file@2.0.5**
      * Licenses: ISC
      * Repository: [https://github.com/stefanpenner/get-caller-file](https://github.com/stefanpenner/get-caller-file)
@@ -1637,7 +1608,13 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **global-modules@1.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/global-modules](https://github.com/jonschlinkert/global-modules)
+1. **global-modules@2.0.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/jonschlinkert/global-modules](https://github.com/jonschlinkert/global-modules)
 1. **global-prefix@1.0.2**
+     * Licenses: MIT
+     * Repository: [https://github.com/jonschlinkert/global-prefix](https://github.com/jonschlinkert/global-prefix)
+1. **global-prefix@3.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/global-prefix](https://github.com/jonschlinkert/global-prefix)
 1. **globals@11.12.0**
@@ -1646,13 +1623,13 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **globals@9.18.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/globals](https://github.com/sindresorhus/globals)
-1. **graceful-fs@4.1.15**
+1. **graceful-fs@4.2.0**
      * Licenses: ISC
      * Repository: [https://github.com/isaacs/node-graceful-fs](https://github.com/isaacs/node-graceful-fs)
 1. **growl@1.10.5**
      * Licenses: MIT
      * Repository: [https://github.com/tj/node-growl](https://github.com/tj/node-growl)
-1. **grpc@1.20.3**
+1. **grpc@1.22.2**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/grpc/grpc-node](https://github.com/grpc/grpc-node)
 1. **handlebars@4.1.2**
@@ -1664,6 +1641,9 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **has-flag@3.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/has-flag](https://github.com/sindresorhus/has-flag)
+1. **has-symbols@1.0.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/ljharb/has-symbols](https://github.com/ljharb/has-symbols)
 1. **has-unicode@2.0.1**
      * Licenses: ISC
      * Repository: [https://github.com/iarna/has-unicode](https://github.com/iarna/has-unicode)
@@ -1706,7 +1686,7 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **https-browserify@1.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/substack/https-browserify](https://github.com/substack/https-browserify)
-1. **https-proxy-agent@2.2.1**
+1. **https-proxy-agent@2.2.2**
      * Licenses: MIT
      * Repository: [https://github.com/TooTallNate/node-https-proxy-agent](https://github.com/TooTallNate/node-https-proxy-agent)
 1. **iconv-lite@0.4.23**
@@ -1937,7 +1917,7 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **lodash.flattendeep@4.4.0**
      * Licenses: MIT
      * Repository: [https://github.com/lodash/lodash](https://github.com/lodash/lodash)
-1. **lodash@4.17.11**
+1. **lodash@4.17.15**
      * Licenses: MIT
      * Repository: [https://github.com/lodash/lodash](https://github.com/lodash/lodash)
 1. **lolex@4.1.0**
@@ -2018,7 +1998,7 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **mississippi@3.0.0**
      * Licenses: BSD-2-Clause
      * Repository: [https://github.com/maxogden/mississippi](https://github.com/maxogden/mississippi)
-1. **mixin-deep@1.3.1**
+1. **mixin-deep@1.3.2**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/mixin-deep](https://github.com/jonschlinkert/mixin-deep)
 1. **mkdirp@0.5.1**
@@ -2048,7 +2028,7 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **needle@2.3.0**
      * Licenses: MIT
      * Repository: [https://github.com/tomas/needle](https://github.com/tomas/needle)
-1. **needle@2.3.1**
+1. **needle@2.4.0**
      * Licenses: MIT
      * Repository: [https://github.com/tomas/needle](https://github.com/tomas/needle)
 1. **neo-async@2.6.1**
@@ -2078,7 +2058,7 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **node-pre-gyp@0.13.0**
      * Licenses: BSD-3-Clause
      * Repository: [https://github.com/mapbox/node-pre-gyp](https://github.com/mapbox/node-pre-gyp)
-1. **node-releases@1.1.23**
+1. **node-releases@1.1.25**
      * Licenses: MIT
      * Repository: [https://github.com/chicoxyzzy/node-releases](https://github.com/chicoxyzzy/node-releases)
 1. **nopt@4.0.1**
@@ -2117,9 +2097,15 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **object-copy@0.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/object-copy](https://github.com/jonschlinkert/object-copy)
+1. **object-keys@1.1.1**
+     * Licenses: MIT
+     * Repository: [https://github.com/ljharb/object-keys](https://github.com/ljharb/object-keys)
 1. **object-visit@1.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/object-visit](https://github.com/jonschlinkert/object-visit)
+1. **object.assign@4.1.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/ljharb/object.assign](https://github.com/ljharb/object.assign)
 1. **object.pick@1.3.0**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/object.pick](https://github.com/jonschlinkert/object.pick)
@@ -2246,9 +2232,6 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **posix-character-classes@0.1.1**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/posix-character-classes](https://github.com/jonschlinkert/posix-character-classes)
-1. **prettier@1.18.2**
-     * Licenses: MIT
-     * Repository: [https://github.com/prettier/prettier](https://github.com/prettier/prettier)
 1. **private@0.1.8**
      * Licenses: MIT
      * Repository: [https://github.com/benjamn/private](https://github.com/benjamn/private)
@@ -2264,7 +2247,7 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **promise-inflight@1.0.1**
      * Licenses: ISC
      * Repository: [https://github.com/iarna/promise-inflight](https://github.com/iarna/promise-inflight)
-1. **promise-polyfill@8.1.0**
+1. **promise-polyfill@8.1.3**
      * Licenses: MIT
      * Repository: [https://github.com/taylorhakes/promise-polyfill](https://github.com/taylorhakes/promise-polyfill)
 1. **protobufjs@5.0.3**
@@ -2330,7 +2313,7 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **readable-stream@2.3.6**
      * Licenses: MIT
      * Repository: [https://github.com/nodejs/readable-stream](https://github.com/nodejs/readable-stream)
-1. **readdir-scoped-modules@1.0.2**
+1. **readdir-scoped-modules@1.1.0**
      * Licenses: ISC
      * Repository: [https://github.com/npm/readdir-scoped-modules](https://github.com/npm/readdir-scoped-modules)
 1. **readdirp@2.2.1**
@@ -2345,13 +2328,13 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **regenerator-runtime@0.11.1**
      * Licenses: MIT
      * Repository: [https://github.com/facebook/regenerator/tree/master/packages/regenerator-runtime](https://github.com/facebook/regenerator/tree/master/packages/regenerator-runtime)
-1. **regenerator-transform@0.14.0**
+1. **regenerator-transform@0.14.1**
      * Licenses: MIT
      * Repository: [https://github.com/facebook/regenerator/tree/master/packages/regenerator-transform](https://github.com/facebook/regenerator/tree/master/packages/regenerator-transform)
 1. **regex-not@1.0.2**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/regex-not](https://github.com/jonschlinkert/regex-not)
-1. **regexp-tree@0.1.10**
+1. **regexp-tree@0.1.11**
      * Licenses: MIT
      * Repository: [https://github.com/DmitrySoshnikov/regexp-tree](https://github.com/DmitrySoshnikov/regexp-tree)
 1. **regexpu-core@4.5.4**
@@ -2378,9 +2361,6 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **require-directory@2.1.1**
      * Licenses: MIT
      * Repository: [https://github.com/troygoode/node-require-directory](https://github.com/troygoode/node-require-directory)
-1. **require-main-filename@1.0.1**
-     * Licenses: ISC
-     * Repository: [https://github.com/yargs/require-main-filename](https://github.com/yargs/require-main-filename)
 1. **require-main-filename@2.0.0**
      * Licenses: ISC
      * Repository: [https://github.com/yargs/require-main-filename](https://github.com/yargs/require-main-filename)
@@ -2402,7 +2382,7 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **resolve-url@0.2.1**
      * Licenses: MIT
      * Repository: [https://github.com/lydell/resolve-url](https://github.com/lydell/resolve-url)
-1. **resolve@1.11.0**
+1. **resolve@1.11.1**
      * Licenses: MIT
      * Repository: [https://github.com/browserify/resolve](https://github.com/browserify/resolve)
 1. **ret@0.1.15**
@@ -2435,7 +2415,7 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **semver@5.7.0**
      * Licenses: ISC
      * Repository: [https://github.com/npm/node-semver](https://github.com/npm/node-semver)
-1. **semver@6.1.1**
+1. **semver@6.2.0**
      * Licenses: ISC
      * Repository: [https://github.com/npm/node-semver](https://github.com/npm/node-semver)
 1. **serialize-javascript@1.7.0**
@@ -2444,10 +2424,7 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **set-blocking@2.0.0**
      * Licenses: ISC
      * Repository: [https://github.com/yargs/set-blocking](https://github.com/yargs/set-blocking)
-1. **set-value@0.4.3**
-     * Licenses: MIT
-     * Repository: [https://github.com/jonschlinkert/set-value](https://github.com/jonschlinkert/set-value)
-1. **set-value@2.0.0**
+1. **set-value@2.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/set-value](https://github.com/jonschlinkert/set-value)
 1. **setimmediate@1.0.5**
@@ -2462,6 +2439,9 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **shebang-regex@1.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/shebang-regex](https://github.com/sindresorhus/shebang-regex)
+1. **signal-exit@3.0.1**
+     * Licenses: ISC
+     * Repository: [https://github.com/tapjs/signal-exit](https://github.com/tapjs/signal-exit)
 1. **signal-exit@3.0.2**
      * Licenses: ISC
      * Repository: [https://github.com/tapjs/signal-exit](https://github.com/tapjs/signal-exit)
@@ -2519,7 +2499,7 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **spdx-expression-parse@3.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/jslicense/spdx-expression-parse.js](https://github.com/jslicense/spdx-expression-parse.js)
-1. **spdx-license-ids@3.0.4**
+1. **spdx-license-ids@3.0.5**
      * Licenses: CC0-1.0
      * Repository: [https://github.com/shinnn/spdx-license-ids](https://github.com/shinnn/spdx-license-ids)
 1. **spdx-ranges@2.1.0**
@@ -2558,9 +2538,6 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **string-width@1.0.2**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/string-width](https://github.com/sindresorhus/string-width)
-1. **string-width@2.1.1**
-     * Licenses: MIT
-     * Repository: [https://github.com/sindresorhus/string-width](https://github.com/sindresorhus/string-width)
 1. **string-width@3.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/string-width](https://github.com/sindresorhus/string-width)
@@ -2568,9 +2545,6 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
      * Licenses: MIT
      * Repository: [https://github.com/nodejs/string_decoder](https://github.com/nodejs/string_decoder)
 1. **strip-ansi@3.0.1**
-     * Licenses: MIT
-     * Repository: [https://github.com/chalk/strip-ansi](https://github.com/chalk/strip-ansi)
-1. **strip-ansi@4.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/chalk/strip-ansi](https://github.com/chalk/strip-ansi)
 1. **strip-ansi@5.2.0**
@@ -2600,6 +2574,9 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **tapable@1.1.3**
      * Licenses: MIT
      * Repository: [https://github.com/webpack/tapable](https://github.com/webpack/tapable)
+1. **tar@4.4.10**
+     * Licenses: ISC
+     * Repository: [https://github.com/npm/node-tar](https://github.com/npm/node-tar)
 1. **tar@4.4.8**
      * Licenses: ISC
      * Repository: [https://github.com/npm/node-tar](https://github.com/npm/node-tar)
@@ -2609,7 +2586,7 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **terser-webpack-plugin@1.3.0**
      * Licenses: MIT
      * Repository: [https://github.com/webpack-contrib/terser-webpack-plugin](https://github.com/webpack-contrib/terser-webpack-plugin)
-1. **terser@4.0.0**
+1. **terser@4.1.2**
      * Licenses: BSD-2-Clause
      * Repository: [https://github.com/fabiosantoscode/terser](https://github.com/fabiosantoscode/terser)
 1. **test-exclude@5.2.3**
@@ -2669,7 +2646,7 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **unicode-property-aliases-ecmascript@1.0.5**
      * Licenses: MIT
      * Repository: [https://github.com/mathiasbynens/unicode-property-aliases-ecmascript](https://github.com/mathiasbynens/unicode-property-aliases-ecmascript)
-1. **union-value@1.0.0**
+1. **union-value@1.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/union-value](https://github.com/jonschlinkert/union-value)
 1. **unique-filename@1.1.1**
@@ -2723,7 +2700,7 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **watchpack@1.6.0**
      * Licenses: MIT
      * Repository: [https://github.com/webpack/watchpack](https://github.com/webpack/watchpack)
-1. **webpack-cli@3.3.4**
+1. **webpack-cli@3.3.6**
      * Licenses: MIT
      * Repository: [https://github.com/webpack/webpack-cli](https://github.com/webpack/webpack-cli)
 1. **webpack-merge@4.2.1**
@@ -2732,7 +2709,7 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **webpack-sources@1.3.0**
      * Licenses: MIT
      * Repository: [https://github.com/webpack/webpack-sources](https://github.com/webpack/webpack-sources)
-1. **webpack@4.35.0**
+1. **webpack@4.36.1**
      * Licenses: MIT
      * Repository: [https://github.com/webpack/webpack](https://github.com/webpack/webpack)
 1. **websocket-driver@0.7.3**
@@ -2777,7 +2754,7 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **xmlhttprequest@1.8.0**
      * Licenses: MIT
      * Repository: [https://github.com/driverdan/node-XMLHttpRequest](https://github.com/driverdan/node-XMLHttpRequest)
-1. **xtend@4.0.1**
+1. **xtend@4.0.2**
      * Licenses: MIT
      * Repository: [https://github.com/Raynos/xtend](https://github.com/Raynos/xtend)
 1. **y18n@3.2.1**
@@ -2792,16 +2769,13 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
 1. **yallist@3.0.3**
      * Licenses: ISC
      * Repository: [https://github.com/isaacs/yallist](https://github.com/isaacs/yallist)
-1. **yargs-parser@11.1.1**
-     * Licenses: ISC
-     * Repository: [https://github.com/yargs/yargs-parser](https://github.com/yargs/yargs-parser)
 1. **yargs-parser@13.1.1**
      * Licenses: ISC
      * Repository: [https://github.com/yargs/yargs-parser](https://github.com/yargs/yargs-parser)
-1. **yargs@12.0.5**
+1. **yargs@13.2.4**
      * Licenses: MIT
      * Repository: [https://github.com/yargs/yargs](https://github.com/yargs/yargs)
-1. **yargs@13.2.4**
+1. **yargs@13.3.0**
      * Licenses: MIT
      * Repository: [https://github.com/yargs/yargs](https://github.com/yargs/yargs)
 1. **yargs@3.32.0**
@@ -2809,7 +2783,7 @@ This report was generated on **Wed Jul 17 20:46:47 EEST 2019** using [Gradle-Lic
      * Repository: [https://github.com/bcoe/yargs](https://github.com/bcoe/yargs)
 
 
-This report was generated on **Wed Jul 17 2019 20:46:49 GMT+0300 (Eastern European Summer Time)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
+This report was generated on **Tue Jul 23 2019 12:16:20 GMT+0300 (EEST)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
 
 
 
@@ -2980,12 +2954,12 @@ This report was generated on **Wed Jul 17 2019 20:46:49 GMT+0300 (Eastern Europe
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.8.0
+1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.9.0
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.8.0
+1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.9.0
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
@@ -2996,37 +2970,17 @@ This report was generated on **Wed Jul 17 2019 20:46:49 GMT+0300 (Eastern Europe
 1. **Group:** com.squareup.okio **Name:** okio **Version:** 1.13.0
      * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** commons-beanutils **Name:** commons-beanutils **Version:** 1.9.2
-     * **Project URL:** [http://commons.apache.org/proper/commons-beanutils/](http://commons.apache.org/proper/commons-beanutils/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1. **Group:** commons-codec **Name:** commons-codec **Version:** 1.10
      * **Project URL:** [http://commons.apache.org/proper/commons-codec/](http://commons.apache.org/proper/commons-codec/)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1. **Group:** commons-collections **Name:** commons-collections **Version:** 3.2.2
-     * **Project URL:** [http://commons.apache.org/collections/](http://commons.apache.org/collections/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1. **Group:** commons-digester **Name:** commons-digester **Version:** 1.8.1
-     * **Project URL:** [http://commons.apache.org/digester/](http://commons.apache.org/digester/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** commons-logging **Name:** commons-logging **Version:** 1.2
      * **Project URL:** [http://commons.apache.org/proper/commons-logging/](http://commons.apache.org/proper/commons-logging/)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** commons-validator **Name:** commons-validator **Version:** 1.6
-     * **Project URL:** [http://commons.apache.org/proper/commons-validator/](http://commons.apache.org/proper/commons-validator/)
-     * **Manifest license URL:** [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **POM License: Apache License, Version 2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1. **Group:** io.grpc **Name:** grpc-api **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-api **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -3034,15 +2988,11 @@ This report was generated on **Wed Jul 17 2019 20:46:49 GMT+0300 (Eastern Europe
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-core **Version:** 1.21.0
-     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
-     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
-
-1. **Group:** io.grpc **Name:** grpc-netty **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-core **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -3050,19 +3000,19 @@ This report was generated on **Wed Jul 17 2019 20:46:49 GMT+0300 (Eastern Europe
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-okhttp **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-okhttp **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-protobuf **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-protobuf **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-protobuf-lite **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-protobuf-lite **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-stub **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-stub **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -3081,27 +3031,12 @@ This report was generated on **Wed Jul 17 2019 20:46:49 GMT+0300 (Eastern Europe
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
-1. **Group:** io.netty **Name:** netty-codec-http2 **Version:** 4.1.34.Final
-     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
-1. **Group:** io.netty **Name:** netty-codec-socks **Version:** 4.1.34.Final
-     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
 1. **Group:** io.netty **Name:** netty-common **Version:** 4.1.34.Final
      * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
 1. **Group:** io.netty **Name:** netty-handler **Version:** 4.1.34.Final
-     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
-1. **Group:** io.netty **Name:** netty-handler-proxy **Version:** 4.1.34.Final
      * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
@@ -3132,6 +3067,10 @@ This report was generated on **Wed Jul 17 2019 20:46:49 GMT+0300 (Eastern Europe
      * **POM Project URL:** [https://github.com/census-instrumentation/opencensus-java](https://github.com/census-instrumentation/opencensus-java)
      * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1. **Group:** io.perfmark **Name:** perfmark-api **Version:** 0.16.0
+     * **POM Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
 1. **Group:** javax.servlet **Name:** javax.servlet-api **Version:** 3.1.0
      * **Manifest Project URL:** [https://glassfish.dev.java.net](https://glassfish.dev.java.net)
      * **Manifest license URL:** [https://glassfish.dev.java.net/nonav/public/CDDL+GPL.html](https://glassfish.dev.java.net/nonav/public/CDDL+GPL.html)
@@ -3151,7 +3090,7 @@ This report was generated on **Wed Jul 17 2019 20:46:49 GMT+0300 (Eastern Europe
      * **POM Project URL:** [http://hc.apache.org/httpcomponents-core-ga](http://hc.apache.org/httpcomponents-core-ga)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.8.2
+1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.9.0
      * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
      * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
 
@@ -3389,17 +3328,17 @@ This report was generated on **Wed Jul 17 2019 20:46:49 GMT+0300 (Eastern Europe
      * **POM Project URL:** [https://github.com/google/protobuf-gradle-plugin](https://github.com/google/protobuf-gradle-plugin)
      * **POM License: BSD 3-Clause** - [http://opensource.org/licenses/BSD-3-Clause](http://opensource.org/licenses/BSD-3-Clause)
 
-1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.8.0
+1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.9.0
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.8.0
+1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.9.0
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1. **Group:** com.google.protobuf **Name:** protoc **Version:** 3.8.0
+1. **Group:** com.google.protobuf **Name:** protoc **Version:** 3.9.0
      * **POM Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -3431,25 +3370,10 @@ This report was generated on **Wed Jul 17 2019 20:46:49 GMT+0300 (Eastern Europe
 1. **Group:** com.squareup.okio **Name:** okio **Version:** 1.13.0
      * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** commons-beanutils **Name:** commons-beanutils **Version:** 1.9.2
-     * **Project URL:** [http://commons.apache.org/proper/commons-beanutils/](http://commons.apache.org/proper/commons-beanutils/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1. **Group:** commons-codec **Name:** commons-codec **Version:** 1.10
      * **Project URL:** [http://commons.apache.org/proper/commons-codec/](http://commons.apache.org/proper/commons-codec/)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1. **Group:** commons-collections **Name:** commons-collections **Version:** 3.2.2
-     * **Project URL:** [http://commons.apache.org/collections/](http://commons.apache.org/collections/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1. **Group:** commons-digester **Name:** commons-digester **Version:** 1.8.1
-     * **Project URL:** [http://commons.apache.org/digester/](http://commons.apache.org/digester/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** commons-io **Name:** commons-io **Version:** 2.6
      * **Project URL:** [http://commons.apache.org/proper/commons-io/](http://commons.apache.org/proper/commons-io/)
@@ -3466,12 +3390,7 @@ This report was generated on **Wed Jul 17 2019 20:46:49 GMT+0300 (Eastern Europe
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** commons-validator **Name:** commons-validator **Version:** 1.6
-     * **Project URL:** [http://commons.apache.org/proper/commons-validator/](http://commons.apache.org/proper/commons-validator/)
-     * **Manifest license URL:** [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **POM License: Apache License, Version 2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1. **Group:** io.grpc **Name:** grpc-api **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-api **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -3479,15 +3398,11 @@ This report was generated on **Wed Jul 17 2019 20:46:49 GMT+0300 (Eastern Europe
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-core **Version:** 1.21.0
-     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
-     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
-
-1. **Group:** io.grpc **Name:** grpc-netty **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-core **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -3495,23 +3410,23 @@ This report was generated on **Wed Jul 17 2019 20:46:49 GMT+0300 (Eastern Europe
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-okhttp **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-okhttp **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-protobuf **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-protobuf **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-protobuf-lite **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-protobuf-lite **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-stub **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-stub **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** protoc-gen-grpc-java **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** protoc-gen-grpc-java **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -3530,27 +3445,12 @@ This report was generated on **Wed Jul 17 2019 20:46:49 GMT+0300 (Eastern Europe
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
-1. **Group:** io.netty **Name:** netty-codec-http2 **Version:** 4.1.34.Final
-     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
-1. **Group:** io.netty **Name:** netty-codec-socks **Version:** 4.1.34.Final
-     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
 1. **Group:** io.netty **Name:** netty-common **Version:** 4.1.34.Final
      * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
 1. **Group:** io.netty **Name:** netty-handler **Version:** 4.1.34.Final
-     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
-1. **Group:** io.netty **Name:** netty-handler-proxy **Version:** 4.1.34.Final
      * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
@@ -3580,6 +3480,10 @@ This report was generated on **Wed Jul 17 2019 20:46:49 GMT+0300 (Eastern Europe
 1. **Group:** io.opencensus **Name:** opencensus-contrib-http-util **Version:** 0.18.0
      * **POM Project URL:** [https://github.com/census-instrumentation/opencensus-java](https://github.com/census-instrumentation/opencensus-java)
      * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** io.perfmark **Name:** perfmark-api **Version:** 0.16.0
+     * **POM Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
 1. **Group:** javax.annotation **Name:** jsr250-api **Version:** 1.0
      * **POM Project URL:** [http://jcp.org/aboutJava/communityprocess/final/jsr250/index.html](http://jcp.org/aboutJava/communityprocess/final/jsr250/index.html)
@@ -3623,10 +3527,10 @@ This report was generated on **Wed Jul 17 2019 20:46:49 GMT+0300 (Eastern Europe
      * **POM Project URL:** [https://javacc.dev.java.net/](https://javacc.dev.java.net/)
      * **POM License: Berkeley Software Distribution (BSD) License** - [http://www.opensource.org/licenses/bsd-license.html](http://www.opensource.org/licenses/bsd-license.html)
 
-1. **Group:** net.sourceforge.pmd **Name:** pmd-core **Version:** 6.13.0
+1. **Group:** net.sourceforge.pmd **Name:** pmd-core **Version:** 6.16.0
      * **POM License: BSD-style** - [http://pmd.sourceforge.net/license.html](http://pmd.sourceforge.net/license.html)
 
-1. **Group:** net.sourceforge.pmd **Name:** pmd-java **Version:** 6.13.0
+1. **Group:** net.sourceforge.pmd **Name:** pmd-java **Version:** 6.16.0
      * **POM License: BSD-style** - [http://pmd.sourceforge.net/license.html](http://pmd.sourceforge.net/license.html)
 
 1. **Group:** net.sourceforge.saxon **Name:** saxon **Version:** 9.1.0.8
@@ -3669,7 +3573,7 @@ This report was generated on **Wed Jul 17 2019 20:46:49 GMT+0300 (Eastern Europe
      * **POM License: GNU General Public License, version 2 (GPL2), with the classpath exception** - [http://www.gnu.org/software/classpath/license.html](http://www.gnu.org/software/classpath/license.html)
      * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
 
-1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.8.2
+1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.9.0
      * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
      * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
 
@@ -3821,7 +3725,7 @@ This report was generated on **Wed Jul 17 2019 20:46:49 GMT+0300 (Eastern Europe
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jul 17 20:46:50 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 23 12:16:21 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3992,12 +3896,12 @@ This report was generated on **Wed Jul 17 20:46:50 EEST 2019** using [Gradle-Lic
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.8.0
+1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.9.0
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.8.0
+1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.9.0
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
@@ -4008,37 +3912,17 @@ This report was generated on **Wed Jul 17 20:46:50 EEST 2019** using [Gradle-Lic
 1. **Group:** com.squareup.okio **Name:** okio **Version:** 1.13.0
      * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** commons-beanutils **Name:** commons-beanutils **Version:** 1.9.2
-     * **Project URL:** [http://commons.apache.org/proper/commons-beanutils/](http://commons.apache.org/proper/commons-beanutils/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1. **Group:** commons-codec **Name:** commons-codec **Version:** 1.10
      * **Project URL:** [http://commons.apache.org/proper/commons-codec/](http://commons.apache.org/proper/commons-codec/)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1. **Group:** commons-collections **Name:** commons-collections **Version:** 3.2.2
-     * **Project URL:** [http://commons.apache.org/collections/](http://commons.apache.org/collections/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1. **Group:** commons-digester **Name:** commons-digester **Version:** 1.8.1
-     * **Project URL:** [http://commons.apache.org/digester/](http://commons.apache.org/digester/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** commons-logging **Name:** commons-logging **Version:** 1.2
      * **Project URL:** [http://commons.apache.org/proper/commons-logging/](http://commons.apache.org/proper/commons-logging/)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** commons-validator **Name:** commons-validator **Version:** 1.6
-     * **Project URL:** [http://commons.apache.org/proper/commons-validator/](http://commons.apache.org/proper/commons-validator/)
-     * **Manifest license URL:** [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **POM License: Apache License, Version 2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1. **Group:** io.grpc **Name:** grpc-api **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-api **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -4046,15 +3930,11 @@ This report was generated on **Wed Jul 17 20:46:50 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-core **Version:** 1.21.0
-     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
-     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
-
-1. **Group:** io.grpc **Name:** grpc-netty **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-core **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -4062,19 +3942,19 @@ This report was generated on **Wed Jul 17 20:46:50 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-okhttp **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-okhttp **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-protobuf **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-protobuf **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-protobuf-lite **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-protobuf-lite **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-stub **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-stub **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -4093,27 +3973,12 @@ This report was generated on **Wed Jul 17 20:46:50 EEST 2019** using [Gradle-Lic
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
-1. **Group:** io.netty **Name:** netty-codec-http2 **Version:** 4.1.34.Final
-     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
-1. **Group:** io.netty **Name:** netty-codec-socks **Version:** 4.1.34.Final
-     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
 1. **Group:** io.netty **Name:** netty-common **Version:** 4.1.34.Final
      * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
 1. **Group:** io.netty **Name:** netty-handler **Version:** 4.1.34.Final
-     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
-1. **Group:** io.netty **Name:** netty-handler-proxy **Version:** 4.1.34.Final
      * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
@@ -4144,6 +4009,10 @@ This report was generated on **Wed Jul 17 20:46:50 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [https://github.com/census-instrumentation/opencensus-java](https://github.com/census-instrumentation/opencensus-java)
      * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1. **Group:** io.perfmark **Name:** perfmark-api **Version:** 0.16.0
+     * **POM Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
 1. **Group:** javax.servlet **Name:** javax.servlet-api **Version:** 3.1.0
      * **Manifest Project URL:** [https://glassfish.dev.java.net](https://glassfish.dev.java.net)
      * **Manifest license URL:** [https://glassfish.dev.java.net/nonav/public/CDDL+GPL.html](https://glassfish.dev.java.net/nonav/public/CDDL+GPL.html)
@@ -4171,7 +4040,7 @@ This report was generated on **Wed Jul 17 20:46:50 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [http://hc.apache.org/httpcomponents-core-ga](http://hc.apache.org/httpcomponents-core-ga)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.8.2
+1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.9.0
      * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
      * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
 
@@ -4425,17 +4294,17 @@ This report was generated on **Wed Jul 17 20:46:50 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [https://github.com/google/protobuf-gradle-plugin](https://github.com/google/protobuf-gradle-plugin)
      * **POM License: BSD 3-Clause** - [http://opensource.org/licenses/BSD-3-Clause](http://opensource.org/licenses/BSD-3-Clause)
 
-1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.8.0
+1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.9.0
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.8.0
+1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.9.0
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1. **Group:** com.google.protobuf **Name:** protoc **Version:** 3.8.0
+1. **Group:** com.google.protobuf **Name:** protoc **Version:** 3.9.0
      * **POM Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -4467,11 +4336,6 @@ This report was generated on **Wed Jul 17 20:46:50 EEST 2019** using [Gradle-Lic
 1. **Group:** com.squareup.okio **Name:** okio **Version:** 1.13.0
      * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** commons-beanutils **Name:** commons-beanutils **Version:** 1.9.2
-     * **Project URL:** [http://commons.apache.org/proper/commons-beanutils/](http://commons.apache.org/proper/commons-beanutils/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1. **Group:** commons-cli **Name:** commons-cli **Version:** 1.2
      * **Project URL:** [http://commons.apache.org/cli/](http://commons.apache.org/cli/)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -4482,18 +4346,8 @@ This report was generated on **Wed Jul 17 20:46:50 EEST 2019** using [Gradle-Lic
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** commons-collections **Name:** commons-collections **Version:** 3.2.2
-     * **Project URL:** [http://commons.apache.org/collections/](http://commons.apache.org/collections/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1. **Group:** commons-configuration **Name:** commons-configuration **Version:** 1.10
      * **Project URL:** [http://commons.apache.org/configuration/](http://commons.apache.org/configuration/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1. **Group:** commons-digester **Name:** commons-digester **Version:** 1.8.1
-     * **Project URL:** [http://commons.apache.org/digester/](http://commons.apache.org/digester/)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -4517,12 +4371,7 @@ This report was generated on **Wed Jul 17 20:46:50 EEST 2019** using [Gradle-Lic
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** commons-validator **Name:** commons-validator **Version:** 1.6
-     * **Project URL:** [http://commons.apache.org/proper/commons-validator/](http://commons.apache.org/proper/commons-validator/)
-     * **Manifest license URL:** [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **POM License: Apache License, Version 2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1. **Group:** io.grpc **Name:** grpc-api **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-api **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -4530,15 +4379,11 @@ This report was generated on **Wed Jul 17 20:46:50 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-core **Version:** 1.21.0
-     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
-     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
-
-1. **Group:** io.grpc **Name:** grpc-netty **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-core **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -4546,23 +4391,23 @@ This report was generated on **Wed Jul 17 20:46:50 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-okhttp **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-okhttp **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-protobuf **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-protobuf **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-protobuf-lite **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-protobuf-lite **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-stub **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-stub **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** protoc-gen-grpc-java **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** protoc-gen-grpc-java **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -4581,27 +4426,12 @@ This report was generated on **Wed Jul 17 20:46:50 EEST 2019** using [Gradle-Lic
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
-1. **Group:** io.netty **Name:** netty-codec-http2 **Version:** 4.1.34.Final
-     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
-1. **Group:** io.netty **Name:** netty-codec-socks **Version:** 4.1.34.Final
-     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
 1. **Group:** io.netty **Name:** netty-common **Version:** 4.1.34.Final
      * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
 1. **Group:** io.netty **Name:** netty-handler **Version:** 4.1.34.Final
-     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
-1. **Group:** io.netty **Name:** netty-handler-proxy **Version:** 4.1.34.Final
      * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
@@ -4631,6 +4461,10 @@ This report was generated on **Wed Jul 17 20:46:50 EEST 2019** using [Gradle-Lic
 1. **Group:** io.opencensus **Name:** opencensus-contrib-http-util **Version:** 0.18.0
      * **POM Project URL:** [https://github.com/census-instrumentation/opencensus-java](https://github.com/census-instrumentation/opencensus-java)
      * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** io.perfmark **Name:** perfmark-api **Version:** 0.16.0
+     * **POM Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
 1. **Group:** javax.annotation **Name:** javax.annotation-api **Version:** 1.2
      * **Manifest Project URL:** [https://glassfish.java.net](https://glassfish.java.net)
@@ -4714,10 +4548,10 @@ This report was generated on **Wed Jul 17 20:46:50 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [https://javacc.dev.java.net/](https://javacc.dev.java.net/)
      * **POM License: Berkeley Software Distribution (BSD) License** - [http://www.opensource.org/licenses/bsd-license.html](http://www.opensource.org/licenses/bsd-license.html)
 
-1. **Group:** net.sourceforge.pmd **Name:** pmd-core **Version:** 6.13.0
+1. **Group:** net.sourceforge.pmd **Name:** pmd-core **Version:** 6.16.0
      * **POM License: BSD-style** - [http://pmd.sourceforge.net/license.html](http://pmd.sourceforge.net/license.html)
 
-1. **Group:** net.sourceforge.pmd **Name:** pmd-java **Version:** 6.13.0
+1. **Group:** net.sourceforge.pmd **Name:** pmd-java **Version:** 6.16.0
      * **POM License: BSD-style** - [http://pmd.sourceforge.net/license.html](http://pmd.sourceforge.net/license.html)
 
 1. **Group:** net.sourceforge.saxon **Name:** saxon **Version:** 9.1.0.8
@@ -4854,7 +4688,7 @@ This report was generated on **Wed Jul 17 20:46:50 EEST 2019** using [Gradle-Lic
      * **POM License: GNU General Public License, version 2 (GPL2), with the classpath exception** - [http://www.gnu.org/software/classpath/license.html](http://www.gnu.org/software/classpath/license.html)
      * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
 
-1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.8.2
+1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.9.0
      * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
      * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
 
@@ -5762,7 +5596,7 @@ This report was generated on **Wed Jul 17 20:46:50 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jul 17 20:46:53 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 23 12:18:03 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5827,12 +5661,12 @@ This report was generated on **Wed Jul 17 20:46:53 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.8.0
+1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.9.0
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.8.0
+1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.9.0
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
@@ -5853,87 +5687,33 @@ This report was generated on **Wed Jul 17 20:46:53 EEST 2019** using [Gradle-Lic
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** io.grpc **Name:** grpc-api **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-api **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-core **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-core **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-netty **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-okhttp **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-okhttp **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-protobuf **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-protobuf **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-protobuf-lite **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-protobuf-lite **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-stub **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
-
-1. **Group:** io.grpc **Name:** grpc-stub **Version:** 1.21.0
-     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
-     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
-
-1. **Group:** io.netty **Name:** netty-buffer **Version:** 4.1.34.Final
-     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
-1. **Group:** io.netty **Name:** netty-codec **Version:** 4.1.34.Final
-     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
-1. **Group:** io.netty **Name:** netty-codec-http **Version:** 4.1.34.Final
-     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
-1. **Group:** io.netty **Name:** netty-codec-http2 **Version:** 4.1.34.Final
-     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
-1. **Group:** io.netty **Name:** netty-codec-socks **Version:** 4.1.34.Final
-     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
-1. **Group:** io.netty **Name:** netty-common **Version:** 4.1.34.Final
-     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
-1. **Group:** io.netty **Name:** netty-handler **Version:** 4.1.34.Final
-     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
-1. **Group:** io.netty **Name:** netty-handler-proxy **Version:** 4.1.34.Final
-     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
-1. **Group:** io.netty **Name:** netty-resolver **Version:** 4.1.34.Final
-     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
-1. **Group:** io.netty **Name:** netty-transport **Version:** 4.1.34.Final
-     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
 1. **Group:** io.opencensus **Name:** opencensus-api **Version:** 0.21.0
      * **POM Project URL:** [https://github.com/census-instrumentation/opencensus-java](https://github.com/census-instrumentation/opencensus-java)
@@ -5946,6 +5726,10 @@ This report was generated on **Wed Jul 17 20:46:53 EEST 2019** using [Gradle-Lic
 1. **Group:** io.opencensus **Name:** opencensus-contrib-http-util **Version:** 0.18.0
      * **POM Project URL:** [https://github.com/census-instrumentation/opencensus-java](https://github.com/census-instrumentation/opencensus-java)
      * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** io.perfmark **Name:** perfmark-api **Version:** 0.16.0
+     * **POM Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
 1. **Group:** javax.servlet **Name:** javax.servlet-api **Version:** 3.1.0
      * **Manifest Project URL:** [https://glassfish.dev.java.net](https://glassfish.dev.java.net)
@@ -5961,7 +5745,7 @@ This report was generated on **Wed Jul 17 20:46:53 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [http://hc.apache.org/httpcomponents-core-ga](http://hc.apache.org/httpcomponents-core-ga)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.8.2
+1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.9.0
      * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
      * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
 
@@ -6082,17 +5866,17 @@ This report was generated on **Wed Jul 17 20:46:53 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [https://github.com/google/protobuf-gradle-plugin](https://github.com/google/protobuf-gradle-plugin)
      * **POM License: BSD 3-Clause** - [http://opensource.org/licenses/BSD-3-Clause](http://opensource.org/licenses/BSD-3-Clause)
 
-1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.8.0
+1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.9.0
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.8.0
+1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.9.0
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1. **Group:** com.google.protobuf **Name:** protoc **Version:** 3.8.0
+1. **Group:** com.google.protobuf **Name:** protoc **Version:** 3.9.0
      * **POM Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -6144,91 +5928,37 @@ This report was generated on **Wed Jul 17 20:46:53 EEST 2019** using [Gradle-Lic
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** io.grpc **Name:** grpc-api **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-api **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-core **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-core **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-netty **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-okhttp **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-okhttp **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-protobuf **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-protobuf **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-protobuf-lite **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-protobuf-lite **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-stub **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-stub **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** protoc-gen-grpc-java **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
-
-1. **Group:** io.grpc **Name:** protoc-gen-grpc-java **Version:** 1.21.0
-     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
-     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
-
-1. **Group:** io.netty **Name:** netty-buffer **Version:** 4.1.34.Final
-     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
-1. **Group:** io.netty **Name:** netty-codec **Version:** 4.1.34.Final
-     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
-1. **Group:** io.netty **Name:** netty-codec-http **Version:** 4.1.34.Final
-     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
-1. **Group:** io.netty **Name:** netty-codec-http2 **Version:** 4.1.34.Final
-     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
-1. **Group:** io.netty **Name:** netty-codec-socks **Version:** 4.1.34.Final
-     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
-1. **Group:** io.netty **Name:** netty-common **Version:** 4.1.34.Final
-     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
-1. **Group:** io.netty **Name:** netty-handler **Version:** 4.1.34.Final
-     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
-1. **Group:** io.netty **Name:** netty-handler-proxy **Version:** 4.1.34.Final
-     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
-1. **Group:** io.netty **Name:** netty-resolver **Version:** 4.1.34.Final
-     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
-1. **Group:** io.netty **Name:** netty-transport **Version:** 4.1.34.Final
-     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
 1. **Group:** io.opencensus **Name:** opencensus-api **Version:** 0.21.0
      * **POM Project URL:** [https://github.com/census-instrumentation/opencensus-java](https://github.com/census-instrumentation/opencensus-java)
@@ -6241,6 +5971,10 @@ This report was generated on **Wed Jul 17 20:46:53 EEST 2019** using [Gradle-Lic
 1. **Group:** io.opencensus **Name:** opencensus-contrib-http-util **Version:** 0.18.0
      * **POM Project URL:** [https://github.com/census-instrumentation/opencensus-java](https://github.com/census-instrumentation/opencensus-java)
      * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** io.perfmark **Name:** perfmark-api **Version:** 0.16.0
+     * **POM Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
 1. **Group:** javax.annotation **Name:** jsr250-api **Version:** 1.0
      * **POM Project URL:** [http://jcp.org/aboutJava/communityprocess/final/jsr250/index.html](http://jcp.org/aboutJava/communityprocess/final/jsr250/index.html)
@@ -6279,10 +6013,10 @@ This report was generated on **Wed Jul 17 20:46:53 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [https://javacc.dev.java.net/](https://javacc.dev.java.net/)
      * **POM License: Berkeley Software Distribution (BSD) License** - [http://www.opensource.org/licenses/bsd-license.html](http://www.opensource.org/licenses/bsd-license.html)
 
-1. **Group:** net.sourceforge.pmd **Name:** pmd-core **Version:** 6.13.0
+1. **Group:** net.sourceforge.pmd **Name:** pmd-core **Version:** 6.16.0
      * **POM License: BSD-style** - [http://pmd.sourceforge.net/license.html](http://pmd.sourceforge.net/license.html)
 
-1. **Group:** net.sourceforge.pmd **Name:** pmd-java **Version:** 6.13.0
+1. **Group:** net.sourceforge.pmd **Name:** pmd-java **Version:** 6.16.0
      * **POM License: BSD-style** - [http://pmd.sourceforge.net/license.html](http://pmd.sourceforge.net/license.html)
 
 1. **Group:** net.sourceforge.saxon **Name:** saxon **Version:** 9.1.0.8
@@ -6325,7 +6059,7 @@ This report was generated on **Wed Jul 17 20:46:53 EEST 2019** using [Gradle-Lic
      * **POM License: GNU General Public License, version 2 (GPL2), with the classpath exception** - [http://www.gnu.org/software/classpath/license.html](http://www.gnu.org/software/classpath/license.html)
      * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
 
-1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.8.2
+1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.9.0
      * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
      * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
 
@@ -6466,7 +6200,7 @@ This report was generated on **Wed Jul 17 20:46:53 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jul 17 20:46:54 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 23 12:18:03 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6502,7 +6236,7 @@ This report was generated on **Wed Jul 17 20:46:54 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.8.2
+1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.9.0
      * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
      * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
 
@@ -6717,17 +6451,17 @@ This report was generated on **Wed Jul 17 20:46:54 EEST 2019** using [Gradle-Lic
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.8.0
+1. **Group:** com.google.protobuf **Name:** protobuf-java **Version:** 3.9.0
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.8.0
+1. **Group:** com.google.protobuf **Name:** protobuf-java-util **Version:** 3.9.0
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **Manifest license URL:** [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1. **Group:** com.google.protobuf **Name:** protoc **Version:** 3.8.0
+1. **Group:** com.google.protobuf **Name:** protoc **Version:** 3.9.0
      * **POM Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -6755,25 +6489,10 @@ This report was generated on **Wed Jul 17 20:46:54 EEST 2019** using [Gradle-Lic
 1. **Group:** com.squareup.okio **Name:** okio **Version:** 1.13.0
      * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** commons-beanutils **Name:** commons-beanutils **Version:** 1.9.2
-     * **Project URL:** [http://commons.apache.org/proper/commons-beanutils/](http://commons.apache.org/proper/commons-beanutils/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1. **Group:** commons-codec **Name:** commons-codec **Version:** 1.10
      * **Project URL:** [http://commons.apache.org/proper/commons-codec/](http://commons.apache.org/proper/commons-codec/)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1. **Group:** commons-collections **Name:** commons-collections **Version:** 3.2.2
-     * **Project URL:** [http://commons.apache.org/collections/](http://commons.apache.org/collections/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1. **Group:** commons-digester **Name:** commons-digester **Version:** 1.8.1
-     * **Project URL:** [http://commons.apache.org/digester/](http://commons.apache.org/digester/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** commons-io **Name:** commons-io **Version:** 2.6
      * **Project URL:** [http://commons.apache.org/proper/commons-io/](http://commons.apache.org/proper/commons-io/)
@@ -6785,12 +6504,7 @@ This report was generated on **Wed Jul 17 20:46:54 EEST 2019** using [Gradle-Lic
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** commons-validator **Name:** commons-validator **Version:** 1.6
-     * **Project URL:** [http://commons.apache.org/proper/commons-validator/](http://commons.apache.org/proper/commons-validator/)
-     * **Manifest license URL:** [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **POM License: Apache License, Version 2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1. **Group:** io.grpc **Name:** grpc-api **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-api **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -6798,15 +6512,11 @@ This report was generated on **Wed Jul 17 20:46:54 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-core **Version:** 1.21.0
-     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
-     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
-
-1. **Group:** io.grpc **Name:** grpc-netty **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-core **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -6814,19 +6524,19 @@ This report was generated on **Wed Jul 17 20:46:54 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-okhttp **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-okhttp **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-protobuf **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-protobuf **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-protobuf-lite **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-protobuf-lite **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-stub **Version:** 1.21.0
+1. **Group:** io.grpc **Name:** grpc-stub **Version:** 1.22.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -6845,27 +6555,12 @@ This report was generated on **Wed Jul 17 20:46:54 EEST 2019** using [Gradle-Lic
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
-1. **Group:** io.netty **Name:** netty-codec-http2 **Version:** 4.1.34.Final
-     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
-1. **Group:** io.netty **Name:** netty-codec-socks **Version:** 4.1.34.Final
-     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
 1. **Group:** io.netty **Name:** netty-common **Version:** 4.1.34.Final
      * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
 1. **Group:** io.netty **Name:** netty-handler **Version:** 4.1.34.Final
-     * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
-     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
-1. **Group:** io.netty **Name:** netty-handler-proxy **Version:** 4.1.34.Final
      * **Manifest Project URL:** [http://netty.io/](http://netty.io/)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
@@ -6895,6 +6590,10 @@ This report was generated on **Wed Jul 17 20:46:54 EEST 2019** using [Gradle-Lic
 1. **Group:** io.opencensus **Name:** opencensus-contrib-http-util **Version:** 0.18.0
      * **POM Project URL:** [https://github.com/census-instrumentation/opencensus-java](https://github.com/census-instrumentation/opencensus-java)
      * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** io.perfmark **Name:** perfmark-api **Version:** 0.16.0
+     * **POM Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
+     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
 1. **Group:** javax.servlet **Name:** javax.servlet-api **Version:** 3.1.0
      * **Manifest Project URL:** [https://glassfish.dev.java.net](https://glassfish.dev.java.net)
@@ -6931,10 +6630,10 @@ This report was generated on **Wed Jul 17 20:46:54 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [https://javacc.dev.java.net/](https://javacc.dev.java.net/)
      * **POM License: Berkeley Software Distribution (BSD) License** - [http://www.opensource.org/licenses/bsd-license.html](http://www.opensource.org/licenses/bsd-license.html)
 
-1. **Group:** net.sourceforge.pmd **Name:** pmd-core **Version:** 6.13.0
+1. **Group:** net.sourceforge.pmd **Name:** pmd-core **Version:** 6.16.0
      * **POM License: BSD-style** - [http://pmd.sourceforge.net/license.html](http://pmd.sourceforge.net/license.html)
 
-1. **Group:** net.sourceforge.pmd **Name:** pmd-java **Version:** 6.13.0
+1. **Group:** net.sourceforge.pmd **Name:** pmd-java **Version:** 6.16.0
      * **POM License: BSD-style** - [http://pmd.sourceforge.net/license.html](http://pmd.sourceforge.net/license.html)
 
 1. **Group:** net.sourceforge.saxon **Name:** saxon **Version:** 9.1.0.8
@@ -6968,7 +6667,7 @@ This report was generated on **Wed Jul 17 20:46:54 EEST 2019** using [Gradle-Lic
      * **POM License: GNU General Public License, version 2 (GPL2), with the classpath exception** - [http://www.gnu.org/software/classpath/license.html](http://www.gnu.org/software/classpath/license.html)
      * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
 
-1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.8.2
+1. **Group:** org.checkerframework **Name:** checker-qual **Version:** 2.9.0
      * **POM Project URL:** [https://checkerframework.org](https://checkerframework.org)
      * **POM License: The MIT License** - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
 
@@ -7094,4 +6793,4 @@ This report was generated on **Wed Jul 17 20:46:54 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jul 17 20:46:55 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 23 12:18:04 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -588,7 +588,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Jul 23 18:13:45 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 23 18:20:19 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 #NPM dependencies of `spine-web@0.18.0`
@@ -2783,7 +2783,7 @@ This report was generated on **Tue Jul 23 18:13:45 EEST 2019** using [Gradle-Lic
      * Repository: [https://github.com/bcoe/yargs](https://github.com/bcoe/yargs)
 
 
-This report was generated on **Tue Jul 23 2019 18:13:48 GMT+0300 (EEST)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
+This report was generated on **Tue Jul 23 2019 18:20:21 GMT+0300 (EEST)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
 
 
 
@@ -3725,7 +3725,7 @@ This report was generated on **Tue Jul 23 2019 18:13:48 GMT+0300 (EEST)** using 
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Jul 23 18:13:49 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 23 18:20:22 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5596,7 +5596,7 @@ This report was generated on **Tue Jul 23 18:13:49 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Jul 23 18:13:51 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 23 18:20:24 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6200,7 +6200,7 @@ This report was generated on **Tue Jul 23 18:13:51 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Jul 23 18:13:52 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 23 18:20:25 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6793,4 +6793,4 @@ This report was generated on **Tue Jul 23 18:13:52 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Jul 23 18:13:53 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 23 18:20:26 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -588,7 +588,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Jul 23 18:20:19 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jul 24 13:50:31 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 #NPM dependencies of `spine-web@0.18.0`
@@ -1437,7 +1437,7 @@ This report was generated on **Tue Jul 23 18:20:19 EEST 2019** using [Gradle-Lic
 1. **duplexify@3.7.1**
      * Licenses: MIT
      * Repository: [https://github.com/mafintosh/duplexify](https://github.com/mafintosh/duplexify)
-1. **electron-to-chromium@1.3.199**
+1. **electron-to-chromium@1.3.200**
      * Licenses: ISC
      * Repository: [https://github.com/kilian/electron-to-chromium](https://github.com/kilian/electron-to-chromium)
 1. **elliptic@6.5.0**
@@ -2058,7 +2058,7 @@ This report was generated on **Tue Jul 23 18:20:19 EEST 2019** using [Gradle-Lic
 1. **node-pre-gyp@0.13.0**
      * Licenses: BSD-3-Clause
      * Repository: [https://github.com/mapbox/node-pre-gyp](https://github.com/mapbox/node-pre-gyp)
-1. **node-releases@1.1.25**
+1. **node-releases@1.1.26**
      * Licenses: MIT
      * Repository: [https://github.com/chicoxyzzy/node-releases](https://github.com/chicoxyzzy/node-releases)
 1. **nopt@4.0.1**
@@ -2415,7 +2415,7 @@ This report was generated on **Tue Jul 23 18:20:19 EEST 2019** using [Gradle-Lic
 1. **semver@5.7.0**
      * Licenses: ISC
      * Repository: [https://github.com/npm/node-semver](https://github.com/npm/node-semver)
-1. **semver@6.2.0**
+1. **semver@6.3.0**
      * Licenses: ISC
      * Repository: [https://github.com/npm/node-semver](https://github.com/npm/node-semver)
 1. **serialize-javascript@1.7.0**
@@ -2783,7 +2783,7 @@ This report was generated on **Tue Jul 23 18:20:19 EEST 2019** using [Gradle-Lic
      * Repository: [https://github.com/bcoe/yargs](https://github.com/bcoe/yargs)
 
 
-This report was generated on **Tue Jul 23 2019 18:20:21 GMT+0300 (EEST)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
+This report was generated on **Wed Jul 24 2019 13:50:33 GMT+0300 (EEST)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
 
 
 
@@ -3725,7 +3725,7 @@ This report was generated on **Tue Jul 23 2019 18:20:21 GMT+0300 (EEST)** using 
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Jul 23 18:20:22 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jul 24 13:50:34 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5596,7 +5596,7 @@ This report was generated on **Tue Jul 23 18:20:22 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Jul 23 18:20:24 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jul 24 13:50:37 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6200,7 +6200,7 @@ This report was generated on **Tue Jul 23 18:20:24 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Jul 23 18:20:25 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jul 24 13:50:38 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6793,4 +6793,4 @@ This report was generated on **Tue Jul 23 18:20:25 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Jul 23 18:20:26 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jul 24 13:50:38 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>com.fasterxml.jackson.core</groupId>
     <artifactId>jackson-databind</artifactId>
-    <version>2.9.9</version>
+    <version>2.9.9.1</version>
     <scope>compile</scope>
   </dependency>
   <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -74,12 +74,6 @@ all modules and does not describe the project structure per-subproject.
     <scope>compile</scope>
   </dependency>
   <dependency>
-    <groupId>commons-validator</groupId>
-    <artifactId>commons-validator</artifactId>
-    <version>1.6</version>
-    <scope>compile</scope>
-  </dependency>
-  <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
     <version>1.0.0-SNAPSHOT</version>
@@ -94,7 +88,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>org.checkerframework</groupId>
     <artifactId>checker-qual</artifactId>
-    <version>2.8.2</version>
+    <version>2.9.0</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -118,6 +112,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testutil-client</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>io.spine.tools</groupId>
+    <artifactId>spine-mute-logging</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <scope>test</scope>
   </dependency>
@@ -176,12 +176,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>com.google.protobuf</groupId>
     <artifactId>protoc</artifactId>
-    <version>3.8.0</version>
+    <version>3.9.0</version>
   </dependency>
   <dependency>
     <groupId>io.grpc</groupId>
     <artifactId>protoc-gen-grpc-java</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
@@ -211,7 +211,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>
     <artifactId>pmd-java</artifactId>
-    <version>6.13.0</version>
+    <version>6.16.0</version>
   </dependency>
   <dependency>
     <groupId>org.gretty</groupId>

--- a/web/build.gradle
+++ b/web/build.gradle
@@ -18,7 +18,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-
 configurations {
     // Avoid collisions of Java classes defined both in `protobuf-lite` and `protobuf-java`
     runtime.exclude group: "com.google.protobuf", module: "protobuf-lite"
@@ -34,10 +33,6 @@ dependencies {
     implementation deps.build.googleHttpClient
     implementation deps.build.googleHttpClientApache
     implementation "io.spine:spine-server:$spineVersion"
-}
-
-modelCompiler {
-    generateValidatingBuilders = true
 }
 
 task compileProtoToJs {

--- a/web/build.gradle
+++ b/web/build.gradle
@@ -33,6 +33,8 @@ dependencies {
     implementation deps.build.googleHttpClient
     implementation deps.build.googleHttpClientApache
     implementation "io.spine:spine-server:$spineVersion"
+
+    testImplementation "io.spine.tools:spine-mute-logging:$spineVersion"
 }
 
 task compileProtoToJs {

--- a/web/src/test/java/io/spine/web/command/CommandServletTest.java
+++ b/web/src/test/java/io/spine/web/command/CommandServletTest.java
@@ -28,6 +28,7 @@ import io.spine.json.Json;
 import io.spine.protobuf.AnyPacker;
 import io.spine.testing.client.TestActorRequestFactory;
 import io.spine.testing.client.command.TestCommandMessage;
+import io.spine.testing.logging.MuteLogging;
 import io.spine.web.command.given.CommandServletTestEnv.TestCommandServlet;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -78,6 +79,7 @@ class CommandServletTest {
         assertEquals(command.getId(), AnyPacker.unpack(ack.getMessageId()));
     }
 
+    @MuteLogging
     @Test
     @DisplayName("respond 400 to an invalid command")
     void testInvalidCommand() throws IOException {

--- a/web/src/test/java/io/spine/web/parser/HttpMessagesTest.java
+++ b/web/src/test/java/io/spine/web/parser/HttpMessagesTest.java
@@ -27,6 +27,7 @@ import com.google.protobuf.Timestamp;
 import com.google.protobuf.UnknownFieldSet;
 import io.spine.base.Time;
 import io.spine.core.Ack;
+import io.spine.testing.logging.MuteLogging;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -103,6 +104,7 @@ class HttpMessagesTest {
         assertEquals(expectedMessage, actual.get());
     }
 
+    @MuteLogging
     @Test
     @DisplayName("not parse message of an unknown format")
     void testNotSupportUnknownFormat() throws IOException {
@@ -124,6 +126,7 @@ class HttpMessagesTest {
         assertEquals(Empty.getDefaultInstance(), parsed.get());
     }
 
+    @MuteLogging
     @Test
     @DisplayName("fail to parse a malformed byte string")
     void testFailToParseBytes() throws IOException {
@@ -133,6 +136,7 @@ class HttpMessagesTest {
         assertFalse(parsed.isPresent());
     }
 
+    @MuteLogging
     @Test
     @DisplayName("fail to parse wrong type of message from JSON")
     void testJsonWrongType() throws IOException {
@@ -141,6 +145,7 @@ class HttpMessagesTest {
         assertFalse(parsed.isPresent());
     }
 
+    @MuteLogging
     @Test
     @DisplayName("parse to parse wrong type of message from bytes into unknown fields")
     void testBase64WrongType() throws IOException {

--- a/web/src/test/java/io/spine/web/query/QueryServletTest.java
+++ b/web/src/test/java/io/spine/web/query/QueryServletTest.java
@@ -25,6 +25,7 @@ import io.spine.client.Query;
 import io.spine.client.QueryFactory;
 import io.spine.json.Json;
 import io.spine.testing.client.TestActorRequestFactory;
+import io.spine.testing.logging.MuteLogging;
 import io.spine.web.query.given.QueryServletTestEnv.TestQueryServlet;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -71,9 +72,10 @@ class QueryServletTest {
         assertEquals(expectedData, actualData);
     }
 
+    @MuteLogging
     @Test
     @DisplayName("respond 400 to an invalid query")
-    void testInvalidCommand() throws IOException {
+    void testInvalidQuery() throws IOException {
         QueryServlet servlet = new TestQueryServlet();
         HttpServletResponse response = response(new StringWriter());
         servlet.doPost(request(currentTime()), response);


### PR DESCRIPTION
In this PR we update the library with the new version of core:
 - JS library is updated to support the latest changes in the `Query` format;
 - `VBuilder`s are removed and substituted for `vBuild()`/`buildPartial()` calls.

Additionally:
 - some test output is now muted, since it prints errors from negative case tests;
 - `buildPartial()` usages are substituted for `build()` as for the recent conventions on _build_ methods.

