### PR TITLE
Release `1.0.2`

### DIFF
--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spine-web",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "Apache-2.0",
   "description": "A JS client for interacting with Spine applications.",
   "homepage": "https://spine.io",

--- a/integration-tests/web-tests/package.json
+++ b/integration-tests/web-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-js-tests",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "Apache-2.0",
   "description": "Tests of a `spine-web` JS library against the Spine-based application.",
   "scripts": {

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client-js:1.0.2-SNAPSHOT`
+# Dependencies of `io.spine:spine-client-js:1.0.2`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -588,14 +588,14 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 20 16:02:24 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
-#NPM dependencies of `spine-web@1.0.1`
+#NPM dependencies of `spine-web@1.0.2`
 
 ## `Production` dependencies:
 
-1. **base64-js@1.3.0**
+1. **base64-js@1.3.1**
      * Licenses: MIT
      * Repository: [https://github.com/beatgammit/base64-js](https://github.com/beatgammit/base64-js)
 1. **encoding@0.1.12**
@@ -622,10 +622,10 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **safer-buffer@2.1.2**
      * Licenses: MIT
      * Repository: [https://github.com/ChALkeR/safer-buffer](https://github.com/ChALkeR/safer-buffer)
-1. **spine-web@1.0.1**
+1. **spine-web@1.0.2**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/SpineEventEngine/web](https://github.com/SpineEventEngine/web)
-1. **tslib@1.9.0**
+1. **tslib@1.10.0**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/Microsoft/tslib](https://github.com/Microsoft/tslib)
 1. **uuid@3.3.2**
@@ -873,13 +873,13 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **@firebase/database-types@0.4.2**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/database@0.5.0**
+1. **@firebase/database@0.4.12**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
 1. **@firebase/firestore-types@1.4.4**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/firestore@1.4.10**
+1. **@firebase/firestore@1.4.9**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
 1. **@firebase/functions-types@0.3.8**
@@ -957,106 +957,103 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **@protobufjs/utf8@1.1.0**
      * Licenses: BSD-3-Clause
      * Repository: [https://github.com/dcodeIO/protobuf.js](https://github.com/dcodeIO/protobuf.js)
-1. **@sinonjs/commons@1.3.0**
+1. **@sinonjs/commons@1.4.0**
      * Licenses: BSD-3-Clause
      * Repository: [https://github.com/sinonjs/commons](https://github.com/sinonjs/commons)
-1. **@sinonjs/formatio@3.1.0**
+1. **@sinonjs/formatio@3.2.1**
      * Licenses: BSD-3-Clause
      * Repository: [https://github.com/sinonjs/formatio](https://github.com/sinonjs/formatio)
-1. **@sinonjs/samsam@3.1.1**
+1. **@sinonjs/samsam@3.3.2**
      * Licenses: BSD-3-Clause
      * Repository: [https://github.com/sinonjs/samsam](https://github.com/sinonjs/samsam)
+1. **@sinonjs/text-encoding@0.7.1**
+     * Licenses: (Unlicense OR Apache-2.0)
+     * Repository: [https://github.com/inexorabletash/text-encoding](https://github.com/inexorabletash/text-encoding)
 1. **@types/long@4.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/DefinitelyTyped/DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped)
 1. **@types/node@10.14.15**
      * Licenses: MIT
      * Repository: [https://github.com/DefinitelyTyped/DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped)
-1. **@webassemblyjs/ast@1.7.11**
+1. **@webassemblyjs/ast@1.8.5**
      * Licenses: MIT
      * Repository: [https://github.com/xtuc/webassemblyjs](https://github.com/xtuc/webassemblyjs)
-1. **@webassemblyjs/floating-point-hex-parser@1.7.11**
+1. **@webassemblyjs/floating-point-hex-parser@1.8.5**
      * Licenses: MIT
      * Repository: [https://github.com/xtuc/webassemblyjs](https://github.com/xtuc/webassemblyjs)
-1. **@webassemblyjs/helper-api-error@1.7.11**
+1. **@webassemblyjs/helper-api-error@1.8.5**
      * Licenses: MIT
      * Repository: unknown
-1. **@webassemblyjs/helper-buffer@1.7.11**
+1. **@webassemblyjs/helper-buffer@1.8.5**
      * Licenses: MIT
      * Repository: [https://github.com/xtuc/webassemblyjs](https://github.com/xtuc/webassemblyjs)
-1. **@webassemblyjs/helper-code-frame@1.7.11**
+1. **@webassemblyjs/helper-code-frame@1.8.5**
      * Licenses: MIT
      * Repository: [https://github.com/xtuc/webassemblyjs](https://github.com/xtuc/webassemblyjs)
-1. **@webassemblyjs/helper-fsm@1.7.11**
+1. **@webassemblyjs/helper-fsm@1.8.5**
      * Licenses: ISC
      * Repository: unknown
-1. **@webassemblyjs/helper-module-context@1.7.11**
+1. **@webassemblyjs/helper-module-context@1.8.5**
      * Licenses: MIT
      * Repository: [https://github.com/xtuc/webassemblyjs](https://github.com/xtuc/webassemblyjs)
-1. **@webassemblyjs/helper-wasm-bytecode@1.7.11**
+1. **@webassemblyjs/helper-wasm-bytecode@1.8.5**
      * Licenses: MIT
      * Repository: [https://github.com/xtuc/webassemblyjs](https://github.com/xtuc/webassemblyjs)
-1. **@webassemblyjs/helper-wasm-section@1.7.11**
+1. **@webassemblyjs/helper-wasm-section@1.8.5**
      * Licenses: MIT
      * Repository: [https://github.com/xtuc/webassemblyjs](https://github.com/xtuc/webassemblyjs)
-1. **@webassemblyjs/ieee754@1.7.11**
+1. **@webassemblyjs/ieee754@1.8.5**
      * Licenses: MIT
      * Repository: unknown
-1. **@webassemblyjs/leb128@1.7.11**
+1. **@webassemblyjs/leb128@1.8.5**
      * Licenses: MIT
      * Repository: unknown
-1. **@webassemblyjs/utf8@1.7.11**
+1. **@webassemblyjs/utf8@1.8.5**
      * Licenses: MIT
      * Repository: [https://github.com/xtuc/webassemblyjs](https://github.com/xtuc/webassemblyjs)
-1. **@webassemblyjs/wasm-edit@1.7.11**
+1. **@webassemblyjs/wasm-edit@1.8.5**
      * Licenses: MIT
      * Repository: [https://github.com/xtuc/webassemblyjs](https://github.com/xtuc/webassemblyjs)
-1. **@webassemblyjs/wasm-gen@1.7.11**
+1. **@webassemblyjs/wasm-gen@1.8.5**
      * Licenses: MIT
      * Repository: [https://github.com/xtuc/webassemblyjs](https://github.com/xtuc/webassemblyjs)
-1. **@webassemblyjs/wasm-opt@1.7.11**
+1. **@webassemblyjs/wasm-opt@1.8.5**
      * Licenses: MIT
      * Repository: [https://github.com/xtuc/webassemblyjs](https://github.com/xtuc/webassemblyjs)
-1. **@webassemblyjs/wasm-parser@1.7.11**
+1. **@webassemblyjs/wasm-parser@1.8.5**
      * Licenses: MIT
      * Repository: [https://github.com/xtuc/webassemblyjs](https://github.com/xtuc/webassemblyjs)
-1. **@webassemblyjs/wast-parser@1.7.11**
+1. **@webassemblyjs/wast-parser@1.8.5**
      * Licenses: MIT
      * Repository: [https://github.com/xtuc/webassemblyjs](https://github.com/xtuc/webassemblyjs)
-1. **@webassemblyjs/wast-printer@1.7.11**
+1. **@webassemblyjs/wast-printer@1.8.5**
      * Licenses: MIT
      * Repository: [https://github.com/xtuc/webassemblyjs](https://github.com/xtuc/webassemblyjs)
 1. **@xtuc/ieee754@1.2.0**
      * Licenses: BSD-3-Clause
      * Repository: [https://github.com/feross/ieee754](https://github.com/feross/ieee754)
-1. **@xtuc/long@4.2.1**
+1. **@xtuc/long@4.2.2**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/dcodeIO/long.js](https://github.com/dcodeIO/long.js)
 1. **abbrev@1.1.1**
      * Licenses: ISC
      * Repository: [https://github.com/isaacs/abbrev-js](https://github.com/isaacs/abbrev-js)
-1. **acorn-dynamic-import@4.0.0**
-     * Licenses: MIT
-     * Repository: [https://github.com/kesne/acorn-dynamic-import](https://github.com/kesne/acorn-dynamic-import)
-1. **acorn@6.1.0**
+1. **acorn@6.3.0**
      * Licenses: MIT
      * Repository: [https://github.com/acornjs/acorn](https://github.com/acornjs/acorn)
-1. **agent-base@4.2.1**
+1. **agent-base@4.3.0**
      * Licenses: MIT
      * Repository: [https://github.com/TooTallNate/node-agent-base](https://github.com/TooTallNate/node-agent-base)
 1. **ajv-errors@1.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/epoberezkin/ajv-errors](https://github.com/epoberezkin/ajv-errors)
-1. **ajv-keywords@3.4.0**
+1. **ajv-keywords@3.4.1**
      * Licenses: MIT
      * Repository: [https://github.com/epoberezkin/ajv-keywords](https://github.com/epoberezkin/ajv-keywords)
-1. **ajv@6.9.1**
+1. **ajv@6.10.2**
      * Licenses: MIT
      * Repository: [https://github.com/epoberezkin/ajv](https://github.com/epoberezkin/ajv)
 1. **ansi-regex@2.1.1**
-     * Licenses: MIT
-     * Repository: [https://github.com/chalk/ansi-regex](https://github.com/chalk/ansi-regex)
-1. **ansi-regex@3.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/chalk/ansi-regex](https://github.com/chalk/ansi-regex)
 1. **ansi-regex@4.1.0**
@@ -1116,13 +1113,13 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **asn1.js@4.10.1**
      * Licenses: MIT
      * Repository: [https://github.com/indutny/asn1.js](https://github.com/indutny/asn1.js)
-1. **assert@1.4.1**
+1. **assert@1.5.0**
      * Licenses: MIT
-     * Repository: [https://github.com/defunctzombie/commonjs-assert](https://github.com/defunctzombie/commonjs-assert)
+     * Repository: [https://github.com/browserify/commonjs-assert](https://github.com/browserify/commonjs-assert)
 1. **assign-symbols@1.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/assign-symbols](https://github.com/jonschlinkert/assign-symbols)
-1. **async-each@1.0.1**
+1. **async-each@1.0.3**
      * Licenses: MIT
      * Repository: [https://github.com/paulmillr/async-each](https://github.com/paulmillr/async-each)
 1. **atob@2.1.2**
@@ -1170,10 +1167,10 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **big.js@5.2.2**
      * Licenses: MIT
      * Repository: [https://github.com/MikeMcl/big.js](https://github.com/MikeMcl/big.js)
-1. **binary-extensions@1.13.0**
+1. **binary-extensions@1.13.1**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/binary-extensions](https://github.com/sindresorhus/binary-extensions)
-1. **bluebird@3.5.3**
+1. **bluebird@3.5.5**
      * Licenses: MIT
      * Repository: [https://github.com/petkaantonov/bluebird](https://github.com/petkaantonov/bluebird)
 1. **bn.js@4.11.8**
@@ -1227,9 +1224,9 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **bytebuffer@5.0.1**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/dcodeIO/bytebuffer.js](https://github.com/dcodeIO/bytebuffer.js)
-1. **cacache@11.3.2**
+1. **cacache@12.0.2**
      * Licenses: ISC
-     * Repository: [https://github.com/zkat/cacache](https://github.com/zkat/cacache)
+     * Repository: [https://github.com/npm/cacache](https://github.com/npm/cacache)
 1. **cache-base@1.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/cache-base](https://github.com/jonschlinkert/cache-base)
@@ -1237,9 +1234,6 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
      * Licenses: MIT
      * Repository: [https://github.com/istanbuljs/caching-transform](https://github.com/istanbuljs/caching-transform)
 1. **camelcase@2.1.1**
-     * Licenses: MIT
-     * Repository: [https://github.com/sindresorhus/camelcase](https://github.com/sindresorhus/camelcase)
-1. **camelcase@5.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/camelcase](https://github.com/sindresorhus/camelcase)
 1. **camelcase@5.3.1**
@@ -1254,16 +1248,16 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **chalk@2.4.2**
      * Licenses: MIT
      * Repository: [https://github.com/chalk/chalk](https://github.com/chalk/chalk)
-1. **chokidar@2.1.1**
-     * Licenses: MIT
-     * Repository: [https://github.com/paulmillr/chokidar](https://github.com/paulmillr/chokidar)
 1. **chokidar@2.1.6**
      * Licenses: MIT
      * Repository: [https://github.com/paulmillr/chokidar](https://github.com/paulmillr/chokidar)
 1. **chownr@1.1.1**
      * Licenses: ISC
      * Repository: [https://github.com/isaacs/chownr](https://github.com/isaacs/chownr)
-1. **chrome-trace-event@1.0.0**
+1. **chownr@1.1.2**
+     * Licenses: ISC
+     * Repository: [https://github.com/isaacs/chownr](https://github.com/isaacs/chownr)
+1. **chrome-trace-event@1.0.2**
      * Licenses: MIT
      * Repository: [github.com:samccone/chrome-trace-event](github.com:samccone/chrome-trace-event)
 1. **cipher-base@1.0.4**
@@ -1275,16 +1269,13 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **cliui@3.2.0**
      * Licenses: ISC
      * Repository: [https://github.com/yargs/cliui](https://github.com/yargs/cliui)
-1. **cliui@4.1.0**
-     * Licenses: ISC
-     * Repository: [https://github.com/yargs/cliui](https://github.com/yargs/cliui)
 1. **cliui@5.0.0**
      * Licenses: ISC
      * Repository: [https://github.com/yargs/cliui](https://github.com/yargs/cliui)
 1. **code-point-at@1.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/code-point-at](https://github.com/sindresorhus/code-point-at)
-1. **codecov@3.2.0**
+1. **codecov@3.5.0**
      * Licenses: MIT
      * Repository: [https://github.com/codecov/codecov-node](https://github.com/codecov/codecov-node)
 1. **collection-visit@1.0.0**
@@ -1302,19 +1293,13 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **commander@2.15.1**
      * Licenses: MIT
      * Repository: [https://github.com/tj/commander.js](https://github.com/tj/commander.js)
-1. **commander@2.17.1**
-     * Licenses: MIT
-     * Repository: [https://github.com/tj/commander.js](https://github.com/tj/commander.js)
-1. **commander@2.19.0**
-     * Licenses: MIT
-     * Repository: [https://github.com/tj/commander.js](https://github.com/tj/commander.js)
 1. **commander@2.20.0**
      * Licenses: MIT
      * Repository: [https://github.com/tj/commander.js](https://github.com/tj/commander.js)
 1. **commondir@1.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/substack/node-commondir](https://github.com/substack/node-commondir)
-1. **component-emitter@1.2.1**
+1. **component-emitter@1.3.0**
      * Licenses: MIT
      * Repository: [https://github.com/component/emitter](https://github.com/component/emitter)
 1. **concat-map@0.0.1**
@@ -1341,16 +1326,16 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **copy-descriptor@0.1.1**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/copy-descriptor](https://github.com/jonschlinkert/copy-descriptor)
-1. **core-js-compat@3.2.1**
+1. **core-js-compat@3.2.0**
      * Licenses: MIT
      * Repository: [https://github.com/zloirock/core-js](https://github.com/zloirock/core-js)
-1. **core-js@2.5.5**
+1. **core-js@2.6.9**
      * Licenses: MIT
      * Repository: [https://github.com/zloirock/core-js](https://github.com/zloirock/core-js)
 1. **core-js@3.1.4**
      * Licenses: MIT
      * Repository: [https://github.com/zloirock/core-js](https://github.com/zloirock/core-js)
-1. **core-js@3.2.1**
+1. **core-js@3.2.0**
      * Licenses: MIT
      * Repository: [https://github.com/zloirock/core-js](https://github.com/zloirock/core-js)
 1. **core-util-is@1.0.2**
@@ -1452,10 +1437,10 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **duplexify@3.7.1**
      * Licenses: MIT
      * Repository: [https://github.com/mafintosh/duplexify](https://github.com/mafintosh/duplexify)
-1. **electron-to-chromium@1.3.233**
+1. **electron-to-chromium@1.3.224**
      * Licenses: ISC
      * Repository: [https://github.com/kilian/electron-to-chromium](https://github.com/kilian/electron-to-chromium)
-1. **elliptic@6.4.1**
+1. **elliptic@6.5.0**
      * Licenses: MIT
      * Repository: [https://github.com/indutny/elliptic](https://github.com/indutny/elliptic)
 1. **emoji-regex@7.0.3**
@@ -1479,7 +1464,7 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **es6-error@4.1.1**
      * Licenses: MIT
      * Repository: [https://github.com/bjyoungblood/es6-error](https://github.com/bjyoungblood/es6-error)
-1. **es6-promise@4.2.5**
+1. **es6-promise@4.2.8**
      * Licenses: MIT
      * Repository: [https://github.com/stefanpenner/es6-promise](https://github.com/stefanpenner/es6-promise)
 1. **es6-promisify@5.0.0**
@@ -1488,7 +1473,7 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **escape-string-regexp@1.0.5**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/escape-string-regexp](https://github.com/sindresorhus/escape-string-regexp)
-1. **eslint-scope@4.0.0**
+1. **eslint-scope@4.0.3**
      * Licenses: BSD-2-Clause
      * Repository: [https://github.com/eslint/eslint-scope](https://github.com/eslint/eslint-scope)
 1. **esprima@4.0.1**
@@ -1500,8 +1485,8 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **estraverse@4.2.0**
      * Licenses: BSD-2-Clause
      * Repository: [https://github.com/estools/estraverse](https://github.com/estools/estraverse)
-1. **esutils@2.0.2**
-     * Licenses: BSD
+1. **esutils@2.0.3**
+     * Licenses: BSD-2-Clause
      * Repository: [https://github.com/estools/esutils](https://github.com/estools/esutils)
 1. **events@3.0.0**
      * Licenses: MIT
@@ -1542,12 +1527,9 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **fill-range@4.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/fill-range](https://github.com/jonschlinkert/fill-range)
-1. **find-babel-config@1.1.0**
+1. **find-babel-config@1.2.0**
      * Licenses: MIT
      * Repository: [https://github.com/tleunen/find-babel-config](https://github.com/tleunen/find-babel-config)
-1. **find-cache-dir@2.0.0**
-     * Licenses: MIT
-     * Repository: [https://github.com/avajs/find-cache-dir](https://github.com/avajs/find-cache-dir)
 1. **find-cache-dir@2.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/avajs/find-cache-dir](https://github.com/avajs/find-cache-dir)
@@ -1557,10 +1539,10 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **find-up@3.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/find-up](https://github.com/sindresorhus/find-up)
-1. **findup-sync@2.0.0**
+1. **findup-sync@3.0.0**
      * Licenses: MIT
-     * Repository: [https://github.com/js-cli/node-findup-sync](https://github.com/js-cli/node-findup-sync)
-1. **firebase@6.4.0**
+     * Repository: [https://github.com/gulpjs/findup-sync](https://github.com/gulpjs/findup-sync)
+1. **firebase@6.3.5**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
 1. **flush-write-stream@1.1.1**
@@ -1596,9 +1578,6 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **gauge@2.7.4**
      * Licenses: ISC
      * Repository: [https://github.com/iarna/gauge](https://github.com/iarna/gauge)
-1. **get-caller-file@1.0.3**
-     * Licenses: ISC
-     * Repository: [https://github.com/stefanpenner/get-caller-file](https://github.com/stefanpenner/get-caller-file)
 1. **get-caller-file@2.0.5**
      * Licenses: ISC
      * Repository: [https://github.com/stefanpenner/get-caller-file](https://github.com/stefanpenner/get-caller-file)
@@ -1614,13 +1593,19 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **glob@7.1.2**
      * Licenses: ISC
      * Repository: [https://github.com/isaacs/node-glob](https://github.com/isaacs/node-glob)
-1. **glob@7.1.3**
+1. **glob@7.1.4**
      * Licenses: ISC
      * Repository: [https://github.com/isaacs/node-glob](https://github.com/isaacs/node-glob)
 1. **global-modules@1.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/global-modules](https://github.com/jonschlinkert/global-modules)
+1. **global-modules@2.0.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/jonschlinkert/global-modules](https://github.com/jonschlinkert/global-modules)
 1. **global-prefix@1.0.2**
+     * Licenses: MIT
+     * Repository: [https://github.com/jonschlinkert/global-prefix](https://github.com/jonschlinkert/global-prefix)
+1. **global-prefix@3.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/global-prefix](https://github.com/jonschlinkert/global-prefix)
 1. **globals@11.12.0**
@@ -1629,7 +1614,7 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **globals@9.18.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/globals](https://github.com/sindresorhus/globals)
-1. **graceful-fs@4.1.15**
+1. **graceful-fs@4.2.1**
      * Licenses: ISC
      * Repository: [https://github.com/isaacs/node-graceful-fs](https://github.com/isaacs/node-graceful-fs)
 1. **growl@1.10.5**
@@ -1680,10 +1665,10 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **hmac-drbg@1.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/indutny/hmac-drbg](https://github.com/indutny/hmac-drbg)
-1. **homedir-polyfill@1.0.1**
+1. **homedir-polyfill@1.0.3**
      * Licenses: MIT
      * Repository: [https://github.com/doowb/homedir-polyfill](https://github.com/doowb/homedir-polyfill)
-1. **hosted-git-info@2.8.4**
+1. **hosted-git-info@2.8.2**
      * Licenses: ISC
      * Repository: [https://github.com/npm/hosted-git-info](https://github.com/npm/hosted-git-info)
 1. **http-parser-js@0.4.10**
@@ -1692,7 +1677,7 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **https-browserify@1.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/substack/https-browserify](https://github.com/substack/https-browserify)
-1. **https-proxy-agent@2.2.1**
+1. **https-proxy-agent@2.2.2**
      * Licenses: MIT
      * Repository: [https://github.com/TooTallNate/node-https-proxy-agent](https://github.com/TooTallNate/node-https-proxy-agent)
 1. **iconv-lite@0.4.23**
@@ -1701,7 +1686,7 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **idb@3.0.2**
      * Licenses: ISC
      * Repository: [https://github.com/jakearchibald/indexeddb-promised](https://github.com/jakearchibald/indexeddb-promised)
-1. **ieee754@1.1.12**
+1. **ieee754@1.1.13**
      * Licenses: BSD-3-Clause
      * Repository: [https://github.com/feross/ieee754](https://github.com/feross/ieee754)
 1. **iferr@0.1.5**
@@ -1716,9 +1701,9 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **imurmurhash@0.1.4**
      * Licenses: MIT
      * Repository: [https://github.com/jensyt/imurmurhash-js](https://github.com/jensyt/imurmurhash-js)
-1. **indexof@0.0.1**
-     * Licenses: MIT*
-     * Repository: unknown
+1. **infer-owner@1.0.4**
+     * Licenses: ISC
+     * Repository: [https://github.com/npm/infer-owner](https://github.com/npm/infer-owner)
 1. **inflight@1.0.6**
      * Licenses: ISC
      * Repository: [https://github.com/npm/inflight](https://github.com/npm/inflight)
@@ -1726,6 +1711,9 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
      * Licenses: ISC
      * Repository: [https://github.com/isaacs/inherits](https://github.com/isaacs/inherits)
 1. **inherits@2.0.3**
+     * Licenses: ISC
+     * Repository: [https://github.com/isaacs/inherits](https://github.com/isaacs/inherits)
+1. **inherits@2.0.4**
      * Licenses: ISC
      * Repository: [https://github.com/isaacs/inherits](https://github.com/isaacs/inherits)
 1. **ini@1.3.5**
@@ -1788,9 +1776,6 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **is-glob@3.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/is-glob](https://github.com/jonschlinkert/is-glob)
-1. **is-glob@4.0.0**
-     * Licenses: MIT
-     * Repository: [https://github.com/jonschlinkert/is-glob](https://github.com/jonschlinkert/is-glob)
 1. **is-glob@4.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/micromatch/is-glob](https://github.com/micromatch/is-glob)
@@ -1806,6 +1791,9 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **is-windows@1.0.2**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/is-windows](https://github.com/jonschlinkert/is-windows)
+1. **is-wsl@1.1.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/sindresorhus/is-wsl](https://github.com/sindresorhus/is-wsl)
 1. **isarray@0.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/juliangruber/isarray](https://github.com/juliangruber/isarray)
@@ -1848,9 +1836,6 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **js-tokens@4.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/lydell/js-tokens](https://github.com/lydell/js-tokens)
-1. **js-yaml@3.12.1**
-     * Licenses: MIT
-     * Repository: [https://github.com/nodeca/js-yaml](https://github.com/nodeca/js-yaml)
 1. **js-yaml@3.13.1**
      * Licenses: MIT
      * Repository: [https://github.com/nodeca/js-yaml](https://github.com/nodeca/js-yaml)
@@ -1923,16 +1908,10 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **lodash.flattendeep@4.4.0**
      * Licenses: MIT
      * Repository: [https://github.com/lodash/lodash](https://github.com/lodash/lodash)
-1. **lodash@4.17.11**
-     * Licenses: MIT
-     * Repository: [https://github.com/lodash/lodash](https://github.com/lodash/lodash)
 1. **lodash@4.17.15**
      * Licenses: MIT
      * Repository: [https://github.com/lodash/lodash](https://github.com/lodash/lodash)
-1. **lolex@2.7.5**
-     * Licenses: BSD-3-Clause
-     * Repository: [https://github.com/sinonjs/lolex](https://github.com/sinonjs/lolex)
-1. **lolex@3.1.0**
+1. **lolex@4.2.0**
      * Licenses: BSD-3-Clause
      * Repository: [https://github.com/sinonjs/lolex](https://github.com/sinonjs/lolex)
 1. **long@3.2.0**
@@ -1950,12 +1929,12 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **lru-cache@5.1.1**
      * Licenses: ISC
      * Repository: [https://github.com/isaacs/node-lru-cache](https://github.com/isaacs/node-lru-cache)
-1. **make-dir@1.3.0**
-     * Licenses: MIT
-     * Repository: [https://github.com/sindresorhus/make-dir](https://github.com/sindresorhus/make-dir)
 1. **make-dir@2.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/make-dir](https://github.com/sindresorhus/make-dir)
+1. **mamacro@0.0.3**
+     * Licenses: MIT
+     * Repository: unknown
 1. **map-age-cleaner@0.1.3**
      * Licenses: MIT
      * Repository: [https://github.com/SamVerschueren/map-age-cleaner](https://github.com/SamVerschueren/map-age-cleaner)
@@ -1968,7 +1947,7 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **md5.js@1.3.5**
      * Licenses: MIT
      * Repository: [https://github.com/crypto-browserify/md5.js](https://github.com/crypto-browserify/md5.js)
-1. **mem@4.1.0**
+1. **mem@4.3.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/mem](https://github.com/sindresorhus/mem)
 1. **memory-fs@0.4.1**
@@ -1983,7 +1962,7 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **miller-rabin@4.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/indutny/miller-rabin](https://github.com/indutny/miller-rabin)
-1. **mimic-fn@1.2.0**
+1. **mimic-fn@2.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/mimic-fn](https://github.com/sindresorhus/mimic-fn)
 1. **minimalistic-assert@1.0.1**
@@ -2010,7 +1989,7 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **mississippi@3.0.0**
      * Licenses: BSD-2-Clause
      * Repository: [https://github.com/maxogden/mississippi](https://github.com/maxogden/mississippi)
-1. **mixin-deep@1.3.1**
+1. **mixin-deep@1.3.2**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/mixin-deep](https://github.com/jonschlinkert/mixin-deep)
 1. **mkdirp@0.5.1**
@@ -2025,9 +2004,6 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **ms@2.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/zeit/ms](https://github.com/zeit/ms)
-1. **ms@2.1.1**
-     * Licenses: MIT
-     * Repository: [https://github.com/zeit/ms](https://github.com/zeit/ms)
 1. **ms@2.1.2**
      * Licenses: MIT
      * Repository: [https://github.com/zeit/ms](https://github.com/zeit/ms)
@@ -2040,7 +2016,7 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **needle@2.4.0**
      * Licenses: MIT
      * Repository: [https://github.com/tomas/needle](https://github.com/tomas/needle)
-1. **neo-async@2.6.0**
+1. **neo-async@2.6.1**
      * Licenses: MIT
      * Repository: [https://github.com/suguru03/neo-async](https://github.com/suguru03/neo-async)
 1. **nested-error-stacks@2.1.0**
@@ -2049,13 +2025,13 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **nice-try@1.0.5**
      * Licenses: MIT
      * Repository: [https://github.com/electerious/nice-try](https://github.com/electerious/nice-try)
-1. **nise@1.4.8**
+1. **nise@1.5.1**
      * Licenses: BSD-3-Clause
      * Repository: [https://github.com/sinonjs/nise](https://github.com/sinonjs/nise)
-1. **node-fetch@2.3.0**
+1. **node-fetch@2.6.0**
      * Licenses: MIT
      * Repository: [https://github.com/bitinn/node-fetch](https://github.com/bitinn/node-fetch)
-1. **node-libs-browser@2.2.0**
+1. **node-libs-browser@2.2.1**
      * Licenses: MIT
      * Repository: [https://github.com/webpack/node-libs-browser](https://github.com/webpack/node-libs-browser)
 1. **node-modules-regexp@1.0.0**
@@ -2151,13 +2127,10 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **p-finally@1.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/p-finally](https://github.com/sindresorhus/p-finally)
-1. **p-is-promise@2.0.0**
+1. **p-is-promise@2.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/p-is-promise](https://github.com/sindresorhus/p-is-promise)
 1. **p-limit@1.3.0**
-     * Licenses: MIT
-     * Repository: [https://github.com/sindresorhus/p-limit](https://github.com/sindresorhus/p-limit)
-1. **p-limit@2.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/p-limit](https://github.com/sindresorhus/p-limit)
 1. **p-limit@2.2.0**
@@ -2172,16 +2145,13 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **p-try@1.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/p-try](https://github.com/sindresorhus/p-try)
-1. **p-try@2.0.0**
-     * Licenses: MIT
-     * Repository: [https://github.com/sindresorhus/p-try](https://github.com/sindresorhus/p-try)
 1. **p-try@2.2.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/p-try](https://github.com/sindresorhus/p-try)
 1. **package-hash@3.0.0**
      * Licenses: ISC
      * Repository: [https://github.com/novemberborn/package-hash](https://github.com/novemberborn/package-hash)
-1. **pako@1.0.8**
+1. **pako@1.0.10**
      * Licenses: (MIT AND Zlib)
      * Repository: [https://github.com/nodeca/pako](https://github.com/nodeca/pako)
 1. **parallel-transform@1.1.0**
@@ -2199,7 +2169,7 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **pascalcase@0.1.1**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/pascalcase](https://github.com/jonschlinkert/pascalcase)
-1. **path-browserify@0.0.0**
+1. **path-browserify@0.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/substack/path-browserify](https://github.com/substack/path-browserify)
 1. **path-dirname@1.0.2**
@@ -2247,9 +2217,6 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **private@0.1.8**
      * Licenses: MIT
      * Repository: [https://github.com/benjamn/private](https://github.com/benjamn/private)
-1. **process-nextick-args@2.0.0**
-     * Licenses: MIT
-     * Repository: [https://github.com/calvinmetcalf/process-nextick-args](https://github.com/calvinmetcalf/process-nextick-args)
 1. **process-nextick-args@2.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/calvinmetcalf/process-nextick-args](https://github.com/calvinmetcalf/process-nextick-args)
@@ -2301,7 +2268,7 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **querystring@0.2.0**
      * Licenses: MIT
      * Repository: [https://github.com/Gozala/querystring](https://github.com/Gozala/querystring)
-1. **randombytes@2.0.6**
+1. **randombytes@2.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/crypto-browserify/randombytes](https://github.com/crypto-browserify/randombytes)
 1. **randomfill@1.0.4**
@@ -2313,7 +2280,7 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **read-installed@4.0.3**
      * Licenses: ISC
      * Repository: [https://github.com/isaacs/read-installed](https://github.com/isaacs/read-installed)
-1. **read-package-json@2.1.0**
+1. **read-package-json@2.0.13**
      * Licenses: ISC
      * Repository: [https://github.com/npm/read-package-json](https://github.com/npm/read-package-json)
 1. **read-pkg-up@4.0.0**
@@ -2373,9 +2340,6 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **require-directory@2.1.1**
      * Licenses: MIT
      * Repository: [https://github.com/troygoode/node-require-directory](https://github.com/troygoode/node-require-directory)
-1. **require-main-filename@1.0.1**
-     * Licenses: ISC
-     * Repository: [https://github.com/yargs/require-main-filename](https://github.com/yargs/require-main-filename)
 1. **require-main-filename@2.0.0**
      * Licenses: ISC
      * Repository: [https://github.com/yargs/require-main-filename](https://github.com/yargs/require-main-filename)
@@ -2397,7 +2361,7 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **resolve-url@0.2.1**
      * Licenses: MIT
      * Repository: [https://github.com/lydell/resolve-url](https://github.com/lydell/resolve-url)
-1. **resolve@1.10.0**
+1. **resolve@1.12.0**
      * Licenses: MIT
      * Repository: [https://github.com/browserify/resolve](https://github.com/browserify/resolve)
 1. **ret@0.1.15**
@@ -2427,25 +2391,19 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **schema-utils@1.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/webpack-contrib/schema-utils](https://github.com/webpack-contrib/schema-utils)
-1. **semver@5.6.0**
-     * Licenses: ISC
-     * Repository: [https://github.com/npm/node-semver](https://github.com/npm/node-semver)
 1. **semver@5.7.0**
      * Licenses: ISC
      * Repository: [https://github.com/npm/node-semver](https://github.com/npm/node-semver)
 1. **semver@6.3.0**
      * Licenses: ISC
      * Repository: [https://github.com/npm/node-semver](https://github.com/npm/node-semver)
-1. **serialize-javascript@1.6.1**
+1. **serialize-javascript@1.7.0**
      * Licenses: BSD-3-Clause
      * Repository: [https://github.com/yahoo/serialize-javascript](https://github.com/yahoo/serialize-javascript)
 1. **set-blocking@2.0.0**
      * Licenses: ISC
      * Repository: [https://github.com/yargs/set-blocking](https://github.com/yargs/set-blocking)
-1. **set-value@0.4.3**
-     * Licenses: MIT
-     * Repository: [https://github.com/jonschlinkert/set-value](https://github.com/jonschlinkert/set-value)
-1. **set-value@2.0.0**
+1. **set-value@2.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/set-value](https://github.com/jonschlinkert/set-value)
 1. **setimmediate@1.0.5**
@@ -2466,7 +2424,7 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **signal-exit@3.0.2**
      * Licenses: ISC
      * Repository: [https://github.com/tapjs/signal-exit](https://github.com/tapjs/signal-exit)
-1. **sinon@7.2.3**
+1. **sinon@7.4.1**
      * Licenses: BSD-3-Clause
      * Repository: [https://github.com/sinonjs/sinon](https://github.com/sinonjs/sinon)
 1. **slash@1.0.0**
@@ -2493,9 +2451,6 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **source-map-resolve@0.5.2**
      * Licenses: MIT
      * Repository: [https://github.com/lydell/source-map-resolve](https://github.com/lydell/source-map-resolve)
-1. **source-map-support@0.5.10**
-     * Licenses: MIT
-     * Repository: [https://github.com/evanw/node-source-map-support](https://github.com/evanw/node-source-map-support)
 1. **source-map-support@0.5.13**
      * Licenses: MIT
      * Repository: [https://github.com/evanw/node-source-map-support](https://github.com/evanw/node-source-map-support)
@@ -2532,7 +2487,7 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **spdx-satisfies@4.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/kemitchell/spdx-satisfies.js](https://github.com/kemitchell/spdx-satisfies.js)
-1. **spine-web@1.0.1**
+1. **spine-web@1.0.2**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/SpineEventEngine/web](https://github.com/SpineEventEngine/web)
 1. **split-string@3.1.0**
@@ -2562,9 +2517,6 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **string-width@1.0.2**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/string-width](https://github.com/sindresorhus/string-width)
-1. **string-width@2.1.1**
-     * Licenses: MIT
-     * Repository: [https://github.com/sindresorhus/string-width](https://github.com/sindresorhus/string-width)
 1. **string-width@3.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/string-width](https://github.com/sindresorhus/string-width)
@@ -2572,9 +2524,6 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
      * Licenses: MIT
      * Repository: [https://github.com/nodejs/string_decoder](https://github.com/nodejs/string_decoder)
 1. **strip-ansi@3.0.1**
-     * Licenses: MIT
-     * Repository: [https://github.com/chalk/strip-ansi](https://github.com/chalk/strip-ansi)
-1. **strip-ansi@4.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/chalk/strip-ansi](https://github.com/chalk/strip-ansi)
 1. **strip-ansi@5.2.0**
@@ -2601,7 +2550,7 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **supports-color@6.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/chalk/supports-color](https://github.com/chalk/supports-color)
-1. **tapable@1.1.1**
+1. **tapable@1.1.3**
      * Licenses: MIT
      * Repository: [https://github.com/webpack/tapable](https://github.com/webpack/tapable)
 1. **tar@4.4.10**
@@ -2610,22 +2559,19 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **teeny-request@3.11.3**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/fhinkel/teeny-request](https://github.com/fhinkel/teeny-request)
-1. **terser-webpack-plugin@1.2.2**
+1. **terser-webpack-plugin@1.4.1**
      * Licenses: MIT
      * Repository: [https://github.com/webpack-contrib/terser-webpack-plugin](https://github.com/webpack-contrib/terser-webpack-plugin)
-1. **terser@3.16.1**
+1. **terser@4.1.4**
      * Licenses: BSD-2-Clause
      * Repository: [https://github.com/fabiosantoscode/terser](https://github.com/fabiosantoscode/terser)
 1. **test-exclude@5.2.3**
      * Licenses: ISC
      * Repository: [https://github.com/istanbuljs/istanbuljs](https://github.com/istanbuljs/istanbuljs)
-1. **text-encoding@0.6.4**
-     * Licenses: Unlicense
-     * Repository: [https://github.com/inexorabletash/text-encoding](https://github.com/inexorabletash/text-encoding)
 1. **through2@2.0.5**
      * Licenses: MIT
      * Repository: [https://github.com/rvagg/through2](https://github.com/rvagg/through2)
-1. **timers-browserify@2.0.10**
+1. **timers-browserify@2.0.11**
      * Licenses: MIT
      * Repository: [https://github.com/jryans/timers-browserify](https://github.com/jryans/timers-browserify)
 1. **to-arraybuffer@1.0.1**
@@ -2652,9 +2598,6 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **trim-right@1.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/trim-right](https://github.com/sindresorhus/trim-right)
-1. **tslib@1.10.0**
-     * Licenses: Apache-2.0
-     * Repository: [https://github.com/Microsoft/tslib](https://github.com/Microsoft/tslib)
 1. **tty-browserify@0.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/substack/tty-browserify](https://github.com/substack/tty-browserify)
@@ -2679,21 +2622,18 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **unicode-property-aliases-ecmascript@1.0.5**
      * Licenses: MIT
      * Repository: [https://github.com/mathiasbynens/unicode-property-aliases-ecmascript](https://github.com/mathiasbynens/unicode-property-aliases-ecmascript)
-1. **union-value@1.0.0**
+1. **union-value@1.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/union-value](https://github.com/jonschlinkert/union-value)
 1. **unique-filename@1.1.1**
      * Licenses: ISC
      * Repository: [https://github.com/iarna/unique-filename](https://github.com/iarna/unique-filename)
-1. **unique-slug@2.0.1**
+1. **unique-slug@2.0.2**
      * Licenses: ISC
      * Repository: [https://github.com/iarna/unique-slug](https://github.com/iarna/unique-slug)
 1. **unset-value@1.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/unset-value](https://github.com/jonschlinkert/unset-value)
-1. **upath@1.1.0**
-     * Licenses: MIT
-     * Repository: [https://github.com/anodynos/upath](https://github.com/anodynos/upath)
 1. **upath@1.1.2**
      * Licenses: MIT
      * Repository: [https://github.com/anodynos/upath](https://github.com/anodynos/upath)
@@ -2724,28 +2664,28 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **util@0.11.1**
      * Licenses: MIT
      * Repository: [https://github.com/defunctzombie/node-util](https://github.com/defunctzombie/node-util)
-1. **v8-compile-cache@2.0.2**
+1. **v8-compile-cache@2.0.3**
      * Licenses: MIT
-     * Repository: unknown
+     * Repository: [https://github.com/zertosh/v8-compile-cache](https://github.com/zertosh/v8-compile-cache)
 1. **validate-npm-package-license@3.0.4**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/kemitchell/validate-npm-package-license.js](https://github.com/kemitchell/validate-npm-package-license.js)
-1. **vm-browserify@0.0.4**
+1. **vm-browserify@1.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/substack/vm-browserify](https://github.com/substack/vm-browserify)
 1. **watchpack@1.6.0**
      * Licenses: MIT
      * Repository: [https://github.com/webpack/watchpack](https://github.com/webpack/watchpack)
-1. **webpack-cli@3.2.3**
+1. **webpack-cli@3.3.6**
      * Licenses: MIT
      * Repository: [https://github.com/webpack/webpack-cli](https://github.com/webpack/webpack-cli)
 1. **webpack-merge@4.2.1**
      * Licenses: MIT
      * Repository: [https://github.com/survivejs/webpack-merge](https://github.com/survivejs/webpack-merge)
-1. **webpack-sources@1.3.0**
+1. **webpack-sources@1.4.3**
      * Licenses: MIT
      * Repository: [https://github.com/webpack/webpack-sources](https://github.com/webpack/webpack-sources)
-1. **webpack@4.29.3**
+1. **webpack@4.39.1**
      * Licenses: MIT
      * Repository: [https://github.com/webpack/webpack](https://github.com/webpack/webpack)
 1. **websocket-driver@0.7.3**
@@ -2772,7 +2712,7 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **wordwrap@0.0.3**
      * Licenses: MIT
      * Repository: [https://github.com/substack/node-wordwrap](https://github.com/substack/node-wordwrap)
-1. **worker-farm@1.6.0**
+1. **worker-farm@1.7.0**
      * Licenses: MIT
      * Repository: [https://github.com/rvagg/node-worker-farm](https://github.com/rvagg/node-worker-farm)
 1. **wrap-ansi@2.1.0**
@@ -2790,7 +2730,7 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **xmlhttprequest@1.8.0**
      * Licenses: MIT
      * Repository: [https://github.com/driverdan/node-XMLHttpRequest](https://github.com/driverdan/node-XMLHttpRequest)
-1. **xtend@4.0.1**
+1. **xtend@4.0.2**
      * Licenses: MIT
      * Repository: [https://github.com/Raynos/xtend](https://github.com/Raynos/xtend)
 1. **y18n@3.2.1**
@@ -2805,13 +2745,10 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
 1. **yallist@3.0.3**
      * Licenses: ISC
      * Repository: [https://github.com/isaacs/yallist](https://github.com/isaacs/yallist)
-1. **yargs-parser@11.1.1**
-     * Licenses: ISC
-     * Repository: [https://github.com/yargs/yargs-parser](https://github.com/yargs/yargs-parser)
 1. **yargs-parser@13.1.1**
      * Licenses: ISC
      * Repository: [https://github.com/yargs/yargs-parser](https://github.com/yargs/yargs-parser)
-1. **yargs@12.0.5**
+1. **yargs@13.2.4**
      * Licenses: MIT
      * Repository: [https://github.com/yargs/yargs](https://github.com/yargs/yargs)
 1. **yargs@13.3.0**
@@ -2822,12 +2759,12 @@ This report was generated on **Sun Aug 18 15:32:12 EEST 2019** using [Gradle-Lic
      * Repository: [https://github.com/bcoe/yargs](https://github.com/bcoe/yargs)
 
 
-This report was generated on **Sun Aug 18 2019 15:32:17 GMT+0300 (FLE Daylight Time)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
+This report was generated on **Tue Aug 20 2019 16:02:27 GMT+0300 (Eastern European Summer Time)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
 
 
 
     
-# Dependencies of `io.spine.gcloud:spine-firebase-web:1.0.2-SNAPSHOT`
+# Dependencies of `io.spine.gcloud:spine-firebase-web:1.0.2`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson.core **Name:** jackson-annotations **Version:** 2.9.0
@@ -3764,12 +3701,12 @@ This report was generated on **Sun Aug 18 2019 15:32:17 GMT+0300 (FLE Daylight T
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sun Aug 18 15:32:35 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 20 16:02:42 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-test-app:1.0.2-SNAPSHOT`
+# Dependencies of `io.spine:spine-test-app:1.0.2`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson.core **Name:** jackson-annotations **Version:** 2.9.0
@@ -5635,12 +5572,12 @@ This report was generated on **Sun Aug 18 15:32:35 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sun Aug 18 15:33:15 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 20 16:03:22 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-web:1.0.2-SNAPSHOT`
+# Dependencies of `io.spine:spine-web:1.0.2`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -6239,12 +6176,12 @@ This report was generated on **Sun Aug 18 15:33:15 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sun Aug 18 15:33:28 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 20 16:03:33 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-web-tests:1.0.2-SNAPSHOT`
+# Dependencies of `io.spine:spine-web-tests:1.0.2`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -6832,4 +6769,4 @@ This report was generated on **Sun Aug 18 15:33:28 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sun Aug 18 15:33:41 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 20 16:03:45 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-web</artifactId>
-<version>1.0.1</version>
+<version>1.0.2</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle
+++ b/version.gradle
@@ -21,7 +21,7 @@
 def final SPINE_VERSION = '1.0.2'
 
 ext {
-    spineVersion = '1.0.2-SNAPSHOT'
+    spineVersion = '1.0.1'
     spineBaseVersion = '1.0.1'
     
     versionToPublish = SPINE_VERSION

--- a/version.gradle
+++ b/version.gradle
@@ -18,14 +18,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-def final SPINE_VERSION = '1.0.2-SNAPSHOT'
+def final SPINE_VERSION = '1.0.2'
 
 ext {
-    spineVersion = SPINE_VERSION
+    spineVersion = '1.0.1'
     spineBaseVersion = '1.0.1'
     
     versionToPublish = SPINE_VERSION
-    versionToPublishJs = '1.0.1'
+    versionToPublishJs = SPINE_VERSION
 
     servletApiVersion = '3.1.0'
 }

--- a/version.gradle
+++ b/version.gradle
@@ -21,7 +21,7 @@
 def final SPINE_VERSION = '1.0.2'
 
 ext {
-    spineVersion = '1.0.1'
+    spineVersion = '1.0.2-SNAPSHOT'
     spineBaseVersion = '1.0.1'
     
     versionToPublish = SPINE_VERSION


### PR DESCRIPTION
This PR updates Java library and JS package version to `1.0.2`.

The Spine core and base dependencies remain `1.0.1` as version `1.0.2` is not released for them yet.