### PR TITLE
Release 1.5.22

### DIFF
--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -22,5 +22,5 @@ val spineBaseVersion: String by extra("1.5.21")
 val spineCoreVersion: String by extra("1.5.21")
 val spineVersion: String by extra(spineCoreVersion)
 
-val versionToPublish: String by extra(spineVersion)
+val versionToPublish: String by extra("1.5.22")
 val versionToPublishJs: String by extra(spineVersion)


### PR DESCRIPTION
This PR updates the version to `1.5.22`.

Current master has a failing build, because it was restarted, and the version must be incremented.

The build was restarted because the `update-gh-pages` task has failed, pending investigation.