### PR TITLE
`order_by` in JS client

### DIFF
--- a/client-js/main/client/actor-request-factory.js
+++ b/client-js/main/client/actor-request-factory.js
@@ -712,6 +712,9 @@ class QueryBuilder extends AbstractTargetBuilder {
     const fieldMask = this.getMask();
     const limit = this._limit;
     const order = this._orderBy;
+    if (limit !== 0 && order === null) {
+        throw Error("Ordering is required for queries with a `limit`.")
+    }
     return this._factory.compose({forTarget: target,
                                   withMask: fieldMask,
                                   limit: limit,

--- a/client-js/main/client/actor-request-factory.js
+++ b/client-js/main/client/actor-request-factory.js
@@ -24,14 +24,14 @@ import uuid from 'uuid';
 
 import {Message} from 'google-protobuf';
 import {Timestamp} from '../proto/google/protobuf/timestamp_pb';
-import {Query, QueryId, ResponseFormat} from '../proto/spine/client/query_pb';
+import {OrderBy, Query, QueryId, ResponseFormat} from '../proto/spine/client/query_pb';
 import {Topic, TopicId} from '../proto/spine/client/subscription_pb';
 import {
-    CompositeFilter,
-    Filter,
-    IdFilter,
-    Target,
-    TargetFilters
+  CompositeFilter,
+  Filter,
+  IdFilter,
+  Target,
+  TargetFilters
 } from '../proto/spine/client/filters_pb';
 import {ActorContext} from '../proto/spine/core/actor_context_pb';
 import {Command, CommandContext, CommandId} from '../proto/spine/core/command_pb';
@@ -629,6 +629,12 @@ class QueryBuilder extends AbstractTargetBuilder {
      * @private
      */
     this._limit = 0;
+
+    /**
+     * @type {OrderBy}
+     * @private
+     */
+    this._orderBy = null;
   }
 
   /**
@@ -636,6 +642,8 @@ class QueryBuilder extends AbstractTargetBuilder {
    *
    * The value must be non-negative, otherwise an error occurs. If set to `0`, all the available
    * entities are retrieved.
+   *
+   * When set, the result ordering must also be specified.
    *
    * @param {number} limit the max number of response entities
    */
@@ -648,6 +656,53 @@ class QueryBuilder extends AbstractTargetBuilder {
   }
 
   /**
+   * Requests the query results to be ordered by the given `column` in the descending direction.
+   *
+   * Weather or not the results will be sorted in the given order depends on the implementation
+   * details of the server-client communication. For example, the Firebase-based communication
+   * protocol does not preserve ordering. Regardless, if a `limit` is set for a query, an ordering
+   * is also required.
+   *
+   * @param column
+   */
+  orderDescendingBy(column) {
+    this._addOrderBy(column, OrderBy.Direction.DESCENDING);
+    return this;
+  }
+
+  /**
+   * Requests the query results to be ordered by the given `column` in the ascending direction.
+   *
+   * Weather or not the results will be sorted in the given order depends on the implementation
+   * details of the server-client communication. For example, the Firebase-based communication
+   * protocol does not preserve ordering. Regardless, if a `limit` is set for a query, an ordering
+   * is also required.
+   *
+   * @param column
+   */
+  orderAscendingBy(column) {
+    this._addOrderBy(column, OrderBy.Direction.ASCENDING);
+    return this;
+  }
+
+  /**
+   * Specifies the expected response ordering.
+   *
+   * @param column the name of the column to order by
+   * @param direction the direction of ordering: `OrderBy.Direction.ASCENDING` or
+   *        `OrderBy.Direction.DESCENDING`
+   * @private
+   */
+  _addOrderBy(column, direction) {
+    if (column === null) {
+      throw new Error("Column name must not be `null`.");
+    }
+    this._orderBy = new OrderBy();
+    this._orderBy.setColumn(column);
+    this._orderBy.setDirection(direction);
+  }
+
+  /**
    * Creates the Query instance based on the current builder configuration.
    *
    * @return {Query} a new query
@@ -656,7 +711,11 @@ class QueryBuilder extends AbstractTargetBuilder {
     const target = this.getTarget();
     const fieldMask = this.getMask();
     const limit = this._limit;
-    return this._factory.compose({forTarget: target, withMask: fieldMask, limit: limit});
+    const order = this._orderBy;
+    return this._factory.compose({forTarget: target,
+                                  withMask: fieldMask,
+                                  limit: limit,
+                                  orderBy: order});
   }
 }
 
@@ -695,24 +754,26 @@ class QueryFactory {
    * @param {number} limit max number of entities to fetch
    * @return {Query}
    */
-  compose({forTarget: target, withMask: fieldMask, limit: limit}) {
-    return this._newQuery(target, fieldMask, limit);
+  compose({forTarget: target, withMask: fieldMask, limit: limit, orderBy: orderBy}) {
+    return this._newQuery(target, fieldMask, limit, orderBy);
   }
 
   /**
    * @param {!Target} target a specification of type and filters for `Query` result to match
    * @param {?FieldMask} fieldMask a specification of fields to be returned by executing `Query`
-   * @param {?Number} limit the maximum number of the requested entities
+   * @param {?Number} limit the maximum number of the requested entities; must go with `orderBy`
+   * @param {?OrderBy} orderBy ordering of the resulting entities
    * @return {Query} a new query instance
    * @private
    */
-  _newQuery(target, fieldMask, limit) {
+  _newQuery(target, fieldMask, limit, orderBy) {
     const id = QueryFactory._newId();
     const actorContext = this._requestFactory._actorContext();
 
     const format = new ResponseFormat();
     format.setFieldMask(fieldMask);
     format.setLimit(limit);
+    format.setOrderBy(orderBy);
 
     const result = new Query();
     result.setId(id);

--- a/client-js/test/client/query-builder-test.js
+++ b/client-js/test/client/query-builder-test.js
@@ -566,4 +566,13 @@ describe('QueryBuilder', function () {
 
     done();
   });
+
+  it('does not allow `limit` without `order_by`', done => {
+    const builder = Given.requestFactory()
+        .query()
+        .select(Given.ENTITY_CLASS.TASK)
+        .limit(42);
+    assert.throws(() => builder.build(), Error);
+    done();
+  });
 });

--- a/client-js/test/client/query-builder-test.js
+++ b/client-js/test/client/query-builder-test.js
@@ -26,6 +26,7 @@ import {Type} from '@lib/client/typed-message';
 import {ActorProvider, ActorRequestFactory, Filters} from '@lib/client/actor-request-factory';
 import {AnyPacker} from '@lib/client/any-packer';
 import {Duration} from '@lib/client/time-utils';
+import {OrderBy} from '@proto/spine/client/query_pb';
 import {Task, TaskId} from '@testProto/spine/web/test/given/task_pb';
 import {CompositeFilter, Filter, TargetFilters} from '@proto/spine/client/filters_pb';
 
@@ -522,12 +523,14 @@ describe('QueryBuilder', function () {
 
   /********* LIMIT *********/
 
-  it('creates a Query with a limit', done => {
+  it('creates a Query with a limit and ascending ordering', done => {
     const limit = 42;
+    const fieldName = 'when_created';
     const query = Given.requestFactory()
         .query()
         .select(Given.ENTITY_CLASS.TASK)
         .limit(limit)
+        .orderAscendingBy(fieldName)
         .build();
 
     assert.ok(query.getId());
@@ -536,6 +539,30 @@ describe('QueryBuilder', function () {
 
     const format = query.getFormat();
     assert.equal(limit, format.getLimit());
+    assert.equal(fieldName, format.getOrderBy().getColumn());
+    assert.equal(OrderBy.Direction.ASCENDING, format.getOrderBy().getDirection());
+
+    done();
+  });
+
+  it('creates a Query with a limit and descending ordering', done => {
+    const limit = 42;
+    const fieldName = 'name';
+    const query = Given.requestFactory()
+        .query()
+        .select(Given.ENTITY_CLASS.TASK)
+        .limit(limit)
+        .orderDescendingBy(fieldName)
+        .build();
+
+    assert.ok(query.getId());
+
+    Given.assertActorContextCorrect(query.getContext());
+
+    const format = query.getFormat();
+    assert.equal(limit, format.getLimit());
+    assert.equal(fieldName, format.getOrderBy().getColumn());
+    assert.equal(OrderBy.Direction.DESCENDING, format.getOrderBy().getDirection());
 
     done();
   });

--- a/license-report.md
+++ b/license-report.md
@@ -576,7 +576,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Oct 09 14:30:37 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 28 15:13:26 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1165,7 +1165,7 @@ This report was generated on **Wed Oct 09 14:30:37 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Oct 09 14:30:38 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 28 15:13:28 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 #NPM dependencies of `spine-web@1.1.6`
@@ -1216,16 +1216,16 @@ This report was generated on **Wed Oct 09 14:30:38 EEST 2019** using [Gradle-Lic
 
 ## `Development` dependencies:
 
-1. **@babel/cli@7.6.3**
+1. **@babel/cli@7.6.4**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-cli](https://github.com/babel/babel/tree/master/packages/babel-cli)
 1. **@babel/code-frame@7.5.5**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-code-frame](https://github.com/babel/babel/tree/master/packages/babel-code-frame)
-1. **@babel/core@7.6.3**
+1. **@babel/core@7.6.4**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-core](https://github.com/babel/babel/tree/master/packages/babel-core)
-1. **@babel/generator@7.6.3**
+1. **@babel/generator@7.6.4**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-generator](https://github.com/babel/babel/tree/master/packages/babel-generator)
 1. **@babel/helper-annotate-as-pure@7.0.0**
@@ -1291,7 +1291,7 @@ This report was generated on **Wed Oct 09 14:30:38 EEST 2019** using [Gradle-Lic
 1. **@babel/highlight@7.5.0**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-highlight](https://github.com/babel/babel/tree/master/packages/babel-highlight)
-1. **@babel/parser@7.6.3**
+1. **@babel/parser@7.6.4**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-parser](https://github.com/babel/babel/tree/master/packages/babel-parser)
 1. **@babel/plugin-proposal-async-generator-functions@7.2.0**
@@ -1552,7 +1552,7 @@ This report was generated on **Wed Oct 09 14:30:38 EEST 2019** using [Gradle-Lic
 1. **@types/long@4.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/DefinitelyTyped/DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped)
-1. **@types/node@10.14.21**
+1. **@types/node@10.17.0**
      * Licenses: MIT
      * Repository: [https://github.com/DefinitelyTyped/DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped)
 1. **@webassemblyjs/ast@1.8.5**
@@ -1750,7 +1750,7 @@ This report was generated on **Wed Oct 09 14:30:38 EEST 2019** using [Gradle-Lic
 1. **binary-extensions@1.13.1**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/binary-extensions](https://github.com/sindresorhus/binary-extensions)
-1. **bluebird@3.7.0**
+1. **bluebird@3.7.1**
      * Licenses: MIT
      * Repository: [https://github.com/petkaantonov/bluebird](https://github.com/petkaantonov/bluebird)
 1. **bn.js@4.11.8**
@@ -1786,7 +1786,7 @@ This report was generated on **Wed Oct 09 14:30:38 EEST 2019** using [Gradle-Lic
 1. **browserify-zlib@0.2.0**
      * Licenses: MIT
      * Repository: [https://github.com/devongovett/browserify-zlib](https://github.com/devongovett/browserify-zlib)
-1. **browserslist@4.7.0**
+1. **browserslist@4.7.2**
      * Licenses: MIT
      * Repository: [https://github.com/browserslist/browserslist](https://github.com/browserslist/browserslist)
 1. **buffer-from@1.1.1**
@@ -1819,7 +1819,7 @@ This report was generated on **Wed Oct 09 14:30:38 EEST 2019** using [Gradle-Lic
 1. **camelcase@5.3.1**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/camelcase](https://github.com/sindresorhus/camelcase)
-1. **caniuse-lite@1.0.30000999**
+1. **caniuse-lite@1.0.30001005**
      * Licenses: CC-BY-4.0
      * Repository: [https://github.com/ben-eb/caniuse-lite](https://github.com/ben-eb/caniuse-lite)
 1. **chalk@1.1.3**
@@ -1876,10 +1876,7 @@ This report was generated on **Wed Oct 09 14:30:38 EEST 2019** using [Gradle-Lic
 1. **commander@2.15.1**
      * Licenses: MIT
      * Repository: [https://github.com/tj/commander.js](https://github.com/tj/commander.js)
-1. **commander@2.20.0**
-     * Licenses: MIT
-     * Repository: [https://github.com/tj/commander.js](https://github.com/tj/commander.js)
-1. **commander@2.20.1**
+1. **commander@2.20.3**
      * Licenses: MIT
      * Repository: [https://github.com/tj/commander.js](https://github.com/tj/commander.js)
 1. **commondir@1.0.1**
@@ -1894,9 +1891,9 @@ This report was generated on **Wed Oct 09 14:30:38 EEST 2019** using [Gradle-Lic
 1. **concat-stream@1.6.2**
      * Licenses: MIT
      * Repository: [https://github.com/maxogden/concat-stream](https://github.com/maxogden/concat-stream)
-1. **console-browserify@1.1.0**
+1. **console-browserify@1.2.0**
      * Licenses: MIT
-     * Repository: [https://github.com/Raynos/console-browserify](https://github.com/Raynos/console-browserify)
+     * Repository: [https://github.com/browserify/console-browserify](https://github.com/browserify/console-browserify)
 1. **console-control-strings@1.1.0**
      * Licenses: ISC
      * Repository: [https://github.com/iarna/console-control-strings](https://github.com/iarna/console-control-strings)
@@ -1912,10 +1909,10 @@ This report was generated on **Wed Oct 09 14:30:38 EEST 2019** using [Gradle-Lic
 1. **copy-descriptor@0.1.1**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/copy-descriptor](https://github.com/jonschlinkert/copy-descriptor)
-1. **core-js-compat@3.2.1**
+1. **core-js-compat@3.3.4**
      * Licenses: MIT
      * Repository: [https://github.com/zloirock/core-js](https://github.com/zloirock/core-js)
-1. **core-js@2.6.9**
+1. **core-js@2.6.10**
      * Licenses: MIT
      * Repository: [https://github.com/zloirock/core-js](https://github.com/zloirock/core-js)
 1. **core-js@3.2.1**
@@ -1948,9 +1945,6 @@ This report was generated on **Wed Oct 09 14:30:38 EEST 2019** using [Gradle-Lic
 1. **cyclist@1.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/mafintosh/cyclist](https://github.com/mafintosh/cyclist)
-1. **date-now@0.1.4**
-     * Licenses: MIT
-     * Repository: [https://github.com/Colingo/date-now](https://github.com/Colingo/date-now)
 1. **debug@2.6.9**
      * Licenses: MIT
      * Repository: [https://github.com/visionmedia/debug](https://github.com/visionmedia/debug)
@@ -2020,7 +2014,7 @@ This report was generated on **Wed Oct 09 14:30:38 EEST 2019** using [Gradle-Lic
 1. **duplexify@3.7.1**
      * Licenses: MIT
      * Repository: [https://github.com/mafintosh/duplexify](https://github.com/mafintosh/duplexify)
-1. **electron-to-chromium@1.3.279**
+1. **electron-to-chromium@1.3.296**
      * Licenses: ISC
      * Repository: [https://github.com/kilian/electron-to-chromium](https://github.com/kilian/electron-to-chromium)
 1. **elliptic@6.5.1**
@@ -2191,6 +2185,9 @@ This report was generated on **Wed Oct 09 14:30:38 EEST 2019** using [Gradle-Lic
 1. **glob@7.1.4**
      * Licenses: ISC
      * Repository: [https://github.com/isaacs/node-glob](https://github.com/isaacs/node-glob)
+1. **glob@7.1.5**
+     * Licenses: ISC
+     * Repository: [https://github.com/isaacs/node-glob](https://github.com/isaacs/node-glob)
 1. **global-modules@1.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/global-modules](https://github.com/jonschlinkert/global-modules)
@@ -2209,7 +2206,7 @@ This report was generated on **Wed Oct 09 14:30:38 EEST 2019** using [Gradle-Lic
 1. **globals@9.18.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/globals](https://github.com/sindresorhus/globals)
-1. **graceful-fs@4.2.2**
+1. **graceful-fs@4.2.3**
      * Licenses: ISC
      * Repository: [https://github.com/isaacs/node-graceful-fs](https://github.com/isaacs/node-graceful-fs)
 1. **growl@1.10.5**
@@ -2218,7 +2215,7 @@ This report was generated on **Wed Oct 09 14:30:38 EEST 2019** using [Gradle-Lic
 1. **grpc@1.23.3**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/grpc/grpc-node](https://github.com/grpc/grpc-node)
-1. **handlebars@4.4.3**
+1. **handlebars@4.4.5**
      * Licenses: MIT
      * Repository: [https://github.com/wycats/handlebars.js](https://github.com/wycats/handlebars.js)
 1. **has-ansi@2.0.0**
@@ -2272,7 +2269,7 @@ This report was generated on **Wed Oct 09 14:30:38 EEST 2019** using [Gradle-Lic
 1. **https-browserify@1.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/substack/https-browserify](https://github.com/substack/https-browserify)
-1. **https-proxy-agent@2.2.2**
+1. **https-proxy-agent@2.2.4**
      * Licenses: MIT
      * Repository: [https://github.com/TooTallNate/node-https-proxy-agent](https://github.com/TooTallNate/node-https-proxy-agent)
 1. **iconv-lite@0.4.24**
@@ -2650,7 +2647,7 @@ This report was generated on **Wed Oct 09 14:30:38 EEST 2019** using [Gradle-Lic
 1. **node-pre-gyp@0.13.0**
      * Licenses: BSD-3-Clause
      * Repository: [https://github.com/mapbox/node-pre-gyp](https://github.com/mapbox/node-pre-gyp)
-1. **node-releases@1.1.35**
+1. **node-releases@1.1.39**
      * Licenses: MIT
      * Repository: [https://github.com/chicoxyzzy/node-releases](https://github.com/chicoxyzzy/node-releases)
 1. **nopt@4.0.1**
@@ -2932,7 +2929,7 @@ This report was generated on **Wed Oct 09 14:30:38 EEST 2019** using [Gradle-Lic
 1. **regexpu-core@4.6.0**
      * Licenses: MIT
      * Repository: [https://github.com/mathiasbynens/regexpu-core](https://github.com/mathiasbynens/regexpu-core)
-1. **regjsgen@0.5.0**
+1. **regjsgen@0.5.1**
      * Licenses: MIT
      * Repository: [https://github.com/bnjmnt4n/regjsgen](https://github.com/bnjmnt4n/regjsgen)
 1. **regjsparser@0.6.0**
@@ -3181,7 +3178,7 @@ This report was generated on **Wed Oct 09 14:30:38 EEST 2019** using [Gradle-Lic
 1. **terser-webpack-plugin@1.4.1**
      * Licenses: MIT
      * Repository: [https://github.com/webpack-contrib/terser-webpack-plugin](https://github.com/webpack-contrib/terser-webpack-plugin)
-1. **terser@4.3.8**
+1. **terser@4.3.9**
      * Licenses: BSD-2-Clause
      * Repository: [https://github.com/terser/terser](https://github.com/terser/terser)
 1. **test-exclude@5.2.3**
@@ -3223,7 +3220,7 @@ This report was generated on **Wed Oct 09 14:30:38 EEST 2019** using [Gradle-Lic
 1. **typedarray@0.0.6**
      * Licenses: MIT
      * Repository: [https://github.com/substack/typedarray](https://github.com/substack/typedarray)
-1. **uglify-js@3.6.1**
+1. **uglify-js@3.6.4**
      * Licenses: BSD-2-Clause
      * Repository: [https://github.com/mishoo/UglifyJS2](https://github.com/mishoo/UglifyJS2)
 1. **unicode-canonical-property-names-ecmascript@1.0.4**
@@ -3301,7 +3298,7 @@ This report was generated on **Wed Oct 09 14:30:38 EEST 2019** using [Gradle-Lic
 1. **webpack-sources@1.4.3**
      * Licenses: MIT
      * Repository: [https://github.com/webpack/webpack-sources](https://github.com/webpack/webpack-sources)
-1. **webpack@4.41.0**
+1. **webpack@4.41.2**
      * Licenses: MIT
      * Repository: [https://github.com/webpack/webpack](https://github.com/webpack/webpack)
 1. **websocket-driver@0.7.3**
@@ -3378,7 +3375,7 @@ This report was generated on **Wed Oct 09 14:30:38 EEST 2019** using [Gradle-Lic
      * Repository: [https://github.com/bcoe/yargs](https://github.com/bcoe/yargs)
 
 
-This report was generated on **Wed Oct 09 2019 14:30:40 GMT+0300 (EEST)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
+This report was generated on **Mon Oct 28 2019 15:13:30 GMT+0200 (EET)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
 
 
 
@@ -3967,7 +3964,7 @@ This report was generated on **Wed Oct 09 2019 14:30:40 GMT+0300 (EEST)** using 
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Oct 09 14:30:41 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 28 15:13:31 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4913,7 +4910,7 @@ This report was generated on **Wed Oct 09 14:30:41 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Oct 09 14:30:42 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 28 15:13:32 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5502,7 +5499,7 @@ This report was generated on **Wed Oct 09 14:30:42 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Oct 09 14:30:42 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 28 15:13:33 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7373,7 +7370,7 @@ This report was generated on **Wed Oct 09 14:30:42 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Oct 09 14:30:45 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 28 15:15:01 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7965,4 +7962,4 @@ This report was generated on **Wed Oct 09 14:30:45 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Oct 09 14:30:45 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 28 15:15:01 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).


### PR DESCRIPTION
This PR adds a missing feature to the JS client. Now we can specify ordering for query response from the JS library.

Note that ordering is neither restored nor verified by the client itself. A server may choose to ignore it completely, or, as is the case with Firebase, the ordering may be lost when transporting data from server to client.

Since the `limit` parameter requires presence of `order_by`, this feature is vital for users who may want to use `limit`, even if strict ordering is not supported.