### PR TITLE
Optimize Firebase writes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 env:
   global:

--- a/firebase-web/src/main/java/io/spine/web/firebase/AsyncClient.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/AsyncClient.java
@@ -70,12 +70,13 @@ public final class AsyncClient implements FirebaseClient {
     }
 
     @Override
-    public void create(NodePath path, NodeValue value) {
-        executor.execute(() -> delegate.create(path, value));
+    public void create(NodePath nodePath, NodeValue value) {
+        executor.execute(() -> delegate.create(nodePath, value));
     }
 
     @Override
-    public void update(NodePath path, NodeValue value) {
-        executor.execute(() -> delegate.update(path, value));
+    public void update(NodePath nodePath, NodeValue value) {
+        executor.execute(() -> delegate.update(nodePath, value));
+
     }
 }

--- a/firebase-web/src/main/java/io/spine/web/firebase/AsyncClient.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/AsyncClient.java
@@ -70,7 +70,12 @@ public final class AsyncClient implements FirebaseClient {
     }
 
     @Override
-    public void merge(NodePath nodePath, NodeValue value) {
-        executor.execute(() -> delegate.merge(nodePath, value));
+    public void create(NodePath path, NodeValue value) {
+        executor.execute(() -> delegate.create(path, value));
+    }
+
+    @Override
+    public void update(NodePath path, NodeValue value) {
+        executor.execute(() -> delegate.update(path, value));
     }
 }

--- a/firebase-web/src/main/java/io/spine/web/firebase/FirebaseClient.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/FirebaseClient.java
@@ -42,32 +42,29 @@ public interface FirebaseClient {
     Optional<NodeValue> get(NodePath nodePath);
 
     /**
-     * Writes the given value under the given path in the database.
+     * Writes the specified value to the Firebase database node.
      *
-     * <p>Overrides any existing value at the given path.
+     * <p>If the node exists, the value is overridden.
      *
-     * @param path
-     *         the path to the node in the database
+     * @param nodePath
+     *         the path to the node in the Firebase database
      * @param value
-     *         the value to write into the database
-     * @see #update(NodePath, NodeValue)
+     *         the value to write
      */
-    void create(NodePath path, NodeValue value);
+    void create(NodePath nodePath, NodeValue value);
 
     /**
-     * Updates the value under the given database path with the given value.
+     * Merges the specified value to the Firebase database node.
      *
-     * <p>If there is an existing value of the given node, the values are merged:
-     * <ul>
-     *     <li>common values are overridden;
-     *     <li>non-common values are preserved.
-     * </ul>
+     * <p>If the node doesn't exist, it is created with the given value.
      *
-     * @param path
-     *         the path to the node in the database
+     * <p>If the node exists, the value entries are added to the node children overwriting common
+     * ones if present.
+     *
+     * @param nodePath
+     *         the path to the node in the Firebase database
      * @param value
-     *         the value to merge into the database node
-     * @see #create(NodePath, NodeValue)
+     *         the value to merge
      */
-    void update(NodePath path, NodeValue value);
+    void update(NodePath nodePath, NodeValue value);
 }

--- a/firebase-web/src/main/java/io/spine/web/firebase/FirebaseClient.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/FirebaseClient.java
@@ -42,17 +42,32 @@ public interface FirebaseClient {
     Optional<NodeValue> get(NodePath nodePath);
 
     /**
-     * Merges the specified value to the Firebase database node.
+     * Writes the given value under the given path in the database.
      *
-     * <p>If the node doesn't exist, it is created with the given value.
+     * <p>Overrides any existing value at the given path.
      *
-     * <p>If the node exists, the value entries are added to the node children overwriting common
-     * ones if present.
-     *
-     * @param nodePath
-     *         the path to the node in the Firebase database
+     * @param path
+     *         the path to the node in the database
      * @param value
-     *         the value to merge
+     *         the value to write into the database
+     * @see #update(NodePath, NodeValue)
      */
-    void merge(NodePath nodePath, NodeValue value);
+    void create(NodePath path, NodeValue value);
+
+    /**
+     * Updates the value under the given database path with the given value.
+     *
+     * <p>If there is an existing value of the given node, the values are merged:
+     * <ul>
+     *     <li>common values are overridden;
+     *     <li>non-common values are preserved.
+     * </ul>
+     *
+     * @param path
+     *         the path to the node in the database
+     * @param value
+     *         the value to merge into the database node
+     * @see #create(NodePath, NodeValue)
+     */
+    void update(NodePath path, NodeValue value);
 }

--- a/firebase-web/src/main/java/io/spine/web/firebase/NodeValue.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/NodeValue.java
@@ -26,9 +26,9 @@ import com.google.firebase.database.utilities.Clock;
 import com.google.firebase.database.utilities.DefaultClock;
 import com.google.firebase.database.utilities.OffsetClock;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 
 import static com.google.api.client.http.ByteArrayContent.fromString;
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.net.MediaType.JSON_UTF_8;
 import static com.google.firebase.database.utilities.PushIdGenerator.generatePushChildName;
 
@@ -61,10 +61,8 @@ public final class NodeValue {
      * Creates a {@code NodeValue} whose underlying {@link com.google.gson.JsonObject} is
      * parsed from the given {@code String}.
      */
-    public static NodeValue from(String json) {
-        JsonParser parser = new JsonParser();
-        JsonObject value = parser.parse(json)
-                                 .getAsJsonObject();
+    static NodeValue from(StoredJson json) {
+        JsonObject value = json.asJsonObject();
         return new NodeValue(value);
     }
 
@@ -76,9 +74,9 @@ public final class NodeValue {
      * @param jsons child nodes
      * @return new node value
      */
-    public static NodeValue withChildren(Iterable<String> jsons) {
+    public static NodeValue withChildren(Iterable<StoredJson> jsons) {
         NodeValue nodeValue = new NodeValue();
-        for (String json : jsons) {
+        for (StoredJson json : jsons) {
             nodeValue.addChild(json);
         }
         return nodeValue;
@@ -103,17 +101,19 @@ public final class NodeValue {
      * @return the generated key under which the data was stored
      */
     @CanIgnoreReturnValue
-    public String addChild(String data) {
+    public String addChild(StoredJson data) {
         String key = ChildKeyGenerator.newKey();
-        value.addProperty(key, data);
+        addChild(key, data);
         return key;
     }
 
     /**
      * Adds a child to the value under a specified key.
      */
-    public void addChild(String key, String data) {
-        value.addProperty(key, data);
+    public void addChild(String key, StoredJson data) {
+        checkNotNull(key);
+        checkNotNull(data);
+        value.addProperty(key, data.value());
     }
 
     /**

--- a/firebase-web/src/main/java/io/spine/web/firebase/NodeValue.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/NodeValue.java
@@ -69,11 +69,18 @@ public final class NodeValue {
     }
 
     /**
-     * Creates a {@code NodeValue} which has a single entry under a generated key.
+     * Creates a new node value with all the given JSONs as its children.
+     *
+     * <p>The child nodes are added under generated keys.
+     *
+     * @param jsons child nodes
+     * @return new node value
      */
-    public static NodeValue withSingleChild(String childValue) {
+    public static NodeValue withChildren(Iterable<String> jsons) {
         NodeValue nodeValue = new NodeValue();
-        nodeValue.addChild(childValue);
+        for (String json : jsons) {
+            nodeValue.addChild(json);
+        }
         return nodeValue;
     }
 

--- a/firebase-web/src/main/java/io/spine/web/firebase/RetryingClient.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/RetryingClient.java
@@ -54,7 +54,12 @@ public final class RetryingClient implements FirebaseClient {
     }
 
     @Override
-    public void merge(NodePath nodePath, NodeValue value) {
-        retryer.runAndRetry(() -> delegate.merge(nodePath, value));
+    public void create(NodePath path, NodeValue value) {
+        retryer.runAndRetry(() -> delegate.create(path, value));
+    }
+
+    @Override
+    public void update(NodePath path, NodeValue value) {
+        retryer.runAndRetry(() -> delegate.update(path, value));
     }
 }

--- a/firebase-web/src/main/java/io/spine/web/firebase/RetryingClient.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/RetryingClient.java
@@ -54,12 +54,12 @@ public final class RetryingClient implements FirebaseClient {
     }
 
     @Override
-    public void create(NodePath path, NodeValue value) {
-        retryer.runAndRetry(() -> delegate.create(path, value));
+    public void create(NodePath nodePath, NodeValue value) {
+        retryer.runAndRetry(() -> delegate.create(nodePath, value));
     }
 
     @Override
-    public void update(NodePath path, NodeValue value) {
-        retryer.runAndRetry(() -> delegate.update(path, value));
+    public void update(NodePath nodePath, NodeValue value) {
+        retryer.runAndRetry(() -> delegate.update(nodePath, value));
     }
 }

--- a/firebase-web/src/main/java/io/spine/web/firebase/StoredJson.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/StoredJson.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.web.firebase;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.protobuf.Any;
+import com.google.protobuf.Message;
+import io.spine.protobuf.AnyPacker;
+import io.spine.value.StringTypeValue;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+import static io.spine.json.Json.toCompactJson;
+
+/**
+ * A JSON representation of data stored in a node of a Firebase Realtime DB.
+ */
+public final class StoredJson extends StringTypeValue {
+
+    private static final long serialVersionUID = 0L;
+
+    /**
+     * The representation of the database {@code null} entry.
+     *
+     * <p>In Firebase the {@code null} node is deemed nonexistent.
+     */
+    private static final String JSON_NULL = "null";
+    private static final StoredJson NULL_JSON = new StoredJson(JSON_NULL);
+
+    private StoredJson(String value) {
+        super(value);
+    }
+
+    public static StoredJson from(String value) {
+        checkNotNull(value);
+        return JSON_NULL.equals(value)
+               ? NULL_JSON
+               : new StoredJson(value);
+    }
+
+    public static StoredJson encode(Message value) {
+        checkNotNull(value);
+        Message message = value;
+        if (message instanceof Any) {
+            message = AnyPacker.unpack((Any) message);
+        }
+        String json = toCompactJson(message);
+        return from(json);
+    }
+
+    public JsonObject asJsonObject() {
+        JsonParser parser = new JsonParser();
+        JsonElement object = parser.parse(value());
+        return object.getAsJsonObject();
+    }
+
+    public NodeValue asNodeValue() {
+        checkState(!isNull(), "A null JSON cannot be converted into a NodeValue.");
+        return NodeValue.from(this);
+    }
+
+    @SuppressWarnings("ReferenceEquality") // There is only one `null` object.
+    public boolean isNull() {
+        return this == NULL_JSON;
+    }
+}

--- a/firebase-web/src/main/java/io/spine/web/firebase/query/QueryNodePath.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/query/QueryNodePath.java
@@ -60,7 +60,6 @@ public class QueryNodePath {
         return path;
     }
 
-    @SuppressWarnings("UnnecessaryDefault")
     private static String tenantIdAsString(Query query) {
         TenantId tenantId = query.getContext()
                                  .getTenantId();

--- a/firebase-web/src/main/java/io/spine/web/firebase/query/QueryRecord.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/query/QueryRecord.java
@@ -23,11 +23,10 @@ package io.spine.web.firebase.query;
 import io.spine.client.EntityStateWithVersion;
 import io.spine.client.Query;
 import io.spine.client.QueryResponse;
-import io.spine.json.Json;
-import io.spine.protobuf.AnyPacker;
 import io.spine.web.firebase.FirebaseClient;
 import io.spine.web.firebase.NodePath;
 import io.spine.web.firebase.NodeValue;
+import io.spine.web.firebase.StoredJson;
 
 import java.util.List;
 
@@ -69,13 +68,12 @@ final class QueryRecord {
      * bulk.
      */
     private void flushTo(FirebaseClient firebaseClient) {
-        List<String> jsons = queryResponse
+        List<StoredJson> jsons = queryResponse
                 .getMessageList()
                 .stream()
                 .unordered()
                 .map(EntityStateWithVersion::getState)
-                .map(AnyPacker::unpack)
-                .map(Json::toCompactJson)
+                .map(StoredJson::encode)
                 .collect(toList());
         firebaseClient.create(path, NodeValue.withChildren(jsons));
     }

--- a/firebase-web/src/main/java/io/spine/web/firebase/query/QueryRecord.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/query/QueryRecord.java
@@ -74,6 +74,6 @@ final class QueryRecord {
                      .map(AnyPacker::unpack)
                      .map(Json::toCompactJson)
                      .map(NodeValue::withSingleChild)
-                     .forEach(node -> firebaseClient.merge(path, node));
+                     .forEach(node -> firebaseClient.create(path, node));
     }
 }

--- a/firebase-web/src/main/java/io/spine/web/firebase/rest/RestClient.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/rest/RestClient.java
@@ -41,7 +41,7 @@ import static io.spine.web.firebase.rest.RestNodeUrls.asGenericUrl;
  * See Firebase REST API <a href="https://firebase.google.com/docs/reference/rest/database/">docs
  * </a>.
  */
-public class RestClient implements FirebaseClient {
+public final class RestClient implements FirebaseClient {
 
     /**
      * The representation of the database {@code null} entry.
@@ -85,18 +85,23 @@ public class RestClient implements FirebaseClient {
     }
 
     @Override
-    public void merge(NodePath nodePath, NodeValue value) {
-        checkNotNull(nodePath);
+    public void create(NodePath path, NodeValue value) {
+        checkNotNull(path);
         checkNotNull(value);
 
-        GenericUrl nodeUrl = asGenericUrl(factory.with(nodePath));
+        GenericUrl nodeUrl = asGenericUrl(factory.with(path));
         ByteArrayContent byteArrayContent = value.toByteArray();
-        Optional<NodeValue> existingValue = get(nodePath);
-        if (!existingValue.isPresent()) {
-            create(nodeUrl, byteArrayContent);
-        } else {
-            update(nodeUrl, byteArrayContent);
-        }
+        create(nodeUrl, byteArrayContent);
+    }
+
+    @Override
+    public void update(NodePath path, NodeValue value) {
+        checkNotNull(path);
+        checkNotNull(value);
+
+        GenericUrl nodeUrl = asGenericUrl(factory.with(path));
+        ByteArrayContent byteArrayContent = value.toByteArray();
+        update(nodeUrl, byteArrayContent);
     }
 
     /**

--- a/firebase-web/src/main/java/io/spine/web/firebase/rest/RestClient.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/rest/RestClient.java
@@ -85,21 +85,21 @@ public final class RestClient implements FirebaseClient {
     }
 
     @Override
-    public void create(NodePath path, NodeValue value) {
-        checkNotNull(path);
+    public void create(NodePath nodePath, NodeValue value) {
+        checkNotNull(nodePath);
         checkNotNull(value);
 
-        GenericUrl nodeUrl = asGenericUrl(factory.with(path));
+        GenericUrl nodeUrl = asGenericUrl(factory.with(nodePath));
         ByteArrayContent byteArrayContent = value.toByteArray();
         create(nodeUrl, byteArrayContent);
     }
 
     @Override
-    public void update(NodePath path, NodeValue value) {
-        checkNotNull(path);
+    public void update(NodePath nodePath, NodeValue value) {
+        checkNotNull(nodePath);
         checkNotNull(value);
 
-        GenericUrl nodeUrl = asGenericUrl(factory.with(path));
+        GenericUrl nodeUrl = asGenericUrl(factory.with(nodePath));
         ByteArrayContent byteArrayContent = value.toByteArray();
         update(nodeUrl, byteArrayContent);
     }

--- a/firebase-web/src/main/java/io/spine/web/firebase/subscription/FirebaseSubscriptionBridge.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/subscription/FirebaseSubscriptionBridge.java
@@ -75,7 +75,7 @@ public final class FirebaseSubscriptionBridge implements SubscriptionBridge {
         ResponseFormat format = ResponseFormat
                 .newBuilder()
                 .setFieldMask(topic.getFieldMask())
-                .build();
+                .buildPartial();
         return Query
                 .newBuilder()
                 .setId(generateId())

--- a/firebase-web/src/main/java/io/spine/web/firebase/subscription/SubscriptionRecord.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/subscription/SubscriptionRecord.java
@@ -102,7 +102,7 @@ final class SubscriptionRecord {
     private void flushEntries(Stream<String> jsonEntries, FirebaseClient client) {
         NodeValue nodeValue = NodeValue.empty();
         jsonEntries.forEach(nodeValue::addChild);
-        client.merge(path, nodeValue);
+        client.create(path, nodeValue);
     }
 
     private void updateWithDiff(Diff diff, FirebaseClient firebaseClient) {
@@ -113,7 +113,7 @@ final class SubscriptionRecord {
             .forEach(record -> nodeValue.addNullChild(record.getKey()));
         diff.getAddedList()
             .forEach(record -> nodeValue.addChild(record.getData()));
-        firebaseClient.merge(path, nodeValue);
+        firebaseClient.update(path, nodeValue);
     }
 
     /**

--- a/firebase-web/src/main/java/io/spine/web/firebase/subscription/SubscriptionRecord.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/subscription/SubscriptionRecord.java
@@ -72,7 +72,7 @@ final class SubscriptionRecord {
     void storeAsUpdate(FirebaseClient firebaseClient) {
         List<String> newEntries = mapMessagesToJson();
 
-        if (DiffCalculator.canCalculateFor(newEntries)) {
+        if (DiffCalculator.canCalculateEfficientlyFor(newEntries)) {
             Optional<NodeValue> existingValue = firebaseClient.get(path);
             if (existingValue.isPresent()) {
                 DiffCalculator diffCalculator = DiffCalculator.from(existingValue.get());

--- a/firebase-web/src/main/java/io/spine/web/firebase/subscription/diff/DiffCalculator.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/subscription/diff/DiffCalculator.java
@@ -20,10 +20,10 @@
 
 package io.spine.web.firebase.subscription.diff;
 
-import com.google.common.collect.ImmutableList;
 import com.google.gson.JsonObject;
 import io.spine.web.firebase.NodeValue;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -66,9 +66,10 @@ public final class DiffCalculator {
     }
 
     private static Diff toDiff(List<EntryUpdate> updates) {
-        ImmutableList.Builder<AddedItem> added = ImmutableList.builder();
-        ImmutableList.Builder<ChangedItem> changed = ImmutableList.builder();
-        ImmutableList.Builder<RemovedItem> removed = ImmutableList.builder();
+        int expectedSize = updates.size();
+        List<AddedItem> added = new ArrayList<>(expectedSize);
+        List<ChangedItem> changed = new ArrayList<>(expectedSize);
+        List<RemovedItem> removed = new ArrayList<>(expectedSize);
         updates.forEach(update -> {
             switch (update.getOperation()) {
                 case ADD:
@@ -93,12 +94,6 @@ public final class DiffCalculator {
                     break;
             }
         });
-        return diff(added.build(), changed.build(), removed.build());
-    }
-
-    private static Diff diff(List<AddedItem> added,
-                             List<ChangedItem> changed,
-                             List<RemovedItem> removed) {
         return Diff
                 .newBuilder()
                 .addAllAdded(added)

--- a/firebase-web/src/main/java/io/spine/web/firebase/subscription/diff/DiffCalculator.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/subscription/diff/DiffCalculator.java
@@ -70,30 +70,30 @@ public final class DiffCalculator {
         List<AddedItem> added = new ArrayList<>(expectedSize);
         List<ChangedItem> changed = new ArrayList<>(expectedSize);
         List<RemovedItem> removed = new ArrayList<>(expectedSize);
-        updates.forEach(update -> {
+        for (EntryUpdate update : updates) {
             switch (update.getOperation()) {
                 case ADD:
                     added.add(AddedItem.newBuilder()
                                        .setData(update.getData())
-                                       .vBuild());
+                                       .buildPartial());
                     break;
                 case REMOVE:
                     removed.add(RemovedItem.newBuilder()
                                            .setKey(update.getKey())
-                                           .vBuild());
+                                           .buildPartial());
                     break;
                 case CHANGE:
                     changed.add(ChangedItem.newBuilder()
                                            .setKey(update.getKey())
                                            .setData(update.getData())
-                                           .vBuild());
+                                           .buildPartial());
                     break;
                 case PASS:
                 case UNRECOGNIZED:
                 default:
                     break;
             }
-        });
+        }
         return Diff
                 .newBuilder()
                 .addAllAdded(added)

--- a/firebase-web/src/main/java/io/spine/web/firebase/subscription/diff/DiffCalculator.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/subscription/diff/DiffCalculator.java
@@ -38,7 +38,22 @@ public final class DiffCalculator {
         this.existingEntries = existingEntries;
     }
 
-    public static boolean canCalculateFor(List<String> entries) {
+    /**
+     * Checks if it is possible to efficiently calculate diff for the given entities.
+     *
+     * <p>For that, the JSON entries must have the {@code "id"} field defined.
+     *
+     * <p>Note that {@code DiffCalculator} can calculate diff even if this condition is not met.
+     * However, that may not be as efficient. In particular,
+     * the {@link EntryUpdate.Operation#CHANGE CHANGE} updates are reflected as a deletion and
+     * an addition.
+     *
+     * @param entries
+     *         the entries to check
+     * @return {@code true} if the entries may be included in a diff calculation,
+     *         {@code false} otherwise
+     */
+    public static boolean canCalculateEfficientlyFor(List<String> entries) {
         if (entries.isEmpty()) {
             return false;
         }

--- a/firebase-web/src/main/java/io/spine/web/firebase/subscription/diff/DiffCalculator.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/subscription/diff/DiffCalculator.java
@@ -22,6 +22,7 @@ package io.spine.web.firebase.subscription.diff;
 
 import com.google.gson.JsonObject;
 import io.spine.web.firebase.NodeValue;
+import io.spine.web.firebase.StoredJson;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -53,12 +54,12 @@ public final class DiffCalculator {
      * @return {@code true} if the entries may be included in a diff calculation,
      *         {@code false} otherwise
      */
-    public static boolean canCalculateEfficientlyFor(List<String> entries) {
+    public static boolean canCalculateEfficientlyFor(List<StoredJson> entries) {
         if (entries.isEmpty()) {
             return false;
         }
-        String firstEntry = entries.get(0);
-        UpToDateEntry upToDateEntry = UpToDateEntry.parse(firstEntry);
+        StoredJson firstEntry = entries.get(0);
+        UpToDateEntry upToDateEntry = UpToDateEntry.parse(firstEntry.value());
         return upToDateEntry.containsId();
     }
 
@@ -82,7 +83,7 @@ public final class DiffCalculator {
      *         a list of JSON serialized entries retrieved from Spine
      * @return a diff between Spine and Firebase data states
      */
-    public Diff compareWith(List<String> newEntries) {
+    public Diff compareWith(List<StoredJson> newEntries) {
         List<UpToDateEntry> entries = UpToDateEntry.parse(newEntries);
         EntriesMatcher matcher = new EntriesMatcher(existingEntries);
         List<EntryUpdate> updates = matcher.match(entries);

--- a/firebase-web/src/main/java/io/spine/web/firebase/subscription/diff/DiffCalculator.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/subscription/diff/DiffCalculator.java
@@ -38,6 +38,15 @@ public final class DiffCalculator {
         this.existingEntries = existingEntries;
     }
 
+    public static boolean canCalculateFor(List<String> entries) {
+        if (entries.isEmpty()) {
+            return false;
+        }
+        String firstEntry = entries.get(0);
+        UpToDateEntry upToDateEntry = UpToDateEntry.parse(firstEntry);
+        return upToDateEntry.containsId();
+    }
+
     /**
      * Create a new {@code DiffCalculator} with state current in Firebase.
      *

--- a/firebase-web/src/main/java/io/spine/web/firebase/subscription/diff/EntriesMatcher.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/subscription/diff/EntriesMatcher.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.web.firebase.subscription.diff.EntryUpdates.addEntry;
 import static io.spine.web.firebase.subscription.diff.EntryUpdates.changeEntry;
 import static io.spine.web.firebase.subscription.diff.EntryUpdates.passEntry;
@@ -66,7 +67,7 @@ final class EntriesMatcher {
     private EntryUpdate matchById(UpToDateEntry entry) {
         Optional<ExistingEntry> optionalMatchingEntry =
                 unmatchedEntries.stream()
-                                .filter(existing -> existing.idEquals(entry.id()))
+                                .filter(existing -> existing.idEquals(checkNotNull(entry.id())))
                                 .findFirst();
         if (optionalMatchingEntry.isPresent()) {
             ExistingEntry matchingEntry = optionalMatchingEntry.get();

--- a/firebase-web/src/main/java/io/spine/web/firebase/subscription/diff/Entry.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/subscription/diff/Entry.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.web.firebase.subscription.diff;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * An implementation base for a Firebase Realtime Database entry.
+ *
+ * <p>An entry is a JSON structure which represents a domain object requested by a user.
+ */
+abstract class Entry {
+
+    private static final String ID = "id";
+
+    private final @Nullable JsonNode id;
+    private final JsonNode json;
+    private final String rawData;
+
+    Entry(String rawData) {
+        this.rawData = checkNotNull(rawData);
+        this.json = JsonParser.parse(rawData);
+        this.id = json.get(ID);
+    }
+
+    /**
+     * Returns {@code true} if the entity contains an {@code "id"} field and {@code false}
+     * otherwise.
+     */
+    boolean containsId() {
+        return id != null;
+    }
+
+    /**
+     * A {@link JsonNode} representation of the entities {@code "id"} field.
+     */
+    @Nullable JsonNode id() {
+        return id;
+    }
+
+    /**
+     * JSON data of this entry.
+     */
+    JsonNode json() {
+        return json;
+    }
+
+    /**
+     * JSON serialized entity data represented as a string.
+     */
+    String rawData() {
+        return rawData;
+    }
+}

--- a/firebase-web/src/main/java/io/spine/web/firebase/subscription/diff/EntryUpdates.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/subscription/diff/EntryUpdates.java
@@ -40,7 +40,7 @@ final class EntryUpdates {
         return EntryUpdate
                 .newBuilder()
                 .setKey(matchingEntry.key())
-                .setData(entry.data())
+                .setData(entry.rawData())
                 .setOperation(CHANGE)
                 .vBuild();
     }
@@ -49,7 +49,7 @@ final class EntryUpdates {
         return EntryUpdate
                 .newBuilder()
                 .setKey(matchingEntry.key())
-                .setData(entry.data())
+                .setData(entry.rawData())
                 .setOperation(PASS)
                 .vBuild();
     }
@@ -57,7 +57,7 @@ final class EntryUpdates {
     static EntryUpdate addEntry(UpToDateEntry entry) {
         return EntryUpdate
                 .newBuilder()
-                .setData(entry.data())
+                .setData(entry.rawData())
                 .setOperation(ADD)
                 .vBuild();
     }
@@ -66,7 +66,7 @@ final class EntryUpdates {
         return EntryUpdate
                 .newBuilder()
                 .setKey(existing.key())
-                .setData(existing.data())
+                .setData(existing.rawData())
                 .setOperation(REMOVE)
                 .vBuild();
     }

--- a/firebase-web/src/main/java/io/spine/web/firebase/subscription/diff/ExistingEntry.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/subscription/diff/ExistingEntry.java
@@ -2,7 +2,6 @@ package io.spine.web.firebase.subscription.diff;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.gson.JsonObject;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.List;
 
@@ -62,7 +61,7 @@ final class ExistingEntry {
      *
      * <p>Returns {@code false} if the ID is {@code null}.
      */
-    boolean idEquals(@Nullable JsonNode id) {
+    boolean idEquals(JsonNode id) {
         return containsId && this.id.equals(id);
     }
 }

--- a/firebase-web/src/main/java/io/spine/web/firebase/subscription/diff/ExistingEntry.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/subscription/diff/ExistingEntry.java
@@ -2,6 +2,7 @@ package io.spine.web.firebase.subscription.diff;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.gson.JsonObject;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.List;
 
@@ -15,23 +16,20 @@ final class ExistingEntry {
     private final String key;
     private final String data;
     private final JsonNode json;
-    private final JsonNode id;
-    private final boolean containsId;
+    private final @Nullable JsonNode id;
 
     private ExistingEntry(String key, String data) {
         this.key = key;
         this.data = data;
         this.json = JsonParser.parse(data);
         this.id = json.get("id");
-        this.containsId = id != null;
     }
 
     static List<ExistingEntry> fromJson(JsonObject object) {
         return object
                 .entrySet()
                 .stream()
-                .map(entry -> new ExistingEntry(entry.getKey(), entry.getValue()
-                                                                     .getAsString()))
+                .map(entry -> new ExistingEntry(entry.getKey(), entry.getValue().getAsString()))
                 .collect(toList());
     }
 
@@ -57,11 +55,14 @@ final class ExistingEntry {
     }
 
     /**
-     * Checks if this entries {@code "id"} field matches the provided one.
+     * Checks if this entry's {@code "id"} field matches the provided one.
      *
-     * <p>Returns {@code false} if the ID is {@code null}.
+     * <p>Returns {@code false} if this entry has no {@code "id"} field
+     *
+     * @return {@code true} if the ID of this entry is equal to the given node,
+     *         {@code false} otherwise
      */
     boolean idEquals(JsonNode id) {
-        return containsId && this.id.equals(id);
+        return id.equals(this.id);
     }
 }

--- a/firebase-web/src/main/java/io/spine/web/firebase/subscription/diff/ExistingEntry.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/subscription/diff/ExistingEntry.java
@@ -2,6 +2,7 @@ package io.spine.web.firebase.subscription.diff;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.gson.JsonObject;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.List;
 
@@ -58,8 +59,10 @@ final class ExistingEntry {
 
     /**
      * Checks if this entries {@code "id"} field matches the provided one.
+     *
+     * <p>Returns {@code false} if the ID is {@code null}.
      */
-    boolean idEquals(JsonNode id) {
+    boolean idEquals(@Nullable JsonNode id) {
         return containsId && this.id.equals(id);
     }
 }

--- a/firebase-web/src/main/java/io/spine/web/firebase/subscription/diff/ExistingEntry.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/subscription/diff/ExistingEntry.java
@@ -2,27 +2,22 @@ package io.spine.web.firebase.subscription.diff;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.gson.JsonObject;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.List;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.stream.Collectors.toList;
 
 /**
  * An entry retrieved from Firebase database to check the {@link UpToDateEntry} against.
  */
-final class ExistingEntry {
+final class ExistingEntry extends Entry {
 
     private final String key;
-    private final String data;
-    private final JsonNode json;
-    private final @Nullable JsonNode id;
 
     private ExistingEntry(String key, String data) {
-        this.key = key;
-        this.data = data;
-        this.json = JsonParser.parse(data);
-        this.id = json.get("id");
+        super(data);
+        this.key = checkNotNull(key);
     }
 
     static List<ExistingEntry> fromJson(JsonObject object) {
@@ -31,20 +26,6 @@ final class ExistingEntry {
                 .stream()
                 .map(entry -> new ExistingEntry(entry.getKey(), entry.getValue().getAsString()))
                 .collect(toList());
-    }
-
-    /**
-     * JSON data of this entry.
-     */
-    JsonNode json() {
-        return json;
-    }
-
-    /**
-     * JSON serialized entity data represented as a string.
-     */
-    String data() {
-        return data;
     }
 
     /**
@@ -63,6 +44,6 @@ final class ExistingEntry {
      *         {@code false} otherwise
      */
     boolean idEquals(JsonNode id) {
-        return id.equals(this.id);
+        return id.equals(id());
     }
 }

--- a/firebase-web/src/main/java/io/spine/web/firebase/subscription/diff/UpToDateEntry.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/subscription/diff/UpToDateEntry.java
@@ -1,8 +1,5 @@
 package io.spine.web.firebase.subscription.diff;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import org.checkerframework.checker.nullness.qual.Nullable;
-
 import java.util.List;
 
 import static java.util.stream.Collectors.toList;
@@ -10,52 +7,15 @@ import static java.util.stream.Collectors.toList;
 /**
  * An entry received from Spine and serialized to JSON to be saved to Firebase database.
  */
-class UpToDateEntry {
+final class UpToDateEntry extends Entry {
 
-    private final String data;
-    private final JsonNode json;
-    private final @Nullable JsonNode id;
-    private final boolean containsId;
-
-    private UpToDateEntry(String data) {
-        this.data = data;
-        this.json = JsonParser.parse(data);
-        this.id = json.get("id");
-        this.containsId = id != null;
+    private UpToDateEntry(String rawData) {
+        super(rawData);
     }
 
     static List<UpToDateEntry> parse(List<String> json) {
         return json.stream()
                    .map(UpToDateEntry::new)
                    .collect(toList());
-    }
-
-    /**
-     * JSON data of this entry.
-     */
-    JsonNode json() {
-        return json;
-    }
-
-    /**
-     * JSON serialized entity data represented as a string.
-     */
-    String data() {
-        return data;
-    }
-
-    /**
-     * Returns {@code true} if the entity contains an {@code "id"} field and {@code false}
-     * otherwise.
-     */
-    boolean containsId() {
-        return containsId;
-    }
-
-    /**
-     * A {@link JsonNode} representation of the entities {@code "id"} field.
-     */
-    @Nullable JsonNode id() {
-        return id;
     }
 }

--- a/firebase-web/src/main/java/io/spine/web/firebase/subscription/diff/UpToDateEntry.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/subscription/diff/UpToDateEntry.java
@@ -1,5 +1,7 @@
 package io.spine.web.firebase.subscription.diff;
 
+import io.spine.web.firebase.StoredJson;
+
 import java.util.List;
 
 import static java.util.stream.Collectors.toList;
@@ -17,8 +19,9 @@ final class UpToDateEntry extends Entry {
         return new UpToDateEntry(json);
     }
 
-    static List<UpToDateEntry> parse(List<String> json) {
+    static List<UpToDateEntry> parse(List<StoredJson> json) {
         return json.stream()
+                   .map(StoredJson::value)
                    .map(UpToDateEntry::parse)
                    .collect(toList());
     }

--- a/firebase-web/src/main/java/io/spine/web/firebase/subscription/diff/UpToDateEntry.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/subscription/diff/UpToDateEntry.java
@@ -1,6 +1,7 @@
 package io.spine.web.firebase.subscription.diff;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.List;
 
@@ -13,7 +14,7 @@ class UpToDateEntry {
 
     private final String data;
     private final JsonNode json;
-    private final JsonNode id;
+    private final @Nullable JsonNode id;
     private final boolean containsId;
 
     private UpToDateEntry(String data) {
@@ -54,7 +55,7 @@ class UpToDateEntry {
     /**
      * A {@link JsonNode} representation of the entities {@code "id"} field.
      */
-    JsonNode id() {
+    @Nullable JsonNode id() {
         return id;
     }
 }

--- a/firebase-web/src/main/java/io/spine/web/firebase/subscription/diff/UpToDateEntry.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/subscription/diff/UpToDateEntry.java
@@ -13,9 +13,13 @@ final class UpToDateEntry extends Entry {
         super(rawData);
     }
 
+    static UpToDateEntry parse(String json) {
+        return new UpToDateEntry(json);
+    }
+
     static List<UpToDateEntry> parse(List<String> json) {
         return json.stream()
-                   .map(UpToDateEntry::new)
+                   .map(UpToDateEntry::parse)
                    .collect(toList());
     }
 }

--- a/firebase-web/src/test/java/io/spine/web/firebase/AsyncClientTest.java
+++ b/firebase-web/src/test/java/io/spine/web/firebase/AsyncClientTest.java
@@ -63,24 +63,17 @@ class AsyncClientTest {
     }
 
     @Test
-    @DisplayName("perform create() with the given executor")
-    void executeCreate() {
+    @DisplayName("perform write operations with the given executor")
+    void executeWrites() {
         AsyncClient asyncClient = new AsyncClient(delegate, executor);
-        checkCreateAsync(asyncClient);
-    }
-
-    @Test
-    @DisplayName("perform update() with the given executor")
-    void executeUpdate() {
-        AsyncClient asyncClient = new AsyncClient(delegate, executor);
-        checkUpdateAsync(asyncClient);
+        checkAsync(asyncClient);
     }
 
     @Test
     @DisplayName("perform write operations with asynchronously by default")
     void executeWritesWithForkJoinPool() {
         AsyncClient asyncClient = new AsyncClient(delegate);
-        checkCreateAsync(asyncClient);
+        checkAsync(asyncClient);
     }
 
     @Test
@@ -91,17 +84,8 @@ class AsyncClientTest {
         assertThat(delegate.writes()).contains(path);
     }
 
-    private void checkCreateAsync(AsyncClient asyncClient) {
-        asyncClient.create(path, NodeValue.empty());
-        checkWrite();
-    }
-
-    private void checkUpdateAsync(AsyncClient asyncClient) {
-        asyncClient.create(path, NodeValue.empty());
-        checkWrite();
-    }
-
-    private void checkWrite() {
+    private void checkAsync(AsyncClient asyncClient) {
+        asyncClient.update(path, NodeValue.empty());
         assertThat(delegate.writes()).doesNotContain(path);
         Duration surefireTime = latency.plusSeconds(1);
         sleepFor(surefireTime);

--- a/firebase-web/src/test/java/io/spine/web/firebase/AsyncClientTest.java
+++ b/firebase-web/src/test/java/io/spine/web/firebase/AsyncClientTest.java
@@ -63,29 +63,45 @@ class AsyncClientTest {
     }
 
     @Test
-    @DisplayName("perform write operations with the given executor")
-    void executeWrites() {
+    @DisplayName("perform create() with the given executor")
+    void executeCreate() {
         AsyncClient asyncClient = new AsyncClient(delegate, executor);
-        checkAsync(asyncClient);
+        checkCreateAsync(asyncClient);
+    }
+
+    @Test
+    @DisplayName("perform update() with the given executor")
+    void executeUpdate() {
+        AsyncClient asyncClient = new AsyncClient(delegate, executor);
+        checkUpdateAsync(asyncClient);
     }
 
     @Test
     @DisplayName("perform write operations with asynchronously by default")
     void executeWritesWithForkJoinPool() {
         AsyncClient asyncClient = new AsyncClient(delegate);
-        checkAsync(asyncClient);
+        checkCreateAsync(asyncClient);
     }
 
     @Test
     @DisplayName("allow to use the direct executor")
     void allowDirectExecutor() {
         AsyncClient asyncClient = new AsyncClient(delegate, directExecutor());
-        asyncClient.merge(path, NodeValue.empty());
+        asyncClient.create(path, NodeValue.empty());
         assertThat(delegate.writes()).contains(path);
     }
 
-    private void checkAsync(AsyncClient asyncClient) {
-        asyncClient.merge(path, NodeValue.empty());
+    private void checkCreateAsync(AsyncClient asyncClient) {
+        asyncClient.create(path, NodeValue.empty());
+        checkWrite();
+    }
+
+    private void checkUpdateAsync(AsyncClient asyncClient) {
+        asyncClient.create(path, NodeValue.empty());
+        checkWrite();
+    }
+
+    private void checkWrite() {
         assertThat(delegate.writes()).doesNotContain(path);
         Duration surefireTime = latency.plusSeconds(1);
         sleepFor(surefireTime);

--- a/firebase-web/src/test/java/io/spine/web/firebase/NodeValueTest.java
+++ b/firebase-web/src/test/java/io/spine/web/firebase/NodeValueTest.java
@@ -54,13 +54,6 @@ class NodeValueTest {
     }
 
     @Test
-    @DisplayName("allow creation with single child")
-    void beCreatedWithSingleChild() {
-        NodeValue value = NodeValue.withSingleChild(VALUE);
-        assertSingleChild(value, VALUE);
-    }
-
-    @Test
     @DisplayName("add a new child under the generated key")
     void pushChild() {
         NodeValue value = NodeValue.empty();

--- a/firebase-web/src/test/java/io/spine/web/firebase/NodeValueTest.java
+++ b/firebase-web/src/test/java/io/spine/web/firebase/NodeValueTest.java
@@ -35,8 +35,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class NodeValueTest {
 
     private static final String KEY = "theKey";
-    private static final String VALUE = "theValue";
-    private static final String DATA = "{\"" + KEY + "\":\"" + VALUE + "\"}";
+    private static final StoredJson VALUE = StoredJson.from("theValue");
+    private static final StoredJson DATA = StoredJson.from("{\"" + KEY + "\":\"" + VALUE + "\"}");
 
     @Test
     @DisplayName("be empty when created via the default constructor")
@@ -69,7 +69,7 @@ class NodeValueTest {
         assertSingleChild(value, KEY, VALUE);
     }
 
-    private static void assertSingleChild(NodeValue value, String childValue) {
+    private static void assertSingleChild(NodeValue value, StoredJson childValue) {
         JsonObject underlyingJson = value.underlyingJson();
         assertEquals(1, underlyingJson.entrySet()
                                       .size());
@@ -78,15 +78,15 @@ class NodeValueTest {
                                                              .next();
         String valueString = entry.getValue()
                                   .getAsString();
-        assertEquals(childValue, valueString);
+        assertEquals(childValue.value(), valueString);
     }
 
     private static void
-    assertSingleChild(NodeValue value, String childKey, String childValue) {
+    assertSingleChild(NodeValue value, String childKey, StoredJson childValue) {
         JsonObject underlyingJson = value.underlyingJson();
         assertTrue(underlyingJson.has(childKey));
         String actual = underlyingJson.get(childKey)
                                       .getAsString();
-        assertEquals(childValue, actual);
+        assertEquals(childValue.value(), actual);
     }
 }

--- a/firebase-web/src/test/java/io/spine/web/firebase/given/TestFirebaseClient.java
+++ b/firebase-web/src/test/java/io/spine/web/firebase/given/TestFirebaseClient.java
@@ -56,15 +56,15 @@ public final class TestFirebaseClient implements FirebaseClient {
     }
 
     @Override
-    public void create(NodePath path, NodeValue value) {
+    public void create(NodePath nodePath, NodeValue value) {
         sleepFor(writeLatency);
-        writes.add(path);
+        writes.add(nodePath);
     }
 
     @Override
-    public void update(NodePath path, NodeValue value) {
+    public void update(NodePath nodePath, NodeValue value) {
         sleepFor(writeLatency);
-        writes.add(path);
+        writes.add(nodePath);
     }
 
     public ImmutableList<NodePath> reads() {

--- a/firebase-web/src/test/java/io/spine/web/firebase/given/TestFirebaseClient.java
+++ b/firebase-web/src/test/java/io/spine/web/firebase/given/TestFirebaseClient.java
@@ -56,9 +56,15 @@ public final class TestFirebaseClient implements FirebaseClient {
     }
 
     @Override
-    public void merge(NodePath nodePath, NodeValue value) {
+    public void create(NodePath path, NodeValue value) {
         sleepFor(writeLatency);
-        writes.add(nodePath);
+        writes.add(path);
+    }
+
+    @Override
+    public void update(NodePath path, NodeValue value) {
+        sleepFor(writeLatency);
+        writes.add(path);
     }
 
     public ImmutableList<NodePath> reads() {

--- a/firebase-web/src/test/java/io/spine/web/firebase/query/FirebaseQueryBridgeTest.java
+++ b/firebase-web/src/test/java/io/spine/web/firebase/query/FirebaseQueryBridgeTest.java
@@ -111,6 +111,6 @@ class FirebaseQueryBridgeTest {
 
         Map<String, String> expected = new HashMap<>();
         expected.put(anyKey(), toCompactJson(dataElement));
-        verify(firebaseClient).merge(any(), argThat(new HasChildren(expected)));
+        verify(firebaseClient).create(any(), argThat(new HasChildren(expected)));
     }
 }

--- a/firebase-web/src/test/java/io/spine/web/firebase/rest/RestClientTest.java
+++ b/firebase-web/src/test/java/io/spine/web/firebase/rest/RestClientTest.java
@@ -28,6 +28,7 @@ import io.spine.web.firebase.DatabaseUrls;
 import io.spine.web.firebase.NodePath;
 import io.spine.web.firebase.NodePaths;
 import io.spine.web.firebase.NodeValue;
+import io.spine.web.firebase.StoredJson;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -49,7 +50,7 @@ import static org.mockito.Mockito.when;
 class RestClientTest {
 
     private static final String PATH = "node/path";
-    private static final String DATA = "{\"a\":\"b\"}";
+    private static final StoredJson DATA = StoredJson.from("{\"a\":\"b\"}");
     private static final String DATABASE_URL_STRING = "https://database.com";
     private static final DatabaseUrl DATABASE_URL = DatabaseUrls.from(DATABASE_URL_STRING);
     private static final RestNodeUrls NODE_FACTORY = new RestNodeUrls(DATABASE_URL);
@@ -67,7 +68,7 @@ class RestClientTest {
         httpClient = mock(HttpClient.class);
         client = new RestClient(NODE_FACTORY, httpClient);
         path = NodePaths.of(PATH);
-        value = NodeValue.from(DATA);
+        value = DATA.asNodeValue();
     }
 
     @Test
@@ -82,14 +83,14 @@ class RestClientTest {
     @Test
     @DisplayName("retrieve data from given database path")
     void getData() {
-        when(httpClient.get(any())).thenReturn(DATA);
+        when(httpClient.get(any())).thenReturn(DATA.value());
 
         Optional<NodeValue> result = client.get(path);
         assertTrue(result.isPresent());
         NodeValue value = result.get();
         String contentString = value.underlyingJson()
                                     .toString();
-        assertEquals(DATA, contentString);
+        assertEquals(DATA.value(), contentString);
     }
 
     @Test
@@ -113,7 +114,7 @@ class RestClientTest {
     @Test
     @DisplayName("store data via PATCH method when node already exists")
     void updateExistingViaPatch() {
-        when(httpClient.get(any())).thenReturn(DATA);
+        when(httpClient.get(any())).thenReturn(DATA.value());
 
         client.update(path, value);
         verify(httpClient).patch(eq(EXPECTED_NODE_URL), any(ByteArrayContent.class));

--- a/firebase-web/src/test/java/io/spine/web/firebase/rest/RestClientTest.java
+++ b/firebase-web/src/test/java/io/spine/web/firebase/rest/RestClientTest.java
@@ -106,7 +106,7 @@ class RestClientTest {
     void storeNewViaPut() {
         when(httpClient.get(any())).thenReturn(NULL_ENTRY);
 
-        client.merge(path, value);
+        client.create(path, value);
         verify(httpClient).put(eq(EXPECTED_NODE_URL), any(ByteArrayContent.class));
     }
 
@@ -115,7 +115,7 @@ class RestClientTest {
     void updateExistingViaPatch() {
         when(httpClient.get(any())).thenReturn(DATA);
 
-        client.merge(path, value);
+        client.update(path, value);
         verify(httpClient).patch(eq(EXPECTED_NODE_URL), any(ByteArrayContent.class));
     }
 }

--- a/firebase-web/src/test/java/io/spine/web/firebase/subscription/QueryRecordTest.java
+++ b/firebase-web/src/test/java/io/spine/web/firebase/subscription/QueryRecordTest.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static io.spine.json.Json.toCompactJson;
+import static io.spine.web.firebase.StoredJson.encode;
 import static io.spine.web.firebase.given.FirebaseSubscriptionRecordTestEnv.Authors.gangOfFour;
 import static io.spine.web.firebase.given.FirebaseSubscriptionRecordTestEnv.Books.aliceInWonderland;
 import static io.spine.web.firebase.given.FirebaseSubscriptionRecordTestEnv.Books.designPatterns;
@@ -97,9 +98,9 @@ class QueryRecordTest {
         SubscriptionRecord record = new SubscriptionRecord(queryResponsePath,
                                                            queryResponse);
         NodeValue existingValue = NodeValue.empty();
-        existingValue.addChild(toCompactJson(aliceInWonderland));
-        String patternsKey = existingValue.addChild(toCompactJson(designPatterns));
-        String guideKey = existingValue.addChild(toCompactJson(guideToTheGalaxy));
+        existingValue.addChild(encode(aliceInWonderland));
+        String patternsKey = existingValue.addChild(encode(designPatterns));
+        String guideKey = existingValue.addChild(encode(guideToTheGalaxy));
 
         when(firebaseClient.get(any())).thenReturn(Optional.of(existingValue));
 

--- a/firebase-web/src/test/java/io/spine/web/firebase/subscription/QueryRecordTest.java
+++ b/firebase-web/src/test/java/io/spine/web/firebase/subscription/QueryRecordTest.java
@@ -72,7 +72,7 @@ class QueryRecordTest {
         Map<String, String> expected = new HashMap<>();
         expected.put(anyKey(), toCompactJson(aliceInWonderland));
         expected.put(anyKey(), toCompactJson(donQuixote));
-        verify(firebaseClient).merge(eq(queryResponsePath), argThat(new HasChildren(expected)));
+        verify(firebaseClient).create(eq(queryResponsePath), argThat(new HasChildren(expected)));
     }
 
     @Test
@@ -109,7 +109,7 @@ class QueryRecordTest {
         expected.put(anyKey(), toCompactJson(donQuixote));
         expected.put(patternsKey, toCompactJson(designPatternsWithAuthors));
         expected.put(guideKey, JSON_NULL);
-        verify(firebaseClient).merge(eq(queryResponsePath), argThat(new HasChildren(expected)));
+        verify(firebaseClient).update(eq(queryResponsePath), argThat(new HasChildren(expected)));
     }
 
     @Test
@@ -127,6 +127,6 @@ class QueryRecordTest {
 
         Map<String, String> expected = new HashMap<>();
         expected.put(anyKey(), toCompactJson(aliceInWonderland));
-        verify(firebaseClient).merge(eq(queryResponsePath), argThat(new HasChildren(expected)));
+        verify(firebaseClient).create(eq(queryResponsePath), argThat(new HasChildren(expected)));
     }
 }

--- a/firebase-web/src/test/java/io/spine/web/firebase/subscription/diff/EntryUpdatesTest.java
+++ b/firebase-web/src/test/java/io/spine/web/firebase/subscription/diff/EntryUpdatesTest.java
@@ -22,6 +22,7 @@ package io.spine.web.firebase.subscription.diff;
 
 import com.google.gson.JsonObject;
 import io.spine.testing.UtilityClassTest;
+import io.spine.web.firebase.StoredJson;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -117,7 +118,7 @@ class EntryUpdatesTest extends UtilityClassTest<EntryUpdates> {
 
     private static UpToDateEntry upToDateEntry(String s) {
         List<UpToDateEntry> upToDateEntries =
-                UpToDateEntry.parse(newArrayList(s));
+                UpToDateEntry.parse(newArrayList(StoredJson.from(s)));
         return upToDateEntries.get(0);
     }
 }

--- a/firebase-web/src/test/java/io/spine/web/firebase/subscription/diff/EntryUpdatesTest.java
+++ b/firebase-web/src/test/java/io/spine/web/firebase/subscription/diff/EntryUpdatesTest.java
@@ -69,7 +69,7 @@ class EntryUpdatesTest extends UtilityClassTest<EntryUpdates> {
         assertThat(entry).isEqualTo(EntryUpdate
                                             .newBuilder()
                                             .setKey(OLD_ENTRY.key())
-                                            .setData(NEW_ENTRY.data())
+                                            .setData(NEW_ENTRY.rawData())
                                             .setOperation(CHANGE)
                                             .build());
     }
@@ -81,7 +81,7 @@ class EntryUpdatesTest extends UtilityClassTest<EntryUpdates> {
         assertThat(entry).isEqualTo(EntryUpdate
                                             .newBuilder()
                                             .setKey(EXISTING_ENTRY.key())
-                                            .setData(UP_TO_DATE_ENTRY.data())
+                                            .setData(UP_TO_DATE_ENTRY.rawData())
                                             .setOperation(PASS)
                                             .build());
     }
@@ -92,7 +92,7 @@ class EntryUpdatesTest extends UtilityClassTest<EntryUpdates> {
 
         assertThat(entry).isEqualTo(EntryUpdate
                                             .newBuilder()
-                                            .setData(UP_TO_DATE_ENTRY.data())
+                                            .setData(UP_TO_DATE_ENTRY.rawData())
                                             .setOperation(ADD)
                                             .build());
     }
@@ -104,7 +104,7 @@ class EntryUpdatesTest extends UtilityClassTest<EntryUpdates> {
         assertThat(entry).isEqualTo(EntryUpdate
                                             .newBuilder()
                                             .setKey(EXISTING_ENTRY.key())
-                                            .setData(EXISTING_ENTRY.data())
+                                            .setData(EXISTING_ENTRY.rawData())
                                             .setOperation(REMOVE)
                                             .build());
     }

--- a/license-report.md
+++ b/license-report.md
@@ -588,7 +588,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jul 24 13:50:31 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 26 15:20:00 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 #NPM dependencies of `spine-web@0.18.0`
@@ -858,70 +858,70 @@ This report was generated on **Wed Jul 24 13:50:31 EEST 2019** using [Gradle-Lic
 1. **@babel/types@7.5.5**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-types](https://github.com/babel/babel/tree/master/packages/babel-types)
-1. **@firebase/app-types@0.4.1**
+1. **@firebase/app-types@0.4.2**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/app@0.4.11**
+1. **@firebase/app@0.4.12**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/auth-types@0.7.1**
+1. **@firebase/auth-types@0.7.2**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/auth@0.11.5**
+1. **@firebase/auth@0.11.6**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/database-types@0.4.1**
+1. **@firebase/database-types@0.4.2**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/database@0.4.8**
+1. **@firebase/database@0.4.9**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/firestore-types@1.4.3**
+1. **@firebase/firestore-types@1.4.4**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/firestore@1.4.5**
+1. **@firebase/firestore@1.4.6**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/functions-types@0.3.7**
+1. **@firebase/functions-types@0.3.8**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/functions@0.4.12**
+1. **@firebase/functions@0.4.13**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
 1. **@firebase/installations-types@0.1.2**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/installations@0.2.1**
+1. **@firebase/installations@0.2.2**
      * Licenses: Apache-2.0
      * Repository: unknown
-1. **@firebase/logger@0.1.19**
+1. **@firebase/logger@0.1.20**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/messaging-types@0.3.1**
+1. **@firebase/messaging-types@0.3.2**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/messaging@0.4.5**
+1. **@firebase/messaging@0.4.6**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
 1. **@firebase/performance-types@0.0.3**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk/tree/master/packages/performance-types](https://github.com/firebase/firebase-js-sdk/tree/master/packages/performance-types)
-1. **@firebase/performance@0.2.12**
+1. **@firebase/performance@0.2.13**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk/tree/master/packages/performance](https://github.com/firebase/firebase-js-sdk/tree/master/packages/performance)
-1. **@firebase/polyfill@0.3.16**
+1. **@firebase/polyfill@0.3.17**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/storage-types@0.3.2**
+1. **@firebase/storage-types@0.3.3**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/storage@0.3.6**
+1. **@firebase/storage@0.3.7**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/util@0.2.22**
+1. **@firebase/util@0.2.23**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/webchannel-wrapper@0.2.22**
+1. **@firebase/webchannel-wrapper@0.2.23**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
 1. **@grpc/proto-loader@0.5.1**
@@ -1542,7 +1542,7 @@ This report was generated on **Wed Jul 24 13:50:31 EEST 2019** using [Gradle-Lic
 1. **findup-sync@3.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/gulpjs/findup-sync](https://github.com/gulpjs/findup-sync)
-1. **firebase@6.3.1**
+1. **firebase@6.3.2**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
 1. **flush-write-stream@1.1.1**
@@ -2709,7 +2709,7 @@ This report was generated on **Wed Jul 24 13:50:31 EEST 2019** using [Gradle-Lic
 1. **webpack-sources@1.3.0**
      * Licenses: MIT
      * Repository: [https://github.com/webpack/webpack-sources](https://github.com/webpack/webpack-sources)
-1. **webpack@4.37.0**
+1. **webpack@4.38.0**
      * Licenses: MIT
      * Repository: [https://github.com/webpack/webpack](https://github.com/webpack/webpack)
 1. **websocket-driver@0.7.3**
@@ -2783,7 +2783,7 @@ This report was generated on **Wed Jul 24 13:50:31 EEST 2019** using [Gradle-Lic
      * Repository: [https://github.com/bcoe/yargs](https://github.com/bcoe/yargs)
 
 
-This report was generated on **Wed Jul 24 2019 13:50:33 GMT+0300 (EEST)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
+This report was generated on **Fri Jul 26 2019 15:20:02 GMT+0300 (EEST)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
 
 
 
@@ -3725,7 +3725,7 @@ This report was generated on **Wed Jul 24 2019 13:50:33 GMT+0300 (EEST)** using 
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jul 24 13:50:34 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 26 15:20:04 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5596,7 +5596,7 @@ This report was generated on **Wed Jul 24 13:50:34 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jul 24 13:50:37 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 26 15:20:07 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6200,7 +6200,7 @@ This report was generated on **Wed Jul 24 13:50:37 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jul 24 13:50:38 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 26 15:20:08 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6793,4 +6793,4 @@ This report was generated on **Wed Jul 24 13:50:38 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jul 24 13:50:38 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 26 15:20:09 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -588,7 +588,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jul 26 19:16:37 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 29 11:54:58 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 #NPM dependencies of `spine-web@0.18.0`
@@ -873,13 +873,13 @@ This report was generated on **Fri Jul 26 19:16:37 EEST 2019** using [Gradle-Lic
 1. **@firebase/database-types@0.4.2**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/database@0.4.9**
+1. **@firebase/database@0.4.10**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
 1. **@firebase/firestore-types@1.4.4**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/firestore@1.4.6**
+1. **@firebase/firestore@1.4.7**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
 1. **@firebase/functions-types@0.3.8**
@@ -1239,7 +1239,7 @@ This report was generated on **Fri Jul 26 19:16:37 EEST 2019** using [Gradle-Lic
 1. **camelcase@5.3.1**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/camelcase](https://github.com/sindresorhus/camelcase)
-1. **caniuse-lite@1.0.30000985**
+1. **caniuse-lite@1.0.30000986**
      * Licenses: CC-BY-4.0
      * Repository: [https://github.com/ben-eb/caniuse-lite](https://github.com/ben-eb/caniuse-lite)
 1. **chalk@1.1.3**
@@ -1437,7 +1437,7 @@ This report was generated on **Fri Jul 26 19:16:37 EEST 2019** using [Gradle-Lic
 1. **duplexify@3.7.1**
      * Licenses: MIT
      * Repository: [https://github.com/mafintosh/duplexify](https://github.com/mafintosh/duplexify)
-1. **electron-to-chromium@1.3.200**
+1. **electron-to-chromium@1.3.203**
      * Licenses: ISC
      * Repository: [https://github.com/kilian/electron-to-chromium](https://github.com/kilian/electron-to-chromium)
 1. **elliptic@6.5.0**
@@ -1542,7 +1542,7 @@ This report was generated on **Fri Jul 26 19:16:37 EEST 2019** using [Gradle-Lic
 1. **findup-sync@3.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/gulpjs/findup-sync](https://github.com/gulpjs/findup-sync)
-1. **firebase@6.3.2**
+1. **firebase@6.3.3**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
 1. **flush-write-stream@1.1.1**
@@ -2783,7 +2783,7 @@ This report was generated on **Fri Jul 26 19:16:37 EEST 2019** using [Gradle-Lic
      * Repository: [https://github.com/bcoe/yargs](https://github.com/bcoe/yargs)
 
 
-This report was generated on **Fri Jul 26 2019 19:16:39 GMT+0300 (EEST)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
+This report was generated on **Mon Jul 29 2019 11:55:00 GMT+0300 (EEST)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
 
 
 
@@ -3725,7 +3725,7 @@ This report was generated on **Fri Jul 26 2019 19:16:39 GMT+0300 (EEST)** using 
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jul 26 19:16:40 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 29 11:55:01 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5596,7 +5596,7 @@ This report was generated on **Fri Jul 26 19:16:40 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jul 26 19:16:43 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 29 11:55:05 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6200,7 +6200,7 @@ This report was generated on **Fri Jul 26 19:16:43 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jul 26 19:16:43 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 29 11:55:05 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6793,4 +6793,4 @@ This report was generated on **Fri Jul 26 19:16:43 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jul 26 19:16:44 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 29 11:55:06 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -588,7 +588,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jul 26 16:47:49 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 26 19:16:37 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 #NPM dependencies of `spine-web@0.18.0`
@@ -2783,7 +2783,7 @@ This report was generated on **Fri Jul 26 16:47:49 EEST 2019** using [Gradle-Lic
      * Repository: [https://github.com/bcoe/yargs](https://github.com/bcoe/yargs)
 
 
-This report was generated on **Fri Jul 26 2019 16:47:51 GMT+0300 (EEST)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
+This report was generated on **Fri Jul 26 2019 19:16:39 GMT+0300 (EEST)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
 
 
 
@@ -3725,7 +3725,7 @@ This report was generated on **Fri Jul 26 2019 16:47:51 GMT+0300 (EEST)** using 
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jul 26 16:47:52 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 26 19:16:40 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5596,7 +5596,7 @@ This report was generated on **Fri Jul 26 16:47:52 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jul 26 16:47:54 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 26 19:16:43 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6200,7 +6200,7 @@ This report was generated on **Fri Jul 26 16:47:54 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jul 26 16:47:54 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 26 19:16:43 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6793,4 +6793,4 @@ This report was generated on **Fri Jul 26 16:47:54 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jul 26 16:47:55 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 26 19:16:44 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -588,7 +588,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jul 26 15:20:00 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 26 16:47:49 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 #NPM dependencies of `spine-web@0.18.0`
@@ -2783,7 +2783,7 @@ This report was generated on **Fri Jul 26 15:20:00 EEST 2019** using [Gradle-Lic
      * Repository: [https://github.com/bcoe/yargs](https://github.com/bcoe/yargs)
 
 
-This report was generated on **Fri Jul 26 2019 15:20:02 GMT+0300 (EEST)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
+This report was generated on **Fri Jul 26 2019 16:47:51 GMT+0300 (EEST)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
 
 
 
@@ -3725,7 +3725,7 @@ This report was generated on **Fri Jul 26 2019 15:20:02 GMT+0300 (EEST)** using 
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jul 26 15:20:04 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 26 16:47:52 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5596,7 +5596,7 @@ This report was generated on **Fri Jul 26 15:20:04 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jul 26 15:20:07 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 26 16:47:54 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6200,7 +6200,7 @@ This report was generated on **Fri Jul 26 15:20:07 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jul 26 15:20:08 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 26 16:47:54 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6793,4 +6793,4 @@ This report was generated on **Fri Jul 26 15:20:08 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jul 26 15:20:09 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 26 16:47:55 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).


### PR DESCRIPTION
Before this PR, `FirebaseClient` made a read requests per each write request, in order to decide whether to merge or simply write entities.

However, the knowledge of whether a write operation is an update or a "clear page" write, is already present in the system before the actual write operation. Thus, the `FirebaseClient` now exposes methods for creating and for updating records and the caller decides which one to use.

Also, this PR performs a minor refactoring and optimizes performance by removing redundant validation calls.