### PR TITLE
Keep up/cancel subscription requests fix.

### DIFF
--- a/client-js/main/client/client-factory.js
+++ b/client-js/main/client/client-factory.js
@@ -44,6 +44,8 @@ import {HttpEndpoint} from "./http-endpoint";
  * @property {?TenantProvider} tenantProvider
  *  the provider of an active tenant ID, if not specified, the application is considered
  *  single-tenant
+ * @property {?Duration} subscriptionKeepUpInterval
+ *  the custom interval for sending requests to keep up subscriptions
  */
 
 /**

--- a/client-js/main/client/firebase-client.js
+++ b/client-js/main/client/firebase-client.js
@@ -235,12 +235,9 @@ class FirebaseSubscribingClient extends SubscribingClient {
     const itemRemoved = new Subject();
 
     const pathSubscriptions = [
-      this._firebase
-          .onChildAdded(path, itemAdded.next.bind(itemAdded)),
-      this._firebase
-          .onChildChanged(path, itemChanged.next.bind(itemChanged)),
-      this._firebase
-          .onChildRemoved(path, itemRemoved.next.bind(itemRemoved))
+      this._firebase.onChildAdded(path, itemAdded),
+      this._firebase.onChildChanged(path, itemChanged),
+      this._firebase.onChildRemoved(path, itemRemoved)
     ];
 
     const typeUrl = subscription.getTopic().getTarget().getType();
@@ -263,8 +260,7 @@ class FirebaseSubscribingClient extends SubscribingClient {
    */
   _eventSubscription(path, subscription) {
     const itemAdded = new Subject();
-    const pathSubscription =
-        this._firebase.onChildAdded(path, itemAdded.next.bind(itemAdded));
+    const pathSubscription = this._firebase.onChildAdded(path, itemAdded);
 
     return new EventSubscription({
       unsubscribedBy: () => {

--- a/client-js/main/client/firebase-client.js
+++ b/client-js/main/client/firebase-client.js
@@ -326,7 +326,8 @@ export class FirebaseClientFactory extends AbstractClientFactory {
     const endpoint = new HttpEndpoint(httpClient, options.routing);
     const firebaseDatabaseClient = new FirebaseDatabaseClient(options.firebaseDatabase);
     const requestFactory = ActorRequestFactory.create(options);
-    const subscriptionService = new FirebaseSubscriptionService(endpoint);
+    const subscriptionService =
+        new FirebaseSubscriptionService(endpoint, options.subscriptionKeepUpInterval);
 
     const querying = new FirebaseQueryingClient(endpoint, firebaseDatabaseClient, requestFactory);
     const subscribing = new FirebaseSubscribingClient(endpoint,
@@ -351,7 +352,8 @@ export class FirebaseClientFactory extends AbstractClientFactory {
     const endpoint = new HttpEndpoint(httpClient, options.routing);
     const firebaseDatabaseClient = new FirebaseDatabaseClient(options.firebaseDatabase);
     const requestFactory = ActorRequestFactory.create(options);
-    const subscriptionService = new FirebaseSubscriptionService(endpoint);
+    const subscriptionService =
+        new FirebaseSubscriptionService(endpoint, options.subscriptionKeepUpInterval);
 
     return new FirebaseSubscribingClient(endpoint,
                                          firebaseDatabaseClient,

--- a/client-js/main/client/firebase-subscription-service.js
+++ b/client-js/main/client/firebase-subscription-service.js
@@ -21,8 +21,15 @@
 "use strict";
 
 import {Duration} from './time-utils';
-import ObjectToProto from "./object-to-proto";
+import ObjectToProto from './object-to-proto';
 import {Status} from '../proto/spine/core/response_pb';
+
+/**
+ * The default interval for sending subscription keep up requests.
+ *
+ * @type {Duration}
+ */
+const DEFAULT_KEEP_UP_INTERVAL = new Duration({minutes: 2});
 
 /**
  * A service that manages the active subscriptions periodically sending requests to keep them
@@ -31,16 +38,8 @@ import {Status} from '../proto/spine/core/response_pb';
 export class FirebaseSubscriptionService {
 
   /**
-   * The default interval for sending subscription keep up requests.
-   *
-   * @type {Duration}
-   * @private
-   */
-  static DEFAULT_KEEP_UP_INTERVAL = new Duration({minutes: 2});
-
-  /**
    * @param {Endpoint} endpoint an endpoint to communicate with
-   * @param {?Duration} keepUpInterval an custom interval for sending subscription keep up requests
+   * @param {?Duration} keepUpInterval a custom interval for sending subscription keep up requests
    */
   constructor(endpoint, keepUpInterval) {
     /**
@@ -59,7 +58,7 @@ export class FirebaseSubscriptionService {
      */
     this._keepUpInterval = keepUpInterval
         ? keepUpInterval
-        : FirebaseSubscriptionService.DEFAULT_KEEP_UP_INTERVAL;
+        : DEFAULT_KEEP_UP_INTERVAL;
   }
 
   /**

--- a/client-js/main/client/firebase-subscription-service.js
+++ b/client-js/main/client/firebase-subscription-service.js
@@ -59,19 +59,41 @@ export class FirebaseSubscriptionService {
       throw new Error('This subscription is already registered in subscription service');
     }
     this._subscriptions.push(subscription);
+
+    if (!this._isRunning()) {
+      this._run();
+    }
+  }
+
+  /**
+   * Indicates whether this service is running keeping up subscriptions.
+   *
+   * @returns {boolean}
+   * @private
+   */
+  _isRunning() {
+     return !!this._interval;
   }
 
   /**
    * Starts the subscription service, keeping up the added subscriptions.
+   *
+   * @private
    */
-  run() {
-    if (this._interval) {
-      throw new Error('The FirebaseSubscriptionService is already running');
-    }
-
+  _run() {
     this._interval = setInterval(() => {
       this._keepUpSubscriptions();
     }, SUBSCRIPTION_KEEP_UP_INTERVAL.inMs());
+  }
+
+  /**
+   * Stops the subscription service.
+   *
+   * @private
+   */
+  _stop() {
+    clearInterval(this._interval);
+    this._interval = null;
   }
 
   /**
@@ -103,29 +125,18 @@ export class FirebaseSubscriptionService {
   }
 
   /**
-   * Stops the subscription service unsubscribing and removing all added subscriptions.
-   */
-  stop() {
-    if (!this._interval) {
-      throw new Error('The FirebaseSubscriptionService was stopped when it was not running');
-    }
-    clearInterval(this._interval);
-    this._subscriptions.forEach(subscription => {
-      subscription.unsubscribe();
-      this._removeSubscription(subscription);
-    });
-    this._interval = null;
-  }
-
-  /**
    * Removes the provided subscription from subscriptions list, which stops any attempts
-   * to update it.
+   * to update it. In case no more subscriptions are left, stops this service.
    *
    * @private
    */
   _removeSubscription(subscription) {
     const index = this._subscriptions.indexOf(subscription);
     this._subscriptions.splice(index, 1);
+
+    if (this._subscriptions.length === 0) {
+      this._stop();
+    }
   }
 
   /**

--- a/client-js/main/client/firebase-subscription-service.js
+++ b/client-js/main/client/firebase-subscription-service.js
@@ -24,17 +24,25 @@ import {Duration} from './time-utils';
 import ObjectToProto from "./object-to-proto";
 import {Status} from '../proto/spine/core/response_pb';
 
-const SUBSCRIPTION_KEEP_UP_INTERVAL = new Duration({minutes: 2});
-
 /**
  * A service that manages the active subscriptions periodically sending requests to keep them
  * running.
  */
 export class FirebaseSubscriptionService {
+
+  /**
+   * The default interval for sending subscription keep up requests.
+   *
+   * @type {Duration}
+   * @private
+   */
+  static DEFAULT_KEEP_UP_INTERVAL = new Duration({minutes: 2});
+
   /**
    * @param {Endpoint} endpoint an endpoint to communicate with
+   * @param {?Duration} keepUpInterval an custom interval for sending subscription keep up requests
    */
-  constructor(endpoint) {
+  constructor(endpoint, keepUpInterval) {
     /**
      * @type {SpineSubscription[]}
      * @private
@@ -45,6 +53,13 @@ export class FirebaseSubscriptionService {
      * @private
      */
     this._endpoint = endpoint;
+    /**
+     * @type {Duration}
+     * @private
+     */
+    this._keepUpInterval = keepUpInterval
+        ? keepUpInterval
+        : FirebaseSubscriptionService.DEFAULT_KEEP_UP_INTERVAL;
   }
 
   /**
@@ -82,12 +97,7 @@ export class FirebaseSubscriptionService {
   _run() {
     this._interval = setInterval(() => {
       this._keepUpSubscriptions();
-    }, this._keepUpInterval());
-  }
-
-  /** Interval in milliseconds for sending subscription keep up requests. */
-  _keepUpInterval() {
-    return SUBSCRIPTION_KEEP_UP_INTERVAL.inMs();
+    }, this._keepUpInterval.inMs());
   }
 
   /**

--- a/client-js/main/client/firebase-subscription-service.js
+++ b/client-js/main/client/firebase-subscription-service.js
@@ -24,7 +24,6 @@ import {Duration} from './time-utils';
 import ObjectToProto from "./object-to-proto";
 import {Status} from '../proto/spine/core/response_pb';
 
-
 const SUBSCRIPTION_KEEP_UP_INTERVAL = new Duration({minutes: 2});
 
 /**
@@ -83,7 +82,12 @@ export class FirebaseSubscriptionService {
   _run() {
     this._interval = setInterval(() => {
       this._keepUpSubscriptions();
-    }, SUBSCRIPTION_KEEP_UP_INTERVAL.inMs());
+    }, this._keepUpInterval());
+  }
+
+  /** Interval in milliseconds for sending subscription keep up requests. */
+  _keepUpInterval() {
+    return SUBSCRIPTION_KEEP_UP_INTERVAL.inMs();
   }
 
   /**
@@ -115,7 +119,7 @@ export class FirebaseSubscriptionService {
       } else {
         this._endpoint.keepUpSubscription(spineSubscription).then(response => {
           const responseStatus = response.status;
-          const responseStatusProto = ObjectToProto.convert(responseStatus, _statusType);
+          const responseStatusProto = ObjectToProto.convert(responseStatus, Status.typeUrl());
           if (responseStatusProto.getStatusCase() !== Status.StatusCase.OK) {
             this._removeSubscription(subscription)
           }

--- a/client-js/main/index.js
+++ b/client-js/main/index.js
@@ -28,3 +28,4 @@ export {Client} from './client/client';
 export {init} from './client/spine';
 export {TenantIds, TenantProvider} from './client/tenant';
 export * from './client/errors';
+export {Duration} from './client/time-utils';

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spine-web",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "license": "Apache-2.0",
   "description": "A JS client for interacting with Spine applications.",
   "homepage": "https://spine.io",

--- a/integration-tests/js-tests/.babelrc
+++ b/integration-tests/js-tests/.babelrc
@@ -3,6 +3,7 @@
     "@babel/preset-env"
   ],
   "plugins": [
+    "@babel/plugin-transform-runtime",
     [
       "module-resolver",
       {

--- a/integration-tests/js-tests/package.json
+++ b/integration-tests/js-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-js-tests",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "license": "Apache-2.0",
   "description": "Tests of a `spine-web` JS library against the Spine-based application.",
   "scripts": {

--- a/integration-tests/js-tests/package.json
+++ b/integration-tests/js-tests/package.json
@@ -9,6 +9,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",
+    "@babel/plugin-transform-runtime": "^7.12.1",
     "@babel/preset-env": "^7.0.0",
     "@babel/register": "^7.0.0",
     "assert": "^2.0.0",
@@ -17,6 +18,7 @@
     "google-protobuf": "^3.8.0",
     "mocha": "^7.2.0",
     "rxjs": "~6.5.1",
+    "sinon": "^9.2.0",
     "uuid": "^3.4.0"
   }
 }

--- a/integration-tests/js-tests/test/firebase-client/given/firebase-client.js
+++ b/integration-tests/js-tests/test/firebase-client/given/firebase-client.js
@@ -32,15 +32,18 @@ import TestEnvironment from "../../given/test-environment";
  *
  * @param {!string} endpointUrl the URL of a backend to interact with
  * @param {?TenantProvider} tenantProvider the tenant provider for multitenant context tests
+ * @param {?Duration} keepUpInterval the custom interval for sending requests to
+ *                    keep up subscriptions in tests
  * @return {FirebaseClient} the Firebase client instance
  */
-export function initClient(endpointUrl, tenantProvider) {
+export function initClient(endpointUrl, tenantProvider, keepUpInterval) {
   return spineWeb.init({
     protoIndexFiles: [testProtobuf],
     endpointUrl: endpointUrl,
     firebaseDatabase: firebaseDatabase,
     actorProvider: new ActorProvider(),
-    tenantProvider: tenantProvider
+    tenantProvider: tenantProvider,
+    subscriptionKeepUpInterval: keepUpInterval
   });
 }
 

--- a/integration-tests/js-tests/test/firebase-client/subscribe-test.js
+++ b/integration-tests/js-tests/test/firebase-client/subscribe-test.js
@@ -28,6 +28,7 @@ import {client, initClient} from './given/firebase-client';
 import {Filters} from '@lib/client/actor-request-factory';
 import {AnyPacker} from '@lib/client/any-packer';
 import {Type} from '@lib/client/typed-message';
+import {Duration} from '@lib/client/time-utils';
 
 describe('FirebaseClient subscription', function () {
 
@@ -377,17 +378,12 @@ describe('FirebaseClient subscription', function () {
 
   describe('should be kept up', () => {
 
-    const TEST_KEEP_UP_INTERVAL = 2000;
+    const TEST_KEEP_UP_INTERVAL = new Duration({seconds: 2});
     let client;
     let sandbox;
 
     beforeEach(() => {
-      client = initClient(TestEnvironment.ENDPOINT);
-      // Decrease subscription keep up interval for tests.
-      client._subscribing._subscriptionService._keepUpInterval = () => {
-        return TEST_KEEP_UP_INTERVAL;
-      };
-
+      client = initClient(TestEnvironment.ENDPOINT, undefined, TEST_KEEP_UP_INTERVAL);
       sandbox = sinon.createSandbox();
     });
 
@@ -515,7 +511,7 @@ describe('FirebaseClient subscription', function () {
      */
     function nextInterval() {
       return new Promise(resolve =>
-          setTimeout(() => resolve(), TEST_KEEP_UP_INTERVAL + 1))
+          setTimeout(() => resolve(), TEST_KEEP_UP_INTERVAL.inMs() + 1))
     }
   });
 });

--- a/integration-tests/js-tests/test/firebase-client/subscribe-test.js
+++ b/integration-tests/js-tests/test/firebase-client/subscribe-test.js
@@ -480,10 +480,7 @@ describe('FirebaseClient subscription', function () {
     });
 
     function subscribeToAllTasks() {
-      const topic = client.newTopic()
-          .select(Task)
-          .build();
-      return client.subscribe(topic);
+      return client.subscribeTo(Task).post();
     }
 
     function checkAllTasks(subscriptionMessage) {

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client-js:1.6.0`
+# Dependencies of `io.spine:spine-client-js:1.6.1`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -389,23 +389,23 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 19 11:10:08 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
-#NPM dependencies of `spine-web@1.6.0`
+#NPM dependencies of `spine-web@1.6.1`
 
 ## `Production` dependencies:
 
-1. **base64-js@1.3.1**
+1. **base64-js@1.3.0**
      * Licenses: MIT
      * Repository: [https://github.com/beatgammit/base64-js](https://github.com/beatgammit/base64-js)
-1. **encoding@0.1.13**
+1. **encoding@0.1.12**
      * Licenses: MIT
      * Repository: [https://github.com/andris9/encoding](https://github.com/andris9/encoding)
-1. **google-protobuf@3.13.0**
+1. **google-protobuf@3.8.0**
      * Licenses: BSD-3-Clause
      * Repository: [https://github.com/protocolbuffers/protobuf/tree/master/js](https://github.com/protocolbuffers/protobuf/tree/master/js)
-1. **iconv-lite@0.6.2**
+1. **iconv-lite@0.4.24**
      * Licenses: MIT
      * Repository: [https://github.com/ashtuchkin/iconv-lite](https://github.com/ashtuchkin/iconv-lite)
 1. **is-stream@1.1.0**
@@ -417,22 +417,22 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **node-fetch@1.7.3**
      * Licenses: MIT
      * Repository: [https://github.com/bitinn/node-fetch](https://github.com/bitinn/node-fetch)
-1. **rxjs@6.5.5**
+1. **rxjs@6.5.2**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/reactivex/rxjs](https://github.com/reactivex/rxjs)
 1. **safer-buffer@2.1.2**
      * Licenses: MIT
      * Repository: [https://github.com/ChALkeR/safer-buffer](https://github.com/ChALkeR/safer-buffer)
-1. **spine-web@1.6.0**
+1. **spine-web@1.6.1**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/SpineEventEngine/web](https://github.com/SpineEventEngine/web)
-1. **tslib@1.13.0**
-     * Licenses: 0BSD
+1. **tslib@1.9.3**
+     * Licenses: Apache-2.0
      * Repository: [https://github.com/Microsoft/tslib](https://github.com/Microsoft/tslib)
 1. **uuid@3.4.0**
      * Licenses: MIT
      * Repository: [https://github.com/uuidjs/uuid](https://github.com/uuidjs/uuid)
-1. **whatwg-fetch@3.4.0**
+1. **whatwg-fetch@3.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/github/fetch](https://github.com/github/fetch)
 
@@ -440,301 +440,286 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 
 ## `Development` dependencies:
 
-1. **@babel/cli@7.10.5**
+1. **@babel/cli@7.4.4**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-cli](https://github.com/babel/babel/tree/master/packages/babel-cli)
+1. **@babel/code-frame@7.0.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-code-frame](https://github.com/babel/babel/tree/master/packages/babel-code-frame)
 1. **@babel/code-frame@7.10.4**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/compat-data@7.11.0**
+1. **@babel/core@7.12.1**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/core@7.11.4**
+1. **@babel/core@7.4.5**
+     * Licenses: MIT
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-core](https://github.com/babel/babel/tree/master/packages/babel-core)
+1. **@babel/generator@7.12.1**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/generator@7.11.4**
+1. **@babel/generator@7.4.4**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/helper-annotate-as-pure@7.10.4**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-generator](https://github.com/babel/babel/tree/master/packages/babel-generator)
+1. **@babel/helper-annotate-as-pure@7.0.0**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/helper-builder-binary-assignment-operator-visitor@7.10.4**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-helper-annotate-as-pure](https://github.com/babel/babel/tree/master/packages/babel-helper-annotate-as-pure)
+1. **@babel/helper-builder-binary-assignment-operator-visitor@7.1.0**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/helper-compilation-targets@7.10.4**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-helper-builder-binary-assignment-operator-visitor](https://github.com/babel/babel/tree/master/packages/babel-helper-builder-binary-assignment-operator-visitor)
+1. **@babel/helper-call-delegate@7.4.4**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/helper-create-class-features-plugin@7.10.5**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-helper-call-delegate](https://github.com/babel/babel/tree/master/packages/babel-helper-call-delegate)
+1. **@babel/helper-define-map@7.4.4**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/helper-create-regexp-features-plugin@7.10.4**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-helper-define-map](https://github.com/babel/babel/tree/master/packages/babel-helper-define-map)
+1. **@babel/helper-explode-assignable-expression@7.1.0**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/helper-define-map@7.10.5**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-helper-explode-assignable-expression](https://github.com/babel/babel/tree/master/packages/babel-helper-explode-assignable-expression)
+1. **@babel/helper-function-name@7.1.0**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/helper-explode-assignable-expression@7.11.4**
-     * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-helper-function-name](https://github.com/babel/babel/tree/master/packages/babel-helper-function-name)
 1. **@babel/helper-function-name@7.10.4**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
+1. **@babel/helper-get-function-arity@7.0.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-helper-get-function-arity](https://github.com/babel/babel/tree/master/packages/babel-helper-get-function-arity)
 1. **@babel/helper-get-function-arity@7.10.4**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/helper-hoist-variables@7.10.4**
+1. **@babel/helper-hoist-variables@7.4.4**
+     * Licenses: MIT
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-helper-hoist-variables](https://github.com/babel/babel/tree/master/packages/babel-helper-hoist-variables)
+1. **@babel/helper-member-expression-to-functions@7.0.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-helper-member-expression-to-functions](https://github.com/babel/babel/tree/master/packages/babel-helper-member-expression-to-functions)
+1. **@babel/helper-member-expression-to-functions@7.12.1**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/helper-member-expression-to-functions@7.11.0**
+1. **@babel/helper-module-imports@7.0.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-helper-module-imports](https://github.com/babel/babel/tree/master/packages/babel-helper-module-imports)
+1. **@babel/helper-module-imports@7.12.1**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/helper-module-imports@7.10.4**
+1. **@babel/helper-module-transforms@7.12.1**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/helper-module-transforms@7.11.0**
+1. **@babel/helper-module-transforms@7.4.4**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-helper-module-transforms](https://github.com/babel/babel/tree/master/packages/babel-helper-module-transforms)
+1. **@babel/helper-optimise-call-expression@7.0.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-helper-optimise-call-expression](https://github.com/babel/babel/tree/master/packages/babel-helper-optimise-call-expression)
 1. **@babel/helper-optimise-call-expression@7.10.4**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/helper-plugin-utils@7.10.4**
+1. **@babel/helper-plugin-utils@7.0.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-helper-plugin-utils](https://github.com/babel/babel/tree/master/packages/babel-helper-plugin-utils)
+1. **@babel/helper-regex@7.4.4**
+     * Licenses: MIT
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-helper-regex](https://github.com/babel/babel/tree/master/packages/babel-helper-regex)
+1. **@babel/helper-remap-async-to-generator@7.1.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-helper-remap-async-to-generator](https://github.com/babel/babel/tree/master/packages/babel-helper-remap-async-to-generator)
+1. **@babel/helper-replace-supers@7.12.1**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/helper-regex@7.10.5**
+1. **@babel/helper-replace-supers@7.4.4**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/helper-remap-async-to-generator@7.11.4**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-helper-replace-supers](https://github.com/babel/babel/tree/master/packages/babel-helper-replace-supers)
+1. **@babel/helper-simple-access@7.1.0**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/helper-replace-supers@7.10.4**
-     * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/helper-simple-access@7.10.4**
-     * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/helper-skip-transparent-expression-wrappers@7.11.0**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-helper-simple-access](https://github.com/babel/babel/tree/master/packages/babel-helper-simple-access)
+1. **@babel/helper-simple-access@7.12.1**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
 1. **@babel/helper-split-export-declaration@7.11.0**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
+1. **@babel/helper-split-export-declaration@7.4.4**
+     * Licenses: MIT
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-helper-split-export-declaration](https://github.com/babel/babel/tree/master/packages/babel-helper-split-export-declaration)
 1. **@babel/helper-validator-identifier@7.10.4**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/helper-wrap-function@7.10.4**
+1. **@babel/helper-wrap-function@7.2.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-helper-wrap-function](https://github.com/babel/babel/tree/master/packages/babel-helper-wrap-function)
+1. **@babel/helpers@7.12.1**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/helpers@7.10.4**
+1. **@babel/helpers@7.4.4**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-helpers](https://github.com/babel/babel/tree/master/packages/babel-helpers)
+1. **@babel/highlight@7.0.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-highlight](https://github.com/babel/babel/tree/master/packages/babel-highlight)
 1. **@babel/highlight@7.10.4**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/parser@7.11.4**
+1. **@babel/parser@7.12.2**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-proposal-async-generator-functions@7.10.5**
+1. **@babel/parser@7.4.5**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-proposal-class-properties@7.10.4**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-parser](https://github.com/babel/babel/tree/master/packages/babel-parser)
+1. **@babel/plugin-proposal-async-generator-functions@7.2.0**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-proposal-dynamic-import@7.10.4**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-async-generator-functions](https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-async-generator-functions)
+1. **@babel/plugin-proposal-json-strings@7.2.0**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-proposal-export-namespace-from@7.10.4**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-json-strings](https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-json-strings)
+1. **@babel/plugin-proposal-object-rest-spread@7.4.4**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-proposal-json-strings@7.10.4**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-object-rest-spread](https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-object-rest-spread)
+1. **@babel/plugin-proposal-optional-catch-binding@7.2.0**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-proposal-logical-assignment-operators@7.11.0**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-optional-catch-binding](https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-optional-catch-binding)
+1. **@babel/plugin-proposal-unicode-property-regex@7.4.4**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-proposal-nullish-coalescing-operator@7.10.4**
-     * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-proposal-numeric-separator@7.10.4**
-     * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-proposal-object-rest-spread@7.11.0**
-     * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-proposal-optional-catch-binding@7.10.4**
-     * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-proposal-optional-chaining@7.11.0**
-     * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-proposal-private-methods@7.10.4**
-     * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-proposal-unicode-property-regex@7.10.4**
-     * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-syntax-async-generators@7.8.4**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-unicode-property-regex](https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-unicode-property-regex)
+1. **@babel/plugin-syntax-async-generators@7.2.0**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-async-generators](https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-async-generators)
-1. **@babel/plugin-syntax-class-properties@7.10.4**
-     * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-syntax-dynamic-import@7.8.3**
-     * Licenses: MIT
-     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-dynamic-import](https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-dynamic-import)
-1. **@babel/plugin-syntax-export-namespace-from@7.8.3**
-     * Licenses: MIT
-     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-export-namespace-from](https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-export-namespace-from)
-1. **@babel/plugin-syntax-json-strings@7.8.3**
+1. **@babel/plugin-syntax-json-strings@7.2.0**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-json-strings](https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-json-strings)
-1. **@babel/plugin-syntax-logical-assignment-operators@7.10.4**
-     * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-syntax-nullish-coalescing-operator@7.8.3**
-     * Licenses: MIT
-     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-nullish-coalescing-operator](https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-nullish-coalescing-operator)
-1. **@babel/plugin-syntax-numeric-separator@7.10.4**
-     * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-syntax-object-rest-spread@7.8.3**
+1. **@babel/plugin-syntax-object-rest-spread@7.2.0**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-object-rest-spread](https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-object-rest-spread)
-1. **@babel/plugin-syntax-optional-catch-binding@7.8.3**
+1. **@babel/plugin-syntax-optional-catch-binding@7.2.0**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-optional-catch-binding](https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-optional-catch-binding)
-1. **@babel/plugin-syntax-optional-chaining@7.8.3**
+1. **@babel/plugin-transform-arrow-functions@7.2.0**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-optional-chaining](https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-optional-chaining)
-1. **@babel/plugin-syntax-top-level-await@7.10.4**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-arrow-functions](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-arrow-functions)
+1. **@babel/plugin-transform-async-to-generator@7.4.4**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-transform-arrow-functions@7.10.4**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-async-to-generator](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-async-to-generator)
+1. **@babel/plugin-transform-block-scoped-functions@7.2.0**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-transform-async-to-generator@7.10.4**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-block-scoped-functions](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-block-scoped-functions)
+1. **@babel/plugin-transform-block-scoping@7.4.4**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-transform-block-scoped-functions@7.10.4**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-block-scoping](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-block-scoping)
+1. **@babel/plugin-transform-classes@7.4.4**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-transform-block-scoping@7.11.1**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-classes](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-classes)
+1. **@babel/plugin-transform-computed-properties@7.2.0**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-transform-classes@7.10.4**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-computed-properties](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-computed-properties)
+1. **@babel/plugin-transform-destructuring@7.4.4**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-transform-computed-properties@7.10.4**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-destructuring](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-destructuring)
+1. **@babel/plugin-transform-dotall-regex@7.4.4**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-transform-destructuring@7.10.4**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-dotall-regex](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-dotall-regex)
+1. **@babel/plugin-transform-duplicate-keys@7.2.0**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-transform-dotall-regex@7.10.4**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-duplicate-keys](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-duplicate-keys)
+1. **@babel/plugin-transform-exponentiation-operator@7.2.0**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-transform-duplicate-keys@7.10.4**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-exponentiation-operator](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-exponentiation-operator)
+1. **@babel/plugin-transform-for-of@7.4.4**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-transform-exponentiation-operator@7.10.4**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-for-of](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-for-of)
+1. **@babel/plugin-transform-function-name@7.4.4**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-transform-for-of@7.10.4**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-function-name](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-function-name)
+1. **@babel/plugin-transform-literals@7.2.0**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-transform-function-name@7.10.4**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-literals](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-literals)
+1. **@babel/plugin-transform-member-expression-literals@7.2.0**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-transform-literals@7.10.4**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-member-expression-literals](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-member-expression-literals)
+1. **@babel/plugin-transform-modules-amd@7.2.0**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-transform-member-expression-literals@7.10.4**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-amd](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-amd)
+1. **@babel/plugin-transform-modules-commonjs@7.4.4**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-transform-modules-amd@7.10.5**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-commonjs](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-commonjs)
+1. **@babel/plugin-transform-modules-systemjs@7.4.4**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-transform-modules-commonjs@7.10.4**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-systemjs](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-systemjs)
+1. **@babel/plugin-transform-modules-umd@7.2.0**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-transform-modules-systemjs@7.10.5**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-umd](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-umd)
+1. **@babel/plugin-transform-named-capturing-groups-regex@7.4.5**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-transform-modules-umd@7.10.4**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-named-capturing-groups-regex](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-named-capturing-groups-regex)
+1. **@babel/plugin-transform-new-target@7.4.4**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-transform-named-capturing-groups-regex@7.10.4**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-new-target](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-new-target)
+1. **@babel/plugin-transform-object-super@7.2.0**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-transform-new-target@7.10.4**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-object-super](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-object-super)
+1. **@babel/plugin-transform-parameters@7.4.4**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-transform-object-super@7.10.4**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-parameters](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-parameters)
+1. **@babel/plugin-transform-property-literals@7.2.0**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-transform-parameters@7.10.5**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-property-literals](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-property-literals)
+1. **@babel/plugin-transform-regenerator@7.4.5**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-transform-property-literals@7.10.4**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-regenerator](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-regenerator)
+1. **@babel/plugin-transform-reserved-words@7.2.0**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-transform-regenerator@7.10.4**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-reserved-words](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-reserved-words)
+1. **@babel/plugin-transform-shorthand-properties@7.2.0**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-transform-reserved-words@7.10.4**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-shorthand-properties](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-shorthand-properties)
+1. **@babel/plugin-transform-spread@7.2.2**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-transform-shorthand-properties@7.10.4**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-spread](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-spread)
+1. **@babel/plugin-transform-sticky-regex@7.2.0**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-transform-spread@7.11.0**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-sticky-regex](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-sticky-regex)
+1. **@babel/plugin-transform-template-literals@7.4.4**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-transform-sticky-regex@7.10.4**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-template-literals](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-template-literals)
+1. **@babel/plugin-transform-typeof-symbol@7.2.0**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-transform-template-literals@7.10.5**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-typeof-symbol](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-typeof-symbol)
+1. **@babel/plugin-transform-unicode-regex@7.4.4**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-transform-typeof-symbol@7.10.4**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-unicode-regex](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-unicode-regex)
+1. **@babel/preset-env@7.4.5**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-transform-unicode-escapes@7.10.4**
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-preset-env](https://github.com/babel/babel/tree/master/packages/babel-preset-env)
+1. **@babel/register@7.4.4**
      * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-transform-unicode-regex@7.10.4**
-     * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/preset-env@7.11.0**
-     * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/preset-modules@0.1.4**
-     * Licenses: MIT
-     * Repository: unknown
-1. **@babel/register@7.10.5**
-     * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/runtime@7.11.2**
-     * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-register](https://github.com/babel/babel/tree/master/packages/babel-register)
 1. **@babel/template@7.10.4**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/traverse@7.11.0**
+1. **@babel/template@7.4.4**
+     * Licenses: MIT
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-template](https://github.com/babel/babel/tree/master/packages/babel-template)
+1. **@babel/traverse@7.12.1**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/types@7.11.0**
+1. **@babel/traverse@7.4.5**
+     * Licenses: MIT
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-traverse](https://github.com/babel/babel/tree/master/packages/babel-traverse)
+1. **@babel/types@7.12.1**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@firebase/analytics-types@0.3.1**
+1. **@babel/types@7.4.4**
+     * Licenses: MIT
+     * Repository: [https://github.com/babel/babel/tree/master/packages/babel-types](https://github.com/babel/babel/tree/master/packages/babel-types)
+1. **@firebase/analytics-types@0.4.0**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/analytics@0.4.2**
+1. **@firebase/analytics@0.6.0**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
 1. **@firebase/app-types@0.6.1**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/app@0.6.10**
+1. **@firebase/app@0.6.11**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
 1. **@firebase/auth-interop-types@0.1.5**
@@ -743,34 +728,34 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **@firebase/auth-types@0.10.1**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/auth@0.14.9**
+1. **@firebase/auth@0.15.0**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/component@0.1.18**
+1. **@firebase/component@0.1.19**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
 1. **@firebase/database-types@0.5.2**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/database@0.6.11**
+1. **@firebase/database@0.6.13**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/firestore-types@1.12.1**
+1. **@firebase/firestore-types@1.14.0**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/firestore@1.16.6**
+1. **@firebase/firestore@1.18.0**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
 1. **@firebase/functions-types@0.3.17**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/functions@0.4.50**
+1. **@firebase/functions@0.5.1**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
 1. **@firebase/installations-types@0.3.4**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/installations@0.4.16**
+1. **@firebase/installations@0.4.17**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
 1. **@firebase/logger@0.2.6**
@@ -779,13 +764,13 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **@firebase/messaging-types@0.5.0**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/messaging@0.7.0**
+1. **@firebase/messaging@0.7.1**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
 1. **@firebase/performance-types@0.0.13**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/performance@0.4.0**
+1. **@firebase/performance@0.4.2**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
 1. **@firebase/polyfill@0.3.36**
@@ -794,22 +779,22 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **@firebase/remote-config-types@0.1.9**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/remote-config@0.1.27**
+1. **@firebase/remote-config@0.1.28**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
 1. **@firebase/storage-types@0.3.13**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/storage@0.3.42**
+1. **@firebase/storage@0.3.43**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/util@0.3.1**
+1. **@firebase/util@0.3.2**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@firebase/webchannel-wrapper@0.3.0**
+1. **@firebase/webchannel-wrapper@0.4.0**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@grpc/grpc-js@1.1.5**
+1. **@grpc/grpc-js@1.1.7**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/grpc/grpc-node/tree/master/packages/grpc-js](https://github.com/grpc/grpc-node/tree/master/packages/grpc-js)
 1. **@grpc/proto-loader@0.5.5**
@@ -863,82 +848,73 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **@sinonjs/formatio@5.0.1**
      * Licenses: BSD-3-Clause
      * Repository: [https://github.com/sinonjs/formatio](https://github.com/sinonjs/formatio)
-1. **@sinonjs/samsam@5.1.0**
+1. **@sinonjs/samsam@5.2.0**
      * Licenses: BSD-3-Clause
      * Repository: [https://github.com/sinonjs/samsam](https://github.com/sinonjs/samsam)
 1. **@sinonjs/text-encoding@0.7.1**
      * Licenses: (Unlicense OR Apache-2.0)
      * Repository: [https://github.com/inexorabletash/text-encoding](https://github.com/inexorabletash/text-encoding)
-1. **@tootallnate/once@1.1.2**
-     * Licenses: MIT
-     * Repository: [https://github.com/TooTallNate/once](https://github.com/TooTallNate/once)
-1. **@types/color-name@1.1.1**
-     * Licenses: MIT
-     * Repository: [https://github.com/DefinitelyTyped/DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped)
-1. **@types/json-schema@7.0.5**
-     * Licenses: MIT
-     * Repository: [https://github.com/DefinitelyTyped/DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped)
 1. **@types/long@4.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/DefinitelyTyped/DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped)
-1. **@types/node@12.12.54**
+1. **@types/node@12.12.67**
      * Licenses: MIT
      * Repository: [https://github.com/DefinitelyTyped/DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped)
-1. **@types/node@13.13.15**
+1. **@types/node@13.13.25**
      * Licenses: MIT
      * Repository: [https://github.com/DefinitelyTyped/DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped)
-1. **@webassemblyjs/ast@1.9.0**
+1. **@webassemblyjs/ast@1.8.5**
      * Licenses: MIT
      * Repository: [https://github.com/xtuc/webassemblyjs](https://github.com/xtuc/webassemblyjs)
-1. **@webassemblyjs/floating-point-hex-parser@1.9.0**
+1. **@webassemblyjs/floating-point-hex-parser@1.8.5**
      * Licenses: MIT
      * Repository: [https://github.com/xtuc/webassemblyjs](https://github.com/xtuc/webassemblyjs)
-1. **@webassemblyjs/helper-api-error@1.9.0**
+1. **@webassemblyjs/helper-api-error@1.8.5**
      * Licenses: MIT
      * Repository: unknown
-1. **@webassemblyjs/helper-buffer@1.9.0**
+1. **@webassemblyjs/helper-buffer@1.8.5**
      * Licenses: MIT
      * Repository: [https://github.com/xtuc/webassemblyjs](https://github.com/xtuc/webassemblyjs)
-1. **@webassemblyjs/helper-code-frame@1.9.0**
+1. **@webassemblyjs/helper-code-frame@1.8.5**
      * Licenses: MIT
      * Repository: [https://github.com/xtuc/webassemblyjs](https://github.com/xtuc/webassemblyjs)
-1. **@webassemblyjs/helper-fsm@1.9.0**
+1. **@webassemblyjs/helper-fsm@1.8.5**
      * Licenses: ISC
      * Repository: unknown
-1. **@webassemblyjs/helper-module-context@1.9.0**
+1. **@webassemblyjs/helper-module-context@1.8.5**
      * Licenses: MIT
      * Repository: [https://github.com/xtuc/webassemblyjs](https://github.com/xtuc/webassemblyjs)
-1. **@webassemblyjs/helper-wasm-bytecode@1.9.0**
+1. **@webassemblyjs/helper-wasm-bytecode@1.8.5**
      * Licenses: MIT
      * Repository: [https://github.com/xtuc/webassemblyjs](https://github.com/xtuc/webassemblyjs)
-1. **@webassemblyjs/helper-wasm-section@1.9.0**
+1. **@webassemblyjs/helper-wasm-section@1.8.5**
      * Licenses: MIT
      * Repository: [https://github.com/xtuc/webassemblyjs](https://github.com/xtuc/webassemblyjs)
-1. **@webassemblyjs/ieee754@1.9.0**
+1. **@webassemblyjs/ieee754@1.8.5**
      * Licenses: MIT
      * Repository: unknown
-1. **@webassemblyjs/leb128@1.9.0**
+1. **@webassemblyjs/leb128@1.8.5**
      * Licenses: MIT
      * Repository: unknown
-1. **@webassemblyjs/utf8@1.9.0**
+1. **@webassemblyjs/utf8@1.8.5**
      * Licenses: MIT
      * Repository: [https://github.com/xtuc/webassemblyjs](https://github.com/xtuc/webassemblyjs)
-1. **@webassemblyjs/wasm-edit@1.9.0**
+1. **@webassemblyjs/wasm-edit@1.8.5**
      * Licenses: MIT
      * Repository: [https://github.com/xtuc/webassemblyjs](https://github.com/xtuc/webassemblyjs)
-1. **@webassemblyjs/wasm-gen@1.9.0**
+1. **@webassemblyjs/wasm-gen@1.8.5**
      * Licenses: MIT
      * Repository: [https://github.com/xtuc/webassemblyjs](https://github.com/xtuc/webassemblyjs)
-1. **@webassemblyjs/wasm-opt@1.9.0**
+1. **@webassemblyjs/wasm-opt@1.8.5**
      * Licenses: MIT
      * Repository: [https://github.com/xtuc/webassemblyjs](https://github.com/xtuc/webassemblyjs)
-1. **@webassemblyjs/wasm-parser@1.9.0**
+1. **@webassemblyjs/wasm-parser@1.8.5**
      * Licenses: MIT
      * Repository: [https://github.com/xtuc/webassemblyjs](https://github.com/xtuc/webassemblyjs)
-1. **@webassemblyjs/wast-parser@1.9.0**
+1. **@webassemblyjs/wast-parser@1.8.5**
      * Licenses: MIT
      * Repository: [https://github.com/xtuc/webassemblyjs](https://github.com/xtuc/webassemblyjs)
-1. **@webassemblyjs/wast-printer@1.9.0**
+1. **@webassemblyjs/wast-printer@1.8.5**
      * Licenses: MIT
      * Repository: [https://github.com/xtuc/webassemblyjs](https://github.com/xtuc/webassemblyjs)
 1. **@xtuc/ieee754@1.2.0**
@@ -953,10 +929,13 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **abort-controller@3.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/mysticatea/abort-controller](https://github.com/mysticatea/abort-controller)
-1. **acorn@6.4.1**
+1. **acorn-dynamic-import@4.0.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/kesne/acorn-dynamic-import](https://github.com/kesne/acorn-dynamic-import)
+1. **acorn@6.1.1**
      * Licenses: MIT
      * Repository: [https://github.com/acornjs/acorn](https://github.com/acornjs/acorn)
-1. **agent-base@5.1.1**
+1. **agent-base@4.3.0**
      * Licenses: MIT
      * Repository: [https://github.com/TooTallNate/node-agent-base](https://github.com/TooTallNate/node-agent-base)
 1. **agent-base@6.0.1**
@@ -968,12 +947,12 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **ajv-errors@1.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/epoberezkin/ajv-errors](https://github.com/epoberezkin/ajv-errors)
-1. **ajv-keywords@3.5.2**
+1. **ajv-keywords@3.4.0**
      * Licenses: MIT
      * Repository: [https://github.com/epoberezkin/ajv-keywords](https://github.com/epoberezkin/ajv-keywords)
-1. **ajv@6.12.4**
+1. **ajv@6.10.0**
      * Licenses: MIT
-     * Repository: [https://github.com/ajv-validator/ajv](https://github.com/ajv-validator/ajv)
+     * Repository: [https://github.com/epoberezkin/ajv](https://github.com/epoberezkin/ajv)
 1. **ansi-colors@3.2.3**
      * Licenses: MIT
      * Repository: [https://github.com/doowb/ansi-colors](https://github.com/doowb/ansi-colors)
@@ -995,7 +974,7 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **ansi-styles@3.2.1**
      * Licenses: MIT
      * Repository: [https://github.com/chalk/ansi-styles](https://github.com/chalk/ansi-styles)
-1. **ansi-styles@4.2.1**
+1. **ansi-styles@4.3.0**
      * Licenses: MIT
      * Repository: [https://github.com/chalk/ansi-styles](https://github.com/chalk/ansi-styles)
 1. **anymatch@2.0.0**
@@ -1040,7 +1019,7 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **asap@2.0.6**
      * Licenses: MIT
      * Repository: [https://github.com/kriskowal/asap](https://github.com/kriskowal/asap)
-1. **asn1.js@5.4.1**
+1. **asn1.js@4.10.1**
      * Licenses: MIT
      * Repository: [https://github.com/indutny/asn1.js](https://github.com/indutny/asn1.js)
 1. **assert@1.5.0**
@@ -1058,15 +1037,12 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **babel-code-frame@6.26.0**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-code-frame](https://github.com/babel/babel/tree/master/packages/babel-code-frame)
-1. **babel-loader@8.1.0**
+1. **babel-loader@8.0.6**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel-loader](https://github.com/babel/babel-loader)
 1. **babel-messages@6.23.0**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-messages](https://github.com/babel/babel/tree/master/packages/babel-messages)
-1. **babel-plugin-dynamic-import-node@2.3.3**
-     * Licenses: MIT
-     * Repository: [https://github.com/airbnb/babel-plugin-dynamic-import-node](https://github.com/airbnb/babel-plugin-dynamic-import-node)
 1. **babel-plugin-module-resolver@3.2.0**
      * Licenses: MIT
      * Repository: [https://github.com/tleunen/babel-plugin-module-resolver](https://github.com/tleunen/babel-plugin-module-resolver)
@@ -1097,7 +1073,7 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **big.js@5.2.2**
      * Licenses: MIT
      * Repository: [https://github.com/MikeMcl/big.js](https://github.com/MikeMcl/big.js)
-1. **bignumber.js@9.0.0**
+1. **bignumber.js@9.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/MikeMcl/bignumber.js](https://github.com/MikeMcl/bignumber.js)
 1. **binary-extensions@1.13.1**
@@ -1106,16 +1082,13 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **binary-extensions@2.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/binary-extensions](https://github.com/sindresorhus/binary-extensions)
-1. **bindings@1.5.0**
+1. **bluebird@3.5.5**
      * Licenses: MIT
-     * Repository: [https://github.com/TooTallNate/node-bindings](https://github.com/TooTallNate/node-bindings)
+     * Repository: [https://github.com/petkaantonov/bluebird](https://github.com/petkaantonov/bluebird)
 1. **bluebird@3.7.2**
      * Licenses: MIT
      * Repository: [https://github.com/petkaantonov/bluebird](https://github.com/petkaantonov/bluebird)
-1. **bn.js@4.11.9**
-     * Licenses: MIT
-     * Repository: [https://github.com/indutny/bn.js](https://github.com/indutny/bn.js)
-1. **bn.js@5.1.3**
+1. **bn.js@4.11.8**
      * Licenses: MIT
      * Repository: [https://github.com/indutny/bn.js](https://github.com/indutny/bn.js)
 1. **brace-expansion@1.1.11**
@@ -1145,13 +1118,13 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **browserify-rsa@4.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/crypto-browserify/browserify-rsa](https://github.com/crypto-browserify/browserify-rsa)
-1. **browserify-sign@4.2.1**
+1. **browserify-sign@4.0.4**
      * Licenses: ISC
      * Repository: [https://github.com/crypto-browserify/browserify-sign](https://github.com/crypto-browserify/browserify-sign)
 1. **browserify-zlib@0.2.0**
      * Licenses: MIT
      * Repository: [https://github.com/devongovett/browserify-zlib](https://github.com/devongovett/browserify-zlib)
-1. **browserslist@4.14.0**
+1. **browserslist@4.6.2**
      * Licenses: MIT
      * Repository: [https://github.com/browserslist/browserslist](https://github.com/browserslist/browserslist)
 1. **buffer-equal-constant-time@1.0.1**
@@ -1163,15 +1136,15 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **buffer-xor@1.0.3**
      * Licenses: MIT
      * Repository: [https://github.com/crypto-browserify/buffer-xor](https://github.com/crypto-browserify/buffer-xor)
-1. **buffer@4.9.2**
+1. **buffer@4.9.1**
      * Licenses: MIT
      * Repository: [https://github.com/feross/buffer](https://github.com/feross/buffer)
 1. **builtin-status-codes@3.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/bendrucker/builtin-status-codes](https://github.com/bendrucker/builtin-status-codes)
-1. **cacache@12.0.4**
+1. **cacache@11.3.2**
      * Licenses: ISC
-     * Repository: [https://github.com/npm/cacache](https://github.com/npm/cacache)
+     * Repository: [https://github.com/zkat/cacache](https://github.com/zkat/cacache)
 1. **cache-base@1.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/cache-base](https://github.com/jonschlinkert/cache-base)
@@ -1181,7 +1154,7 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **camelcase@5.3.1**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/camelcase](https://github.com/sindresorhus/camelcase)
-1. **caniuse-lite@1.0.30001120**
+1. **caniuse-lite@1.0.30000974**
      * Licenses: CC-BY-4.0
      * Repository: [https://github.com/ben-eb/caniuse-lite](https://github.com/ben-eb/caniuse-lite)
 1. **catharsis@0.8.11**
@@ -1193,16 +1166,13 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **chalk@2.4.2**
      * Licenses: MIT
      * Repository: [https://github.com/chalk/chalk](https://github.com/chalk/chalk)
-1. **chokidar@2.1.8**
+1. **chokidar@2.1.6**
      * Licenses: MIT
      * Repository: [https://github.com/paulmillr/chokidar](https://github.com/paulmillr/chokidar)
 1. **chokidar@3.3.0**
      * Licenses: MIT
      * Repository: [https://github.com/paulmillr/chokidar](https://github.com/paulmillr/chokidar)
-1. **chokidar@3.4.2**
-     * Licenses: MIT
-     * Repository: [https://github.com/paulmillr/chokidar](https://github.com/paulmillr/chokidar)
-1. **chownr@1.1.4**
+1. **chownr@1.1.1**
      * Licenses: ISC
      * Repository: [https://github.com/isaacs/chownr](https://github.com/isaacs/chownr)
 1. **chrome-trace-event@1.0.2**
@@ -1217,13 +1187,19 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **clean-stack@2.2.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/clean-stack](https://github.com/sindresorhus/clean-stack)
+1. **cliui@4.1.0**
+     * Licenses: ISC
+     * Repository: [https://github.com/yargs/cliui](https://github.com/yargs/cliui)
 1. **cliui@5.0.0**
      * Licenses: ISC
      * Repository: [https://github.com/yargs/cliui](https://github.com/yargs/cliui)
 1. **cliui@6.0.0**
      * Licenses: ISC
      * Repository: [https://github.com/yargs/cliui](https://github.com/yargs/cliui)
-1. **codecov@3.7.2**
+1. **code-point-at@1.1.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/sindresorhus/code-point-at](https://github.com/sindresorhus/code-point-at)
+1. **codecov@3.5.0**
      * Licenses: MIT
      * Repository: [https://github.com/codecov/codecov-node](https://github.com/codecov/codecov-node)
 1. **collection-visit@1.0.0**
@@ -1241,10 +1217,7 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **color-name@1.1.4**
      * Licenses: MIT
      * Repository: [https://github.com/colorjs/color-name](https://github.com/colorjs/color-name)
-1. **commander@2.20.3**
-     * Licenses: MIT
-     * Repository: [https://github.com/tj/commander.js](https://github.com/tj/commander.js)
-1. **commander@4.1.1**
+1. **commander@2.20.0**
      * Licenses: MIT
      * Repository: [https://github.com/tj/commander.js](https://github.com/tj/commander.js)
 1. **commondir@1.0.1**
@@ -1259,12 +1232,15 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **concat-stream@1.6.2**
      * Licenses: MIT
      * Repository: [https://github.com/maxogden/concat-stream](https://github.com/maxogden/concat-stream)
-1. **console-browserify@1.2.0**
+1. **console-browserify@1.1.0**
      * Licenses: MIT
-     * Repository: [https://github.com/browserify/console-browserify](https://github.com/browserify/console-browserify)
+     * Repository: [https://github.com/Raynos/console-browserify](https://github.com/Raynos/console-browserify)
 1. **constants-browserify@1.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/juliangruber/constants-browserify](https://github.com/juliangruber/constants-browserify)
+1. **convert-source-map@1.6.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/thlorenz/convert-source-map](https://github.com/thlorenz/convert-source-map)
 1. **convert-source-map@1.7.0**
      * Licenses: MIT
      * Repository: [https://github.com/thlorenz/convert-source-map](https://github.com/thlorenz/convert-source-map)
@@ -1274,10 +1250,16 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **copy-descriptor@0.1.1**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/copy-descriptor](https://github.com/jonschlinkert/copy-descriptor)
-1. **core-js-compat@3.6.5**
+1. **core-js-compat@3.1.3**
      * Licenses: MIT
      * Repository: [https://github.com/zloirock/core-js](https://github.com/zloirock/core-js)
-1. **core-js@2.6.11**
+1. **core-js-pure@3.1.3**
+     * Licenses: MIT
+     * Repository: [https://github.com/zloirock/core-js](https://github.com/zloirock/core-js)
+1. **core-js@2.6.9**
+     * Licenses: MIT
+     * Repository: [https://github.com/zloirock/core-js](https://github.com/zloirock/core-js)
+1. **core-js@3.1.3**
      * Licenses: MIT
      * Repository: [https://github.com/zloirock/core-js](https://github.com/zloirock/core-js)
 1. **core-js@3.6.5**
@@ -1286,7 +1268,7 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **core-util-is@1.0.2**
      * Licenses: MIT
      * Repository: [https://github.com/isaacs/core-util-is](https://github.com/isaacs/core-util-is)
-1. **create-ecdh@4.0.4**
+1. **create-ecdh@4.0.3**
      * Licenses: MIT
      * Repository: [https://github.com/crypto-browserify/createECDH](https://github.com/crypto-browserify/createECDH)
 1. **create-hash@1.2.0**
@@ -1304,9 +1286,12 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **crypto-browserify@3.12.0**
      * Licenses: MIT
      * Repository: [https://github.com/crypto-browserify/crypto-browserify](https://github.com/crypto-browserify/crypto-browserify)
-1. **cyclist@1.0.1**
-     * Licenses: MIT
+1. **cyclist@0.2.2**
+     * Licenses: MIT*
      * Repository: [https://github.com/mafintosh/cyclist](https://github.com/mafintosh/cyclist)
+1. **date-now@0.1.4**
+     * Licenses: MIT
+     * Repository: [https://github.com/Colingo/date-now](https://github.com/Colingo/date-now)
 1. **debug@2.6.9**
      * Licenses: MIT
      * Repository: [https://github.com/visionmedia/debug](https://github.com/visionmedia/debug)
@@ -1314,6 +1299,9 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
      * Licenses: MIT
      * Repository: [https://github.com/visionmedia/debug](https://github.com/visionmedia/debug)
 1. **debug@4.1.1**
+     * Licenses: MIT
+     * Repository: [https://github.com/visionmedia/debug](https://github.com/visionmedia/debug)
+1. **debug@4.2.0**
      * Licenses: MIT
      * Repository: [https://github.com/visionmedia/debug](https://github.com/visionmedia/debug)
 1. **debuglog@1.0.1**
@@ -1340,7 +1328,7 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **define-property@2.0.2**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/define-property](https://github.com/jonschlinkert/define-property)
-1. **des.js@1.0.1**
+1. **des.js@1.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/indutny/des.js](https://github.com/indutny/des.js)
 1. **detect-file@1.0.0**
@@ -1370,10 +1358,10 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **ecdsa-sig-formatter@1.0.11**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/Brightspace/node-ecdsa-sig-formatter](https://github.com/Brightspace/node-ecdsa-sig-formatter)
-1. **electron-to-chromium@1.3.555**
+1. **electron-to-chromium@1.3.155**
      * Licenses: ISC
      * Repository: [https://github.com/kilian/electron-to-chromium](https://github.com/kilian/electron-to-chromium)
-1. **elliptic@6.5.3**
+1. **elliptic@6.4.1**
      * Licenses: MIT
      * Repository: [https://github.com/indutny/elliptic](https://github.com/indutny/elliptic)
 1. **emoji-regex@7.0.3**
@@ -1382,13 +1370,13 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **emoji-regex@8.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/mathiasbynens/emoji-regex](https://github.com/mathiasbynens/emoji-regex)
-1. **emojis-list@3.0.0**
+1. **emojis-list@2.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/kikobeats/emojis-list](https://github.com/kikobeats/emojis-list)
-1. **end-of-stream@1.4.4**
+1. **end-of-stream@1.4.1**
      * Licenses: MIT
      * Repository: [https://github.com/mafintosh/end-of-stream](https://github.com/mafintosh/end-of-stream)
-1. **enhanced-resolve@4.3.0**
+1. **enhanced-resolve@4.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/webpack/enhanced-resolve](https://github.com/webpack/enhanced-resolve)
 1. **entities@2.0.3**
@@ -1397,7 +1385,10 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **errno@0.1.7**
      * Licenses: MIT
      * Repository: [https://github.com/rvagg/node-errno](https://github.com/rvagg/node-errno)
-1. **es-abstract@1.17.6**
+1. **es-abstract@1.17.7**
+     * Licenses: MIT
+     * Repository: [https://github.com/ljharb/es-abstract](https://github.com/ljharb/es-abstract)
+1. **es-abstract@1.18.0-next.1**
      * Licenses: MIT
      * Repository: [https://github.com/ljharb/es-abstract](https://github.com/ljharb/es-abstract)
 1. **es-to-primitive@1.2.1**
@@ -1406,9 +1397,12 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **es6-error@4.1.1**
      * Licenses: MIT
      * Repository: [https://github.com/bjyoungblood/es6-error](https://github.com/bjyoungblood/es6-error)
-1. **escalade@3.0.2**
+1. **es6-promise@4.2.8**
      * Licenses: MIT
-     * Repository: [https://github.com/lukeed/escalade](https://github.com/lukeed/escalade)
+     * Repository: [https://github.com/stefanpenner/es6-promise](https://github.com/stefanpenner/es6-promise)
+1. **es6-promisify@5.0.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/digitaldesignlabs/es6-promisify](https://github.com/digitaldesignlabs/es6-promisify)
 1. **escape-string-regexp@1.0.5**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/escape-string-regexp](https://github.com/sindresorhus/escape-string-regexp)
@@ -1424,21 +1418,24 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **esrecurse@4.2.1**
      * Licenses: BSD-2-Clause
      * Repository: [https://github.com/estools/esrecurse](https://github.com/estools/esrecurse)
-1. **estraverse@4.3.0**
+1. **estraverse@4.2.0**
      * Licenses: BSD-2-Clause
      * Repository: [https://github.com/estools/estraverse](https://github.com/estools/estraverse)
-1. **esutils@2.0.3**
-     * Licenses: BSD-2-Clause
+1. **esutils@2.0.2**
+     * Licenses: BSD
      * Repository: [https://github.com/estools/esutils](https://github.com/estools/esutils)
 1. **event-target-shim@5.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/mysticatea/event-target-shim](https://github.com/mysticatea/event-target-shim)
-1. **events@3.2.0**
+1. **events@3.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/Gozala/events](https://github.com/Gozala/events)
 1. **evp_bytestokey@1.0.3**
      * Licenses: MIT
      * Repository: [https://github.com/crypto-browserify/EVP_BytesToKey](https://github.com/crypto-browserify/EVP_BytesToKey)
+1. **execa@1.0.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/sindresorhus/execa](https://github.com/sindresorhus/execa)
 1. **expand-brackets@2.1.4**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/expand-brackets](https://github.com/jonschlinkert/expand-brackets)
@@ -1457,10 +1454,10 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **extglob@2.0.4**
      * Licenses: MIT
      * Repository: [https://github.com/micromatch/extglob](https://github.com/micromatch/extglob)
-1. **fast-deep-equal@3.1.3**
+1. **fast-deep-equal@2.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/epoberezkin/fast-deep-equal](https://github.com/epoberezkin/fast-deep-equal)
-1. **fast-json-stable-stringify@2.1.0**
+1. **fast-json-stable-stringify@2.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/epoberezkin/fast-json-stable-stringify](https://github.com/epoberezkin/fast-json-stable-stringify)
 1. **fast-text-encoding@1.0.3**
@@ -1469,12 +1466,9 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **faye-websocket@0.11.3**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/faye/faye-websocket-node](https://github.com/faye/faye-websocket-node)
-1. **figgy-pudding@3.5.2**
+1. **figgy-pudding@3.5.1**
      * Licenses: ISC
-     * Repository: [https://github.com/npm/figgy-pudding](https://github.com/npm/figgy-pudding)
-1. **file-uri-to-path@1.0.0**
-     * Licenses: MIT
-     * Repository: [https://github.com/TooTallNate/file-uri-to-path](https://github.com/TooTallNate/file-uri-to-path)
+     * Repository: [https://github.com/zkat/figgy-pudding](https://github.com/zkat/figgy-pudding)
 1. **fill-range@4.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/fill-range](https://github.com/jonschlinkert/fill-range)
@@ -1499,13 +1493,13 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **find-up@4.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/find-up](https://github.com/sindresorhus/find-up)
-1. **findup-sync@3.0.0**
+1. **findup-sync@2.0.0**
      * Licenses: MIT
-     * Repository: [https://github.com/gulpjs/findup-sync](https://github.com/gulpjs/findup-sync)
-1. **firebase@7.19.1**
+     * Repository: [https://github.com/js-cli/node-findup-sync](https://github.com/js-cli/node-findup-sync)
+1. **firebase@7.24.0**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **flat@4.1.0**
+1. **flat@4.1.1**
      * Licenses: BSD-3-Clause
      * Repository: [https://github.com/hughsk/flat](https://github.com/hughsk/flat)
 1. **flush-write-stream@1.1.1**
@@ -1535,30 +1529,30 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **fs.realpath@1.0.0**
      * Licenses: ISC
      * Repository: [https://github.com/isaacs/fs.realpath](https://github.com/isaacs/fs.realpath)
-1. **fsevents@1.2.13**
-     * Licenses: MIT
-     * Repository: [https://github.com/strongloop/fsevents](https://github.com/strongloop/fsevents)
-1. **fsevents@2.1.3**
-     * Licenses: MIT
-     * Repository: [https://github.com/fsevents/fsevents](https://github.com/fsevents/fsevents)
 1. **function-bind@1.1.1**
      * Licenses: MIT
      * Repository: [https://github.com/Raynos/function-bind](https://github.com/Raynos/function-bind)
-1. **gaxios@3.1.0**
+1. **gaxios@3.2.0**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/googleapis/gaxios](https://github.com/googleapis/gaxios)
-1. **gcp-metadata@4.1.4**
+1. **gcp-metadata@4.2.0**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/googleapis/gcp-metadata](https://github.com/googleapis/gcp-metadata)
 1. **gensync@1.0.0-beta.1**
      * Licenses: MIT
      * Repository: unknown
+1. **get-caller-file@1.0.3**
+     * Licenses: ISC
+     * Repository: [https://github.com/stefanpenner/get-caller-file](https://github.com/stefanpenner/get-caller-file)
 1. **get-caller-file@2.0.5**
      * Licenses: ISC
      * Repository: [https://github.com/stefanpenner/get-caller-file](https://github.com/stefanpenner/get-caller-file)
 1. **get-package-type@0.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/cfware/get-package-type](https://github.com/cfware/get-package-type)
+1. **get-stream@4.1.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/sindresorhus/get-stream](https://github.com/sindresorhus/get-stream)
 1. **get-value@2.0.6**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/get-value](https://github.com/jonschlinkert/get-value)
@@ -1571,19 +1565,16 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **glob@7.1.3**
      * Licenses: ISC
      * Repository: [https://github.com/isaacs/node-glob](https://github.com/isaacs/node-glob)
+1. **glob@7.1.4**
+     * Licenses: ISC
+     * Repository: [https://github.com/isaacs/node-glob](https://github.com/isaacs/node-glob)
 1. **glob@7.1.6**
      * Licenses: ISC
      * Repository: [https://github.com/isaacs/node-glob](https://github.com/isaacs/node-glob)
 1. **global-modules@1.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/global-modules](https://github.com/jonschlinkert/global-modules)
-1. **global-modules@2.0.0**
-     * Licenses: MIT
-     * Repository: [https://github.com/jonschlinkert/global-modules](https://github.com/jonschlinkert/global-modules)
 1. **global-prefix@1.0.2**
-     * Licenses: MIT
-     * Repository: [https://github.com/jonschlinkert/global-prefix](https://github.com/jonschlinkert/global-prefix)
-1. **global-prefix@3.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/global-prefix](https://github.com/jonschlinkert/global-prefix)
 1. **globals@11.12.0**
@@ -1592,19 +1583,19 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **globals@9.18.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/globals](https://github.com/sindresorhus/globals)
-1. **google-auth-library@6.0.6**
+1. **google-auth-library@6.1.1**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/googleapis/google-auth-library-nodejs](https://github.com/googleapis/google-auth-library-nodejs)
-1. **google-p12-pem@3.0.2**
+1. **google-p12-pem@3.0.3**
      * Licenses: MIT
      * Repository: [https://github.com/google/google-p12-pem](https://github.com/google/google-p12-pem)
-1. **graceful-fs@4.2.4**
+1. **graceful-fs@4.1.15**
      * Licenses: ISC
      * Repository: [https://github.com/isaacs/node-graceful-fs](https://github.com/isaacs/node-graceful-fs)
 1. **growl@1.10.5**
      * Licenses: MIT
      * Repository: [https://github.com/tj/node-growl](https://github.com/tj/node-growl)
-1. **gtoken@5.0.3**
+1. **gtoken@5.0.4**
      * Licenses: MIT
      * Repository: [https://github.com/google/node-gtoken](https://github.com/google/node-gtoken)
 1. **has-ansi@2.0.0**
@@ -1634,13 +1625,13 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **has@1.0.3**
      * Licenses: MIT
      * Repository: [https://github.com/tarruda/has](https://github.com/tarruda/has)
-1. **hash-base@3.1.0**
+1. **hash-base@3.0.4**
      * Licenses: MIT
      * Repository: [https://github.com/crypto-browserify/hash-base](https://github.com/crypto-browserify/hash-base)
 1. **hash.js@1.1.7**
      * Licenses: MIT
      * Repository: [https://github.com/indutny/hash.js](https://github.com/indutny/hash.js)
-1. **hasha@5.2.0**
+1. **hasha@5.2.2**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/hasha](https://github.com/sindresorhus/hasha)
 1. **he@1.2.0**
@@ -1652,7 +1643,7 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **homedir-polyfill@1.0.3**
      * Licenses: MIT
      * Repository: [https://github.com/doowb/homedir-polyfill](https://github.com/doowb/homedir-polyfill)
-1. **hosted-git-info@2.8.8**
+1. **hosted-git-info@2.7.1**
      * Licenses: ISC
      * Repository: [https://github.com/npm/hosted-git-info](https://github.com/npm/hosted-git-info)
 1. **html-escaper@2.0.2**
@@ -1661,13 +1652,10 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **http-parser-js@0.5.2**
      * Licenses: MIT
      * Repository: [https://github.com/creationix/http-parser-js](https://github.com/creationix/http-parser-js)
-1. **http-proxy-agent@4.0.1**
-     * Licenses: MIT
-     * Repository: [https://github.com/TooTallNate/node-http-proxy-agent](https://github.com/TooTallNate/node-http-proxy-agent)
 1. **https-browserify@1.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/substack/https-browserify](https://github.com/substack/https-browserify)
-1. **https-proxy-agent@4.0.0**
+1. **https-proxy-agent@2.2.1**
      * Licenses: MIT
      * Repository: [https://github.com/TooTallNate/node-https-proxy-agent](https://github.com/TooTallNate/node-https-proxy-agent)
 1. **https-proxy-agent@5.0.0**
@@ -1682,7 +1670,7 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **iferr@0.1.5**
      * Licenses: MIT
      * Repository: [https://github.com/shesek/iferr](https://github.com/shesek/iferr)
-1. **ignore-walk@3.0.3**
+1. **ignore-walk@3.0.1**
      * Licenses: ISC
      * Repository: [https://github.com/isaacs/ignore-walk](https://github.com/isaacs/ignore-walk)
 1. **import-local@2.0.0**
@@ -1694,9 +1682,9 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **indent-string@4.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/indent-string](https://github.com/sindresorhus/indent-string)
-1. **infer-owner@1.0.4**
-     * Licenses: ISC
-     * Repository: [https://github.com/npm/infer-owner](https://github.com/npm/infer-owner)
+1. **indexof@0.0.1**
+     * Licenses: MIT*
+     * Repository: unknown
 1. **inflight@1.0.6**
      * Licenses: ISC
      * Repository: [https://github.com/npm/inflight](https://github.com/npm/inflight)
@@ -1706,18 +1694,18 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **inherits@2.0.3**
      * Licenses: ISC
      * Repository: [https://github.com/isaacs/inherits](https://github.com/isaacs/inherits)
-1. **inherits@2.0.4**
-     * Licenses: ISC
-     * Repository: [https://github.com/isaacs/inherits](https://github.com/isaacs/inherits)
 1. **ini@1.3.5**
      * Licenses: ISC
      * Repository: [https://github.com/isaacs/ini](https://github.com/isaacs/ini)
-1. **interpret@1.4.0**
+1. **interpret@1.2.0**
      * Licenses: MIT
      * Repository: [https://github.com/gulpjs/interpret](https://github.com/gulpjs/interpret)
 1. **invariant@2.2.4**
      * Licenses: MIT
      * Repository: [https://github.com/zertosh/invariant](https://github.com/zertosh/invariant)
+1. **invert-kv@2.0.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/sindresorhus/invert-kv](https://github.com/sindresorhus/invert-kv)
 1. **is-accessor-descriptor@0.1.6**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/is-accessor-descriptor](https://github.com/jonschlinkert/is-accessor-descriptor)
@@ -1736,7 +1724,7 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **is-buffer@2.0.4**
      * Licenses: MIT
      * Repository: [https://github.com/feross/is-buffer](https://github.com/feross/is-buffer)
-1. **is-callable@1.2.0**
+1. **is-callable@1.2.2**
      * Licenses: MIT
      * Repository: [https://github.com/ljharb/is-callable](https://github.com/ljharb/is-callable)
 1. **is-data-descriptor@0.1.4**
@@ -1763,6 +1751,9 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **is-extglob@2.1.1**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/is-extglob](https://github.com/jonschlinkert/is-extglob)
+1. **is-fullwidth-code-point@1.0.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/sindresorhus/is-fullwidth-code-point](https://github.com/sindresorhus/is-fullwidth-code-point)
 1. **is-fullwidth-code-point@2.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/is-fullwidth-code-point](https://github.com/sindresorhus/is-fullwidth-code-point)
@@ -1775,12 +1766,18 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **is-glob@4.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/micromatch/is-glob](https://github.com/micromatch/is-glob)
+1. **is-negative-zero@2.0.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/ljharb/is-negative-zero](https://github.com/ljharb/is-negative-zero)
 1. **is-number@3.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/is-number](https://github.com/jonschlinkert/is-number)
 1. **is-number@7.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/is-number](https://github.com/jonschlinkert/is-number)
+1. **is-plain-obj@1.1.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/sindresorhus/is-plain-obj](https://github.com/sindresorhus/is-plain-obj)
 1. **is-plain-object@2.0.4**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/is-plain-object](https://github.com/jonschlinkert/is-plain-object)
@@ -1838,6 +1835,9 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **istanbul-reports@3.0.2**
      * Licenses: BSD-3-Clause
      * Repository: [https://github.com/istanbuljs/istanbuljs](https://github.com/istanbuljs/istanbuljs)
+1. **js-levenshtein@1.1.6**
+     * Licenses: MIT
+     * Repository: [https://github.com/gustf/js-levenshtein](https://github.com/gustf/js-levenshtein)
 1. **js-tokens@3.0.2**
      * Licenses: MIT
      * Repository: [https://github.com/lydell/js-tokens](https://github.com/lydell/js-tokens)
@@ -1850,7 +1850,7 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **js2xmlparser@4.0.1**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/michaelkourlas/node-js2xmlparser](https://github.com/michaelkourlas/node-js2xmlparser)
-1. **jsdoc@3.6.5**
+1. **jsdoc@3.6.6**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/jsdoc/jsdoc](https://github.com/jsdoc/jsdoc)
 1. **jsesc@0.5.0**
@@ -1865,9 +1865,6 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **json-parse-better-errors@1.0.2**
      * Licenses: MIT
      * Repository: [https://github.com/zkat/json-parse-better-errors](https://github.com/zkat/json-parse-better-errors)
-1. **json-parse-even-better-errors@2.3.0**
-     * Licenses: MIT
-     * Repository: [https://github.com/npm/json-parse-even-better-errors](https://github.com/npm/json-parse-even-better-errors)
 1. **json-schema-traverse@0.4.1**
      * Licenses: MIT
      * Repository: [https://github.com/epoberezkin/json-schema-traverse](https://github.com/epoberezkin/json-schema-traverse)
@@ -1877,10 +1874,13 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **json5@1.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/json5/json5](https://github.com/json5/json5)
+1. **json5@2.1.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/json5/json5](https://github.com/json5/json5)
 1. **json5@2.1.3**
      * Licenses: MIT
      * Repository: [https://github.com/json5/json5](https://github.com/json5/json5)
-1. **just-extend@4.1.0**
+1. **just-extend@4.1.1**
      * Licenses: MIT
      * Repository: [https://github.com/angus-c/just](https://github.com/angus-c/just)
 1. **jwa@2.0.0**
@@ -1898,18 +1898,15 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **kind-of@5.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/kind-of](https://github.com/jonschlinkert/kind-of)
-1. **kind-of@6.0.3**
+1. **kind-of@6.0.2**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/kind-of](https://github.com/jonschlinkert/kind-of)
 1. **klaw@3.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/jprichardson/node-klaw](https://github.com/jprichardson/node-klaw)
-1. **leven@3.1.0**
+1. **lcid@2.0.0**
      * Licenses: MIT
-     * Repository: [https://github.com/sindresorhus/leven](https://github.com/sindresorhus/leven)
-1. **levenary@1.1.1**
-     * Licenses: MIT
-     * Repository: [https://github.com/tanhauhau/levenary](https://github.com/tanhauhau/levenary)
+     * Repository: [https://github.com/sindresorhus/lcid](https://github.com/sindresorhus/lcid)
 1. **license-checker@25.0.1**
      * Licenses: BSD-3-Clause
      * Repository: [https://github.com/davglass/license-checker](https://github.com/davglass/license-checker)
@@ -1919,7 +1916,7 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **loader-runner@2.4.0**
      * Licenses: MIT
      * Repository: [https://github.com/webpack/loader-runner](https://github.com/webpack/loader-runner)
-1. **loader-utils@1.4.0**
+1. **loader-utils@1.2.3**
      * Licenses: MIT
      * Repository: [https://github.com/webpack/loader-utils](https://github.com/webpack/loader-utils)
 1. **locate-path@2.0.0**
@@ -1938,6 +1935,9 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
      * Licenses: MIT
      * Repository: [https://github.com/lodash/lodash](https://github.com/lodash/lodash)
 1. **lodash.get@4.4.2**
+     * Licenses: MIT
+     * Repository: [https://github.com/lodash/lodash](https://github.com/lodash/lodash)
+1. **lodash@4.17.11**
      * Licenses: MIT
      * Repository: [https://github.com/lodash/lodash](https://github.com/lodash/lodash)
 1. **lodash@4.17.20**
@@ -1964,6 +1964,12 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **make-dir@3.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/make-dir](https://github.com/sindresorhus/make-dir)
+1. **mamacro@0.0.3**
+     * Licenses: MIT
+     * Repository: unknown
+1. **map-age-cleaner@0.1.3**
+     * Licenses: MIT
+     * Repository: [https://github.com/SamVerschueren/map-age-cleaner](https://github.com/SamVerschueren/map-age-cleaner)
 1. **map-cache@0.2.2**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/map-cache](https://github.com/jonschlinkert/map-cache)
@@ -1985,10 +1991,10 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **mdurl@1.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/markdown-it/mdurl](https://github.com/markdown-it/mdurl)
-1. **memory-fs@0.4.1**
+1. **mem@4.3.0**
      * Licenses: MIT
-     * Repository: [https://github.com/webpack/memory-fs](https://github.com/webpack/memory-fs)
-1. **memory-fs@0.5.0**
+     * Repository: [https://github.com/sindresorhus/mem](https://github.com/sindresorhus/mem)
+1. **memory-fs@0.4.1**
      * Licenses: MIT
      * Repository: [https://github.com/webpack/memory-fs](https://github.com/webpack/memory-fs)
 1. **micromatch@3.1.10**
@@ -2000,6 +2006,9 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **mime@2.4.6**
      * Licenses: MIT
      * Repository: [https://github.com/broofa/mime](https://github.com/broofa/mime)
+1. **mimic-fn@2.1.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/sindresorhus/mimic-fn](https://github.com/sindresorhus/mimic-fn)
 1. **minimalistic-assert@1.0.1**
      * Licenses: ISC
      * Repository: [https://github.com/calvinmetcalf/minimalistic-assert](https://github.com/calvinmetcalf/minimalistic-assert)
@@ -2009,15 +2018,24 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **minimatch@3.0.4**
      * Licenses: ISC
      * Repository: [https://github.com/isaacs/minimatch](https://github.com/isaacs/minimatch)
+1. **minimist@0.0.8**
+     * Licenses: MIT
+     * Repository: [https://github.com/substack/minimist](https://github.com/substack/minimist)
+1. **minimist@1.2.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/substack/minimist](https://github.com/substack/minimist)
 1. **minimist@1.2.5**
      * Licenses: MIT
      * Repository: [https://github.com/substack/minimist](https://github.com/substack/minimist)
 1. **mississippi@3.0.0**
      * Licenses: BSD-2-Clause
      * Repository: [https://github.com/maxogden/mississippi](https://github.com/maxogden/mississippi)
-1. **mixin-deep@1.3.2**
+1. **mixin-deep@1.3.1**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/mixin-deep](https://github.com/jonschlinkert/mixin-deep)
+1. **mkdirp@0.5.1**
+     * Licenses: MIT
+     * Repository: [https://github.com/substack/node-mkdirp](https://github.com/substack/node-mkdirp)
 1. **mkdirp@0.5.5**
      * Licenses: MIT
      * Repository: [https://github.com/substack/node-mkdirp](https://github.com/substack/node-mkdirp)
@@ -2039,13 +2057,10 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **ms@2.1.2**
      * Licenses: MIT
      * Repository: [https://github.com/zeit/ms](https://github.com/zeit/ms)
-1. **nan@2.14.1**
-     * Licenses: MIT
-     * Repository: [https://github.com/nodejs/nan](https://github.com/nodejs/nan)
 1. **nanomatch@1.2.13**
      * Licenses: MIT
      * Repository: [https://github.com/micromatch/nanomatch](https://github.com/micromatch/nanomatch)
-1. **neo-async@2.6.2**
+1. **neo-async@2.6.1**
      * Licenses: MIT
      * Repository: [https://github.com/suguru03/neo-async](https://github.com/suguru03/neo-async)
 1. **nice-try@1.0.5**
@@ -2060,10 +2075,13 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **node-fetch@2.6.0**
      * Licenses: MIT
      * Repository: [https://github.com/bitinn/node-fetch](https://github.com/bitinn/node-fetch)
-1. **node-forge@0.9.1**
+1. **node-fetch@2.6.1**
+     * Licenses: MIT
+     * Repository: [https://github.com/bitinn/node-fetch](https://github.com/bitinn/node-fetch)
+1. **node-forge@0.10.0**
      * Licenses: (BSD-3-Clause OR GPL-2.0)
      * Repository: [https://github.com/digitalbazaar/forge](https://github.com/digitalbazaar/forge)
-1. **node-libs-browser@2.2.1**
+1. **node-libs-browser@2.2.0**
      * Licenses: MIT
      * Repository: [https://github.com/webpack/node-libs-browser](https://github.com/webpack/node-libs-browser)
 1. **node-modules-regexp@1.0.0**
@@ -2072,10 +2090,10 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **node-preload@0.2.1**
      * Licenses: MIT
      * Repository: [https://github.com/cfware/node-preload](https://github.com/cfware/node-preload)
-1. **node-releases@1.1.60**
+1. **node-releases@1.1.23**
      * Licenses: MIT
      * Repository: [https://github.com/chicoxyzzy/node-releases](https://github.com/chicoxyzzy/node-releases)
-1. **nopt@4.0.3**
+1. **nopt@4.0.1**
      * Licenses: ISC
      * Repository: [https://github.com/npm/nopt](https://github.com/npm/nopt)
 1. **normalize-package-data@2.5.0**
@@ -2087,9 +2105,12 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **normalize-path@3.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/normalize-path](https://github.com/jonschlinkert/normalize-path)
-1. **npm-normalize-package-bin@1.0.1**
-     * Licenses: ISC
-     * Repository: [https://github.com/npm/npm-normalize-package-bin](https://github.com/npm/npm-normalize-package-bin)
+1. **npm-run-path@2.0.2**
+     * Licenses: MIT
+     * Repository: [https://github.com/sindresorhus/npm-run-path](https://github.com/sindresorhus/npm-run-path)
+1. **number-is-nan@1.0.1**
+     * Licenses: MIT
+     * Repository: [https://github.com/sindresorhus/number-is-nan](https://github.com/sindresorhus/number-is-nan)
 1. **nyc@15.1.0**
      * Licenses: ISC
      * Repository: [https://github.com/istanbuljs/nyc](https://github.com/istanbuljs/nyc)
@@ -2111,6 +2132,9 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **object.assign@4.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/ljharb/object.assign](https://github.com/ljharb/object.assign)
+1. **object.assign@4.1.1**
+     * Licenses: MIT
+     * Repository: [https://github.com/ljharb/object.assign](https://github.com/ljharb/object.assign)
 1. **object.getownpropertydescriptors@2.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/es-shims/object.getownpropertydescriptors](https://github.com/es-shims/object.getownpropertydescriptors)
@@ -2126,16 +2150,31 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **os-homedir@1.0.2**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/os-homedir](https://github.com/sindresorhus/os-homedir)
+1. **os-locale@3.1.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/sindresorhus/os-locale](https://github.com/sindresorhus/os-locale)
 1. **os-tmpdir@1.0.2**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/os-tmpdir](https://github.com/sindresorhus/os-tmpdir)
 1. **osenv@0.1.5**
      * Licenses: ISC
      * Repository: [https://github.com/npm/osenv](https://github.com/npm/osenv)
+1. **output-file-sync@2.0.1**
+     * Licenses: ISC
+     * Repository: [https://github.com/shinnn/output-file-sync](https://github.com/shinnn/output-file-sync)
+1. **p-defer@1.0.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/sindresorhus/p-defer](https://github.com/sindresorhus/p-defer)
+1. **p-finally@1.0.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/sindresorhus/p-finally](https://github.com/sindresorhus/p-finally)
+1. **p-is-promise@2.1.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/sindresorhus/p-is-promise](https://github.com/sindresorhus/p-is-promise)
 1. **p-limit@1.3.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/p-limit](https://github.com/sindresorhus/p-limit)
-1. **p-limit@2.3.0**
+1. **p-limit@2.2.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/p-limit](https://github.com/sindresorhus/p-limit)
 1. **p-locate@2.0.0**
@@ -2159,13 +2198,13 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **package-hash@4.0.0**
      * Licenses: ISC
      * Repository: [https://github.com/novemberborn/package-hash](https://github.com/novemberborn/package-hash)
-1. **pako@1.0.11**
+1. **pako@1.0.10**
      * Licenses: (MIT AND Zlib)
      * Repository: [https://github.com/nodeca/pako](https://github.com/nodeca/pako)
-1. **parallel-transform@1.2.0**
+1. **parallel-transform@1.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/mafintosh/parallel-transform](https://github.com/mafintosh/parallel-transform)
-1. **parse-asn1@5.1.6**
+1. **parse-asn1@5.1.4**
      * Licenses: ISC
      * Repository: [https://github.com/crypto-browserify/parse-asn1](https://github.com/crypto-browserify/parse-asn1)
 1. **parse-passwd@1.0.0**
@@ -2174,7 +2213,7 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **pascalcase@0.1.1**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/pascalcase](https://github.com/jonschlinkert/pascalcase)
-1. **path-browserify@0.0.1**
+1. **path-browserify@0.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/substack/path-browserify](https://github.com/substack/path-browserify)
 1. **path-dirname@1.0.2**
@@ -2201,7 +2240,7 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **path-to-regexp@1.8.0**
      * Licenses: MIT
      * Repository: [https://github.com/pillarjs/path-to-regexp](https://github.com/pillarjs/path-to-regexp)
-1. **pbkdf2@3.1.1**
+1. **pbkdf2@3.0.17**
      * Licenses: MIT
      * Repository: [https://github.com/crypto-browserify/pbkdf2](https://github.com/crypto-browserify/pbkdf2)
 1. **picomatch@2.2.2**
@@ -2225,7 +2264,13 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **posix-character-classes@0.1.1**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/posix-character-classes](https://github.com/jonschlinkert/posix-character-classes)
-1. **process-nextick-args@2.0.1**
+1. **prettier@1.18.2**
+     * Licenses: MIT
+     * Repository: [https://github.com/prettier/prettier](https://github.com/prettier/prettier)
+1. **private@0.1.8**
+     * Licenses: MIT
+     * Repository: [https://github.com/benjamn/private](https://github.com/benjamn/private)
+1. **process-nextick-args@2.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/calvinmetcalf/process-nextick-args](https://github.com/calvinmetcalf/process-nextick-args)
 1. **process-on-spawn@1.0.0**
@@ -2282,16 +2327,13 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **read-installed@4.0.3**
      * Licenses: ISC
      * Repository: [https://github.com/isaacs/read-installed](https://github.com/isaacs/read-installed)
-1. **read-package-json@2.1.2**
+1. **read-package-json@2.0.13**
      * Licenses: ISC
      * Repository: [https://github.com/npm/read-package-json](https://github.com/npm/read-package-json)
-1. **readable-stream@2.3.7**
+1. **readable-stream@2.3.6**
      * Licenses: MIT
      * Repository: [https://github.com/nodejs/readable-stream](https://github.com/nodejs/readable-stream)
-1. **readable-stream@3.6.0**
-     * Licenses: MIT
-     * Repository: [https://github.com/nodejs/readable-stream](https://github.com/nodejs/readable-stream)
-1. **readdir-scoped-modules@1.1.0**
+1. **readdir-scoped-modules@1.0.2**
      * Licenses: ISC
      * Repository: [https://github.com/npm/readdir-scoped-modules](https://github.com/npm/readdir-scoped-modules)
 1. **readdirp@2.2.1**
@@ -2300,34 +2342,31 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **readdirp@3.2.0**
      * Licenses: MIT
      * Repository: [https://github.com/paulmillr/readdirp](https://github.com/paulmillr/readdirp)
-1. **readdirp@3.4.0**
-     * Licenses: MIT
-     * Repository: [https://github.com/paulmillr/readdirp](https://github.com/paulmillr/readdirp)
-1. **regenerate-unicode-properties@8.2.0**
+1. **regenerate-unicode-properties@8.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/mathiasbynens/regenerate-unicode-properties](https://github.com/mathiasbynens/regenerate-unicode-properties)
-1. **regenerate@1.4.1**
+1. **regenerate@1.4.0**
      * Licenses: MIT
      * Repository: [https://github.com/mathiasbynens/regenerate](https://github.com/mathiasbynens/regenerate)
 1. **regenerator-runtime@0.11.1**
      * Licenses: MIT
      * Repository: [https://github.com/facebook/regenerator/tree/master/packages/regenerator-runtime](https://github.com/facebook/regenerator/tree/master/packages/regenerator-runtime)
-1. **regenerator-runtime@0.13.7**
-     * Licenses: MIT
-     * Repository: [https://github.com/facebook/regenerator/tree/master/packages/regenerator-runtime](https://github.com/facebook/regenerator/tree/master/packages/regenerator-runtime)
-1. **regenerator-transform@0.14.5**
+1. **regenerator-transform@0.14.0**
      * Licenses: MIT
      * Repository: [https://github.com/facebook/regenerator/tree/master/packages/regenerator-transform](https://github.com/facebook/regenerator/tree/master/packages/regenerator-transform)
 1. **regex-not@1.0.2**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/regex-not](https://github.com/jonschlinkert/regex-not)
-1. **regexpu-core@4.7.0**
+1. **regexp-tree@0.1.10**
+     * Licenses: MIT
+     * Repository: [https://github.com/DmitrySoshnikov/regexp-tree](https://github.com/DmitrySoshnikov/regexp-tree)
+1. **regexpu-core@4.5.4**
      * Licenses: MIT
      * Repository: [https://github.com/mathiasbynens/regexpu-core](https://github.com/mathiasbynens/regexpu-core)
-1. **regjsgen@0.5.2**
+1. **regjsgen@0.5.0**
      * Licenses: MIT
      * Repository: [https://github.com/bnjmnt4n/regjsgen](https://github.com/bnjmnt4n/regjsgen)
-1. **regjsparser@0.6.4**
+1. **regjsparser@0.6.0**
      * Licenses: BSD-2-Clause
      * Repository: [https://github.com/jviereck/regjsparser](https://github.com/jviereck/regjsparser)
 1. **release-zalgo@1.0.0**
@@ -2345,6 +2384,9 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **require-directory@2.1.1**
      * Licenses: MIT
      * Repository: [https://github.com/troygoode/node-require-directory](https://github.com/troygoode/node-require-directory)
+1. **require-main-filename@1.0.1**
+     * Licenses: ISC
+     * Repository: [https://github.com/yargs/require-main-filename](https://github.com/yargs/require-main-filename)
 1. **require-main-filename@2.0.0**
      * Licenses: ISC
      * Repository: [https://github.com/yargs/require-main-filename](https://github.com/yargs/require-main-filename)
@@ -2369,13 +2411,13 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **resolve-url@0.2.1**
      * Licenses: MIT
      * Repository: [https://github.com/lydell/resolve-url](https://github.com/lydell/resolve-url)
-1. **resolve@1.17.0**
+1. **resolve@1.11.1**
      * Licenses: MIT
      * Repository: [https://github.com/browserify/resolve](https://github.com/browserify/resolve)
 1. **ret@0.1.15**
      * Licenses: MIT
      * Repository: [https://github.com/fent/ret.js](https://github.com/fent/ret.js)
-1. **rimraf@2.7.1**
+1. **rimraf@2.6.3**
      * Licenses: ISC
      * Repository: [https://github.com/isaacs/rimraf](https://github.com/isaacs/rimraf)
 1. **rimraf@3.0.2**
@@ -2390,34 +2432,34 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **safe-buffer@5.1.2**
      * Licenses: MIT
      * Repository: [https://github.com/feross/safe-buffer](https://github.com/feross/safe-buffer)
-1. **safe-buffer@5.2.1**
-     * Licenses: MIT
-     * Repository: [https://github.com/feross/safe-buffer](https://github.com/feross/safe-buffer)
 1. **safe-regex@1.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/substack/safe-regex](https://github.com/substack/safe-regex)
 1. **schema-utils@1.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/webpack-contrib/schema-utils](https://github.com/webpack-contrib/schema-utils)
-1. **schema-utils@2.7.0**
-     * Licenses: MIT
-     * Repository: [https://github.com/webpack/schema-utils](https://github.com/webpack/schema-utils)
+1. **semver@5.7.0**
+     * Licenses: ISC
+     * Repository: [https://github.com/npm/node-semver](https://github.com/npm/node-semver)
 1. **semver@5.7.1**
+     * Licenses: ISC
+     * Repository: [https://github.com/npm/node-semver](https://github.com/npm/node-semver)
+1. **semver@6.1.1**
      * Licenses: ISC
      * Repository: [https://github.com/npm/node-semver](https://github.com/npm/node-semver)
 1. **semver@6.3.0**
      * Licenses: ISC
      * Repository: [https://github.com/npm/node-semver](https://github.com/npm/node-semver)
-1. **semver@7.0.0**
-     * Licenses: ISC
-     * Repository: [https://github.com/npm/node-semver](https://github.com/npm/node-semver)
-1. **serialize-javascript@4.0.0**
+1. **serialize-javascript@1.7.0**
      * Licenses: BSD-3-Clause
      * Repository: [https://github.com/yahoo/serialize-javascript](https://github.com/yahoo/serialize-javascript)
 1. **set-blocking@2.0.0**
      * Licenses: ISC
      * Repository: [https://github.com/yargs/set-blocking](https://github.com/yargs/set-blocking)
-1. **set-value@2.0.1**
+1. **set-value@0.4.3**
+     * Licenses: MIT
+     * Repository: [https://github.com/jonschlinkert/set-value](https://github.com/jonschlinkert/set-value)
+1. **set-value@2.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/set-value](https://github.com/jonschlinkert/set-value)
 1. **setimmediate@1.0.5**
@@ -2438,12 +2480,15 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **shebang-regex@3.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/shebang-regex](https://github.com/sindresorhus/shebang-regex)
-1. **signal-exit@3.0.3**
+1. **signal-exit@3.0.2**
      * Licenses: ISC
      * Repository: [https://github.com/tapjs/signal-exit](https://github.com/tapjs/signal-exit)
-1. **sinon@9.0.3**
+1. **sinon@9.2.0**
      * Licenses: BSD-3-Clause
      * Repository: [https://github.com/sinonjs/sinon](https://github.com/sinonjs/sinon)
+1. **slash@1.0.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/sindresorhus/slash](https://github.com/sindresorhus/slash)
 1. **slash@2.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/slash](https://github.com/sindresorhus/slash)
@@ -2462,10 +2507,10 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **source-list-map@2.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/webpack/source-list-map](https://github.com/webpack/source-list-map)
-1. **source-map-resolve@0.5.3**
+1. **source-map-resolve@0.5.2**
      * Licenses: MIT
      * Repository: [https://github.com/lydell/source-map-resolve](https://github.com/lydell/source-map-resolve)
-1. **source-map-support@0.5.19**
+1. **source-map-support@0.5.12**
      * Licenses: MIT
      * Repository: [https://github.com/evanw/node-source-map-support](https://github.com/evanw/node-source-map-support)
 1. **source-map-url@0.4.0**
@@ -2483,25 +2528,25 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **spdx-compare@1.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/kemitchell/spdx-compare.js](https://github.com/kemitchell/spdx-compare.js)
-1. **spdx-correct@3.1.1**
+1. **spdx-correct@3.1.0**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/jslicense/spdx-correct.js](https://github.com/jslicense/spdx-correct.js)
-1. **spdx-exceptions@2.3.0**
+1. **spdx-exceptions@2.2.0**
      * Licenses: CC-BY-3.0
      * Repository: [https://github.com/kemitchell/spdx-exceptions.json](https://github.com/kemitchell/spdx-exceptions.json)
-1. **spdx-expression-parse@3.0.1**
+1. **spdx-expression-parse@3.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/jslicense/spdx-expression-parse.js](https://github.com/jslicense/spdx-expression-parse.js)
-1. **spdx-license-ids@3.0.5**
+1. **spdx-license-ids@3.0.4**
      * Licenses: CC0-1.0
      * Repository: [https://github.com/shinnn/spdx-license-ids](https://github.com/shinnn/spdx-license-ids)
-1. **spdx-ranges@2.1.1**
-     * Licenses: (MIT AND CC-BY-3.0)
+1. **spdx-ranges@2.1.0**
+     * Licenses: CC-BY-3.0
      * Repository: [https://github.com/kemitchell/spdx-ranges.js](https://github.com/kemitchell/spdx-ranges.js)
 1. **spdx-satisfies@4.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/kemitchell/spdx-satisfies.js](https://github.com/kemitchell/spdx-satisfies.js)
-1. **spine-web@1.6.0**
+1. **spine-web@1.6.1**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/SpineEventEngine/web](https://github.com/SpineEventEngine/web)
 1. **split-string@3.1.0**
@@ -2522,15 +2567,15 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **stream-each@1.2.3**
      * Licenses: MIT
      * Repository: [https://github.com/mafintosh/stream-each](https://github.com/mafintosh/stream-each)
-1. **stream-events@1.0.5**
-     * Licenses: MIT
-     * Repository: [https://github.com/stephenplusplus/stream-events](https://github.com/stephenplusplus/stream-events)
 1. **stream-http@2.8.3**
      * Licenses: MIT
      * Repository: [https://github.com/jhiesey/stream-http](https://github.com/jhiesey/stream-http)
-1. **stream-shift@1.0.1**
+1. **stream-shift@1.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/mafintosh/stream-shift](https://github.com/mafintosh/stream-shift)
+1. **string-width@1.0.2**
+     * Licenses: MIT
+     * Repository: [https://github.com/sindresorhus/string-width](https://github.com/sindresorhus/string-width)
 1. **string-width@2.1.1**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/string-width](https://github.com/sindresorhus/string-width)
@@ -2564,15 +2609,15 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **strip-bom@4.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/strip-bom](https://github.com/sindresorhus/strip-bom)
+1. **strip-eof@1.0.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/sindresorhus/strip-eof](https://github.com/sindresorhus/strip-eof)
 1. **strip-json-comments@2.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/strip-json-comments](https://github.com/sindresorhus/strip-json-comments)
 1. **strip-json-comments@3.1.1**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/strip-json-comments](https://github.com/sindresorhus/strip-json-comments)
-1. **stubs@3.0.0**
-     * Licenses: MIT
-     * Repository: [https://github.com/stephenplusplus/stubs](https://github.com/stephenplusplus/stubs)
 1. **supports-color@2.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/chalk/supports-color](https://github.com/chalk/supports-color)
@@ -2580,9 +2625,6 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
      * Licenses: MIT
      * Repository: [https://github.com/chalk/supports-color](https://github.com/chalk/supports-color)
 1. **supports-color@6.0.0**
-     * Licenses: MIT
-     * Repository: [https://github.com/chalk/supports-color](https://github.com/chalk/supports-color)
-1. **supports-color@6.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/chalk/supports-color](https://github.com/chalk/supports-color)
 1. **supports-color@7.2.0**
@@ -2594,22 +2636,22 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **tapable@1.1.3**
      * Licenses: MIT
      * Repository: [https://github.com/webpack/tapable](https://github.com/webpack/tapable)
-1. **teeny-request@6.0.1**
+1. **teeny-request@3.11.3**
      * Licenses: Apache-2.0
-     * Repository: [https://github.com/googleapis/teeny-request](https://github.com/googleapis/teeny-request)
-1. **terser-webpack-plugin@1.4.5**
+     * Repository: [https://github.com/fhinkel/teeny-request](https://github.com/fhinkel/teeny-request)
+1. **terser-webpack-plugin@1.3.0**
      * Licenses: MIT
      * Repository: [https://github.com/webpack-contrib/terser-webpack-plugin](https://github.com/webpack-contrib/terser-webpack-plugin)
-1. **terser@4.8.0**
+1. **terser@4.0.0**
      * Licenses: BSD-2-Clause
-     * Repository: [https://github.com/terser/terser](https://github.com/terser/terser)
+     * Repository: [https://github.com/fabiosantoscode/terser](https://github.com/fabiosantoscode/terser)
 1. **test-exclude@6.0.0**
      * Licenses: ISC
      * Repository: [https://github.com/istanbuljs/test-exclude](https://github.com/istanbuljs/test-exclude)
 1. **through2@2.0.5**
      * Licenses: MIT
      * Repository: [https://github.com/rvagg/through2](https://github.com/rvagg/through2)
-1. **timers-browserify@2.0.11**
+1. **timers-browserify@2.0.10**
      * Licenses: MIT
      * Repository: [https://github.com/jryans/timers-browserify](https://github.com/jryans/timers-browserify)
 1. **to-arraybuffer@1.0.1**
@@ -2636,6 +2678,12 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **treeify@1.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/notatestuser/treeify](https://github.com/notatestuser/treeify)
+1. **trim-right@1.0.1**
+     * Licenses: MIT
+     * Repository: [https://github.com/sindresorhus/trim-right](https://github.com/sindresorhus/trim-right)
+1. **tslib@1.14.1**
+     * Licenses: 0BSD
+     * Repository: [https://github.com/Microsoft/tslib](https://github.com/Microsoft/tslib)
 1. **tty-browserify@0.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/substack/tty-browserify](https://github.com/substack/tty-browserify)
@@ -2663,28 +2711,28 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **unicode-match-property-ecmascript@1.0.4**
      * Licenses: MIT
      * Repository: [https://github.com/mathiasbynens/unicode-match-property-ecmascript](https://github.com/mathiasbynens/unicode-match-property-ecmascript)
-1. **unicode-match-property-value-ecmascript@1.2.0**
+1. **unicode-match-property-value-ecmascript@1.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/mathiasbynens/unicode-match-property-value-ecmascript](https://github.com/mathiasbynens/unicode-match-property-value-ecmascript)
-1. **unicode-property-aliases-ecmascript@1.1.0**
+1. **unicode-property-aliases-ecmascript@1.0.5**
      * Licenses: MIT
      * Repository: [https://github.com/mathiasbynens/unicode-property-aliases-ecmascript](https://github.com/mathiasbynens/unicode-property-aliases-ecmascript)
-1. **union-value@1.0.1**
+1. **union-value@1.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/union-value](https://github.com/jonschlinkert/union-value)
 1. **unique-filename@1.1.1**
      * Licenses: ISC
      * Repository: [https://github.com/iarna/unique-filename](https://github.com/iarna/unique-filename)
-1. **unique-slug@2.0.2**
+1. **unique-slug@2.0.1**
      * Licenses: ISC
      * Repository: [https://github.com/iarna/unique-slug](https://github.com/iarna/unique-slug)
 1. **unset-value@1.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/unset-value](https://github.com/jonschlinkert/unset-value)
-1. **upath@1.2.0**
+1. **upath@1.1.2**
      * Licenses: MIT
      * Repository: [https://github.com/anodynos/upath](https://github.com/anodynos/upath)
-1. **uri-js@4.4.0**
+1. **uri-js@4.2.2**
      * Licenses: BSD-2-Clause
      * Repository: [https://github.com/garycourt/uri-js](https://github.com/garycourt/uri-js)
 1. **urix@0.1.0**
@@ -2711,31 +2759,28 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **util@0.11.1**
      * Licenses: MIT
      * Repository: [https://github.com/defunctzombie/node-util](https://github.com/defunctzombie/node-util)
-1. **v8-compile-cache@2.1.1**
+1. **v8-compile-cache@2.0.3**
      * Licenses: MIT
      * Repository: [https://github.com/zertosh/v8-compile-cache](https://github.com/zertosh/v8-compile-cache)
 1. **validate-npm-package-license@3.0.4**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/kemitchell/validate-npm-package-license.js](https://github.com/kemitchell/validate-npm-package-license.js)
-1. **vm-browserify@1.1.2**
+1. **vm-browserify@0.0.4**
      * Licenses: MIT
      * Repository: [https://github.com/substack/vm-browserify](https://github.com/substack/vm-browserify)
-1. **watchpack-chokidar2@2.0.0**
+1. **watchpack@1.6.0**
      * Licenses: MIT
      * Repository: [https://github.com/webpack/watchpack](https://github.com/webpack/watchpack)
-1. **watchpack@1.7.4**
-     * Licenses: MIT
-     * Repository: [https://github.com/webpack/watchpack](https://github.com/webpack/watchpack)
-1. **webpack-cli@3.3.12**
+1. **webpack-cli@3.3.4**
      * Licenses: MIT
      * Repository: [https://github.com/webpack/webpack-cli](https://github.com/webpack/webpack-cli)
-1. **webpack-merge@4.2.2**
+1. **webpack-merge@4.2.1**
      * Licenses: MIT
      * Repository: [https://github.com/survivejs/webpack-merge](https://github.com/survivejs/webpack-merge)
-1. **webpack-sources@1.4.3**
+1. **webpack-sources@1.3.0**
      * Licenses: MIT
      * Repository: [https://github.com/webpack/webpack-sources](https://github.com/webpack/webpack-sources)
-1. **webpack@4.44.1**
+1. **webpack@4.33.0**
      * Licenses: MIT
      * Repository: [https://github.com/webpack/webpack](https://github.com/webpack/webpack)
 1. **websocket-driver@0.7.4**
@@ -2762,6 +2807,9 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **worker-farm@1.7.0**
      * Licenses: MIT
      * Repository: [https://github.com/rvagg/node-worker-farm](https://github.com/rvagg/node-worker-farm)
+1. **wrap-ansi@2.1.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/chalk/wrap-ansi](https://github.com/chalk/wrap-ansi)
 1. **wrap-ansi@5.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/chalk/wrap-ansi](https://github.com/chalk/wrap-ansi)
@@ -2780,18 +2828,24 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **xmlhttprequest@1.8.0**
      * Licenses: MIT
      * Repository: [https://github.com/driverdan/node-XMLHttpRequest](https://github.com/driverdan/node-XMLHttpRequest)
-1. **xtend@4.0.2**
+1. **xtend@4.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/Raynos/xtend](https://github.com/Raynos/xtend)
+1. **y18n@3.2.1**
+     * Licenses: ISC
+     * Repository: [https://github.com/yargs/y18n](https://github.com/yargs/y18n)
 1. **y18n@4.0.0**
      * Licenses: ISC
      * Repository: [https://github.com/yargs/y18n](https://github.com/yargs/y18n)
-1. **yallist@3.1.1**
+1. **yallist@3.0.3**
      * Licenses: ISC
      * Repository: [https://github.com/isaacs/yallist](https://github.com/isaacs/yallist)
 1. **yallist@4.0.0**
      * Licenses: ISC
      * Repository: [https://github.com/isaacs/yallist](https://github.com/isaacs/yallist)
+1. **yargs-parser@11.1.1**
+     * Licenses: ISC
+     * Repository: [https://github.com/yargs/yargs-parser](https://github.com/yargs/yargs-parser)
 1. **yargs-parser@13.1.2**
      * Licenses: ISC
      * Repository: [https://github.com/yargs/yargs-parser](https://github.com/yargs/yargs-parser)
@@ -2801,6 +2855,9 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
 1. **yargs-unparser@1.6.0**
      * Licenses: MIT
      * Repository: [https://github.com/yargs/yargs-unparser](https://github.com/yargs/yargs-unparser)
+1. **yargs@12.0.5**
+     * Licenses: MIT
+     * Repository: [https://github.com/yargs/yargs](https://github.com/yargs/yargs)
 1. **yargs@13.3.2**
      * Licenses: MIT
      * Repository: [https://github.com/yargs/yargs](https://github.com/yargs/yargs)
@@ -2809,12 +2866,12 @@ This report was generated on **Tue Sep 08 22:23:33 EEST 2020** using [Gradle-Lic
      * Repository: [https://github.com/yargs/yargs](https://github.com/yargs/yargs)
 
 
-This report was generated on **Tue Sep 08 2020 22:23:35 GMT+0300 (Eastern European Summer Time)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
+This report was generated on **Mon Oct 19 2020 11:10:10 GMT+0300 (Eastern European Summer Time)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
 
 
 
     
-# Dependencies of `io.spine.gcloud:spine-firebase-web:1.6.0`
+# Dependencies of `io.spine.gcloud:spine-firebase-web:1.6.1`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson.core **Name:** jackson-annotations **Version:** 2.9.10
@@ -3642,12 +3699,12 @@ This report was generated on **Tue Sep 08 2020 22:23:35 GMT+0300 (Eastern Europe
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Sep 08 22:23:40 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 19 11:10:16 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-js-tests:1.6.0`
+# Dependencies of `io.spine:spine-js-tests:1.6.1`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -4068,12 +4125,12 @@ This report was generated on **Tue Sep 08 22:23:40 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Sep 08 22:23:47 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 19 11:10:30 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-test-app:1.6.0`
+# Dependencies of `io.spine:spine-test-app:1.6.1`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson.core **Name:** jackson-annotations **Version:** 2.9.10
@@ -5651,12 +5708,12 @@ This report was generated on **Tue Sep 08 22:23:47 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Sep 08 22:23:50 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 19 11:10:34 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-web:1.6.0`
+# Dependencies of `io.spine:spine-testutil-web:1.6.1`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -6136,12 +6193,12 @@ This report was generated on **Tue Sep 08 22:23:50 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Sep 08 22:23:50 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 19 11:10:35 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-web:1.6.0`
+# Dependencies of `io.spine:spine-web:1.6.1`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -6660,4 +6717,4 @@ This report was generated on **Tue Sep 08 22:23:50 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Sep 08 22:23:52 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 19 11:10:37 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-web</artifactId>
-<version>1.6.0</version>
+<version>1.6.1</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@ val spineCoreVersion: String by extra("1.6.0")
 val spineVersion: String by extra(spineCoreVersion)
 
 val versionToPublish: String by extra("1.6.0")
-val versionToPublishJs: String by extra("1.6.0")
+val versionToPublishJs: String by extra("1.6.1")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -23,5 +23,5 @@ val spineTimeVersion: String by extra("1.6.0")
 val spineCoreVersion: String by extra("1.6.0")
 val spineVersion: String by extra(spineCoreVersion)
 
-val versionToPublish: String by extra("1.6.0")
+val versionToPublish: String by extra("1.6.1")
 val versionToPublishJs: String by extra("1.6.1")


### PR DESCRIPTION
This PR brings changes enabling sending of requests for keeping up and cancelling Firebase subscriptions.

The following fixes were made:
 - remove methods of `FirebaseSubscriptionService` making it `run()` and `stop()`. This service now can run and stop itself depending on presence of subscriptions it manages.
 - fix callback notifying subscribers of entity (event) subscriptions, that a subscription is closed. 
 - added integration tests making sure that `/subscription/keep-up` and `/subscription/cancel` requests are sent correctly during a subscription lifecycle.