### PR TITLE
Expose transitive dependencies

### DIFF
--- a/firebase-web/build.gradle
+++ b/firebase-web/build.gradle
@@ -34,14 +34,9 @@ dependencies {
         exclude group: 'com.google.guava', module: 'guava'
     }
 
-    api deps.build.firebaseAdmin
     implementation deps.build.jacksonDatabind
-    implementation deps.build.googleHttpClient
     implementation deps.build.googleHttpClientApache
     implementation deps.build.appengineApi
-
-    implementation "io.spine:spine-server:$spineVersion"
-    implementation "io.spine:spine-client:$spineVersion"
 }
 
 task compileProtoToJs {

--- a/license-report.md
+++ b/license-report.md
@@ -588,7 +588,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 21 19:08:44 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 22 12:43:19 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 #NPM dependencies of `spine-web@1.0.3-SNAPSHOT`
@@ -1248,7 +1248,7 @@ This report was generated on **Wed Aug 21 19:08:44 EEST 2019** using [Gradle-Lic
 1. **chalk@2.4.2**
      * Licenses: MIT
      * Repository: [https://github.com/chalk/chalk](https://github.com/chalk/chalk)
-1. **chokidar@2.1.6**
+1. **chokidar@2.1.8**
      * Licenses: MIT
      * Repository: [https://github.com/paulmillr/chokidar](https://github.com/paulmillr/chokidar)
 1. **chownr@1.1.1**
@@ -2061,7 +2061,7 @@ This report was generated on **Wed Aug 21 19:08:44 EEST 2019** using [Gradle-Lic
 1. **node-pre-gyp@0.13.0**
      * Licenses: BSD-3-Clause
      * Repository: [https://github.com/mapbox/node-pre-gyp](https://github.com/mapbox/node-pre-gyp)
-1. **node-releases@1.1.27**
+1. **node-releases@1.1.28**
      * Licenses: MIT
      * Repository: [https://github.com/chicoxyzzy/node-releases](https://github.com/chicoxyzzy/node-releases)
 1. **nopt@4.0.1**
@@ -2792,7 +2792,7 @@ This report was generated on **Wed Aug 21 19:08:44 EEST 2019** using [Gradle-Lic
      * Repository: [https://github.com/bcoe/yargs](https://github.com/bcoe/yargs)
 
 
-This report was generated on **Wed Aug 21 2019 19:08:47 GMT+0300 (EEST)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
+This report was generated on **Thu Aug 22 2019 12:43:22 GMT+0300 (EEST)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
 
 
 
@@ -3734,7 +3734,7 @@ This report was generated on **Wed Aug 21 2019 19:08:47 GMT+0300 (EEST)** using 
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 21 19:08:48 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 22 12:43:23 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5605,7 +5605,7 @@ This report was generated on **Wed Aug 21 19:08:48 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 21 19:08:51 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 22 12:43:27 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6209,7 +6209,7 @@ This report was generated on **Wed Aug 21 19:08:51 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 21 19:08:51 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 22 12:43:28 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6802,4 +6802,4 @@ This report was generated on **Wed Aug 21 19:08:51 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 21 19:08:52 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 22 12:43:29 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/web/build.gradle
+++ b/web/build.gradle
@@ -29,10 +29,10 @@ apply from: deps.scripts.modelCompiler
 
 dependencies {
     api "javax.servlet:javax.servlet-api:$servletApiVersion"
+    api "io.spine:spine-server:$spineVersion"
+    api deps.build.googleHttpClient
 
-    implementation deps.build.googleHttpClient
     implementation deps.build.googleHttpClientApache
-    implementation "io.spine:spine-server:$spineVersion"
 
     testImplementation "io.spine.tools:spine-mute-logging:$spineBaseVersion"
 }


### PR DESCRIPTION
In this PR we expose the dependencies to the Spine core components via the `api` configuration.

Previously, it was only exposed at runtime (via the `implementation` configuration).