### PR TITLE
Fix publishing

### DIFF
--- a/client-js/build.gradle.kts
+++ b/client-js/build.gradle.kts
@@ -73,6 +73,8 @@ val jsDoc by tasks.registering(type = Exec::class) {
 afterEvaluate {
     val generatedDocs = "generatedDocs"
     val predefinedDocs = extra[generatedDocs] as Iterable<File>
-    extra[generatedDocs] = Lists.newArrayList(predefinedDocs).add(file(jsDocDir))
+    val newDocs = Lists.newArrayList(predefinedDocs)
+    newDocs.add(file(jsDocDir))
+    extra[generatedDocs] = newDocs
     tasks.getByName("updateGitHubPages").dependsOn(jsDoc)
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -22,5 +22,5 @@ val spineBaseVersion: String by extra("1.5.21")
 val spineCoreVersion: String by extra("1.5.21")
 val spineVersion: String by extra(spineCoreVersion)
 
-val versionToPublish: String by extra("1.5.23")
-val versionToPublishJs: String by extra("1.5.23")
+val versionToPublish: String by extra("1.5.24")
+val versionToPublishJs: String by extra("1.5.24")


### PR DESCRIPTION
This PR fixes the publishing of JsDocs.

`update-gh-pages` exposes a list of `generatedDocs` via `ext`, which other tasks can write to, if they wish to expand the list of docs.

At some point during migration to Kotlin, we have substituted a call of `ext.generatedDocs += newDocs` to `ext["generatedDocs"] += newList(predefinedDocs).add(newDocs)`. `add` returns `true`, and thus `generatedDocs` became a boolean.

This PR also advances the versions.