### PR TITLE
Version increment check

### DIFF
--- a/.github/workflows/increment_guard.yml
+++ b/.github/workflows/increment_guard.yml
@@ -1,0 +1,26 @@
+# Ensures that the current lib version is not yet published but executing the Gradle
+# `checkVersionIncrement` task.
+
+name: Check version increment
+
+on:
+  push:
+    branches: '**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Pull config
+        run: git submodule update --init --recursive
+
+      - name: Check version is not yet published
+        shell: bash
+        run: ./gradlew checkVersionIncrement

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -25,24 +25,6 @@
         <ANNO name="org.junit.jupiter.api.Test" />
       </REPEAT_ANNOTATIONS>
     </JavaCodeStyleSettings>
-    <JetCodeStyleSettings>
-      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
-        <value>
-          <package name="java.util" alias="false" withSubpackages="false" />
-          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
-          <package name="io.ktor" alias="false" withSubpackages="true" />
-        </value>
-      </option>
-      <option name="PACKAGES_IMPORT_LAYOUT">
-        <value>
-          <package name="" alias="false" withSubpackages="true" />
-          <package name="java" alias="false" withSubpackages="true" />
-          <package name="javax" alias="false" withSubpackages="true" />
-          <package name="kotlin" alias="false" withSubpackages="true" />
-          <package name="" alias="true" withSubpackages="true" />
-        </value>
-      </option>
-    </JetCodeStyleSettings>
     <XML>
       <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
     </XML>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -35,8 +35,5 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK" />
-  <component name="WebPackConfiguration">
-    <option name="path" value="$PROJECT_DIR$/client-js/test/webpack-test.config.js" />
-  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK" />
 </project>

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spine-web",
-  "version": "1.6.12",
+  "version": "1.6.15",
   "license": "Apache-2.0",
   "description": "A JS client for interacting with Spine applications.",
   "homepage": "https://spine.io",

--- a/integration-tests/js-tests/package.json
+++ b/integration-tests/js-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-js-tests",
-  "version": "1.6.12",
+  "version": "1.6.15",
   "license": "Apache-2.0",
   "description": "Tests of a `spine-web` JS library against the Spine-based application.",
   "scripts": {

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client-js:1.6.12`
+# Dependencies of `io.spine:spine-client-js:1.6.15`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -388,17 +388,17 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 23 17:08:56 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
-#NPM dependencies of `spine-web@1.6.12`
+#NPM dependencies of `spine-web@1.6.15`
 
 ## `Production` dependencies:
 
 1. **base64-js@1.3.1**
      * Licenses: MIT
      * Repository: [https://github.com/beatgammit/base64-js](https://github.com/beatgammit/base64-js)
-1. **google-protobuf@3.13.0**
+1. **google-protobuf@3.14.0**
      * Licenses: BSD-3-Clause
      * Repository: [https://github.com/protocolbuffers/protobuf/tree/master/js](https://github.com/protocolbuffers/protobuf/tree/master/js)
 1. **isomorphic-fetch@3.0.0**
@@ -410,7 +410,7 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **rxjs@6.5.5**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/reactivex/rxjs](https://github.com/reactivex/rxjs)
-1. **spine-web@1.6.12**
+1. **spine-web@1.6.15**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/SpineEventEngine/web](https://github.com/SpineEventEngine/web)
 1. **tslib@1.14.1**
@@ -419,7 +419,7 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **uuid@8.3.1**
      * Licenses: MIT
      * Repository: [https://github.com/uuidjs/uuid](https://github.com/uuidjs/uuid)
-1. **whatwg-fetch@3.4.1**
+1. **whatwg-fetch@3.5.0**
      * Licenses: MIT
      * Repository: [https://github.com/github/fetch](https://github.com/github/fetch)
 
@@ -427,16 +427,16 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 
 ## `Development` dependencies:
 
-1. **@babel/cli@7.12.1**
+1. **@babel/cli@7.12.7**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
 1. **@babel/code-frame@7.10.4**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/compat-data@7.12.5**
+1. **@babel/compat-data@7.12.7**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/core@7.12.3**
+1. **@babel/core@7.12.7**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
 1. **@babel/generator@7.12.5**
@@ -454,7 +454,7 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **@babel/helper-create-class-features-plugin@7.12.1**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/helper-create-regexp-features-plugin@7.12.1**
+1. **@babel/helper-create-regexp-features-plugin@7.12.7**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
 1. **@babel/helper-define-map@7.10.5**
@@ -472,7 +472,7 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **@babel/helper-hoist-variables@7.10.4**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/helper-member-expression-to-functions@7.12.1**
+1. **@babel/helper-member-expression-to-functions@7.12.7**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
 1. **@babel/helper-module-imports@7.12.5**
@@ -481,13 +481,10 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **@babel/helper-module-transforms@7.12.1**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/helper-optimise-call-expression@7.10.4**
+1. **@babel/helper-optimise-call-expression@7.12.7**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
 1. **@babel/helper-plugin-utils@7.10.4**
-     * Licenses: MIT
-     * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/helper-regex@7.10.5**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
 1. **@babel/helper-remap-async-to-generator@7.12.1**
@@ -520,7 +517,7 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **@babel/highlight@7.10.4**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/parser@7.12.5**
+1. **@babel/parser@7.12.7**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
 1. **@babel/plugin-proposal-async-generator-functions@7.12.1**
@@ -544,7 +541,7 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **@babel/plugin-proposal-nullish-coalescing-operator@7.12.1**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-proposal-numeric-separator@7.12.5**
+1. **@babel/plugin-proposal-numeric-separator@7.12.7**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
 1. **@babel/plugin-proposal-object-rest-spread@7.12.1**
@@ -553,7 +550,7 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **@babel/plugin-proposal-optional-catch-binding@7.12.1**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-proposal-optional-chaining@7.12.1**
+1. **@babel/plugin-proposal-optional-chaining@7.12.7**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
 1. **@babel/plugin-proposal-private-methods@7.12.1**
@@ -679,7 +676,7 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **@babel/plugin-transform-spread@7.12.1**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-transform-sticky-regex@7.12.1**
+1. **@babel/plugin-transform-sticky-regex@7.12.7**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
 1. **@babel/plugin-transform-template-literals@7.12.1**
@@ -694,7 +691,7 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **@babel/plugin-transform-unicode-regex@7.12.1**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/preset-env@7.12.1**
+1. **@babel/preset-env@7.12.7**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
 1. **@babel/preset-modules@0.1.4**
@@ -706,13 +703,13 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **@babel/runtime@7.12.5**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/template@7.10.4**
+1. **@babel/template@7.12.7**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/traverse@7.12.5**
+1. **@babel/traverse@7.12.7**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/types@7.12.6**
+1. **@babel/types@7.12.7**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
 1. **@firebase/analytics-types@0.4.0**
@@ -799,13 +796,10 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **@firebase/webchannel-wrapper@0.4.0**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@grpc/grpc-js@1.1.8**
+1. **@grpc/grpc-js@1.2.1**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/grpc/grpc-node/tree/master/packages/grpc-js](https://github.com/grpc/grpc-node/tree/master/packages/grpc-js)
 1. **@grpc/proto-loader@0.5.5**
-     * Licenses: Apache-2.0
-     * Repository: [https://github.com/grpc/grpc-node](https://github.com/grpc/grpc-node)
-1. **@grpc/proto-loader@0.6.0-pre9**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/grpc/grpc-node](https://github.com/grpc/grpc-node)
 1. **@istanbuljs/load-nyc-config@1.1.0**
@@ -814,7 +808,7 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **@istanbuljs/schema@0.1.2**
      * Licenses: MIT
      * Repository: [https://github.com/istanbuljs/schema](https://github.com/istanbuljs/schema)
-1. **@nicolo-ribaudo/chokidar-2@2.1.8**
+1. **@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents**
      * Licenses: MIT
      * Repository: [https://github.com/nicolo-ribaudo/chokidar-2](https://github.com/nicolo-ribaudo/chokidar-2)
 1. **@protobufjs/aspromise@1.1.2**
@@ -856,7 +850,7 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **@sinonjs/formatio@5.0.1**
      * Licenses: BSD-3-Clause
      * Repository: [https://github.com/sinonjs/formatio](https://github.com/sinonjs/formatio)
-1. **@sinonjs/samsam@5.2.0**
+1. **@sinonjs/samsam@5.3.0**
      * Licenses: BSD-3-Clause
      * Repository: [https://github.com/sinonjs/samsam](https://github.com/sinonjs/samsam)
 1. **@sinonjs/text-encoding@0.7.1**
@@ -865,16 +859,19 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **@tootallnate/once@1.1.2**
      * Licenses: MIT
      * Repository: [https://github.com/TooTallNate/once](https://github.com/TooTallNate/once)
+1. **@types/color-name@1.1.1**
+     * Licenses: MIT
+     * Repository: [https://github.com/DefinitelyTyped/DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped)
 1. **@types/json-schema@7.0.6**
      * Licenses: MIT
      * Repository: [https://github.com/DefinitelyTyped/DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped)
 1. **@types/long@4.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/DefinitelyTyped/DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped)
-1. **@types/node@12.19.3**
+1. **@types/node@12.19.6**
      * Licenses: MIT
      * Repository: [https://github.com/DefinitelyTyped/DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped)
-1. **@types/node@13.13.30**
+1. **@types/node@13.13.32**
      * Licenses: MIT
      * Repository: [https://github.com/DefinitelyTyped/DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped)
 1. **@ungap/promise-all-settled@1.1.2**
@@ -961,7 +958,7 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **agent-base@6.0.2**
      * Licenses: MIT
      * Repository: [https://github.com/TooTallNate/node-agent-base](https://github.com/TooTallNate/node-agent-base)
-1. **aggregate-error@3.1.0**
+1. **aggregate-error@3.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/aggregate-error](https://github.com/sindresorhus/aggregate-error)
 1. **ajv-errors@1.0.1**
@@ -992,6 +989,9 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
      * Licenses: MIT
      * Repository: [https://github.com/chalk/ansi-styles](https://github.com/chalk/ansi-styles)
 1. **ansi-styles@3.2.1**
+     * Licenses: MIT
+     * Repository: [https://github.com/chalk/ansi-styles](https://github.com/chalk/ansi-styles)
+1. **ansi-styles@4.2.1**
      * Licenses: MIT
      * Repository: [https://github.com/chalk/ansi-styles](https://github.com/chalk/ansi-styles)
 1. **ansi-styles@4.3.0**
@@ -1060,7 +1060,7 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **babel-code-frame@6.26.0**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel/tree/master/packages/babel-code-frame](https://github.com/babel/babel/tree/master/packages/babel-code-frame)
-1. **babel-loader@8.1.0**
+1. **babel-loader@8.2.1**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel-loader](https://github.com/babel/babel-loader)
 1. **babel-messages@6.23.0**
@@ -1108,6 +1108,9 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **binary-extensions@2.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/binary-extensions](https://github.com/sindresorhus/binary-extensions)
+1. **bindings@1.5.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/TooTallNate/node-bindings](https://github.com/TooTallNate/node-bindings)
 1. **bluebird@3.7.2**
      * Licenses: MIT
      * Repository: [https://github.com/petkaantonov/bluebird](https://github.com/petkaantonov/bluebird)
@@ -1141,7 +1144,7 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **browserify-des@1.0.2**
      * Licenses: MIT
      * Repository: [https://github.com/crypto-browserify/browserify-des](https://github.com/crypto-browserify/browserify-des)
-1. **browserify-rsa@4.0.1**
+1. **browserify-rsa@4.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/crypto-browserify/browserify-rsa](https://github.com/crypto-browserify/browserify-rsa)
 1. **browserify-sign@4.2.1**
@@ -1150,7 +1153,7 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **browserify-zlib@0.2.0**
      * Licenses: MIT
      * Repository: [https://github.com/devongovett/browserify-zlib](https://github.com/devongovett/browserify-zlib)
-1. **browserslist@4.14.6**
+1. **browserslist@4.14.7**
      * Licenses: MIT
      * Repository: [https://github.com/browserslist/browserslist](https://github.com/browserslist/browserslist)
 1. **buffer-equal-constant-time@1.0.1**
@@ -1186,7 +1189,7 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **camelcase@6.2.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/camelcase](https://github.com/sindresorhus/camelcase)
-1. **caniuse-lite@1.0.30001156**
+1. **caniuse-lite@1.0.30001159**
      * Licenses: CC-BY-4.0
      * Repository: [https://github.com/ben-eb/caniuse-lite](https://github.com/ben-eb/caniuse-lite)
 1. **catharsis@0.8.11**
@@ -1249,7 +1252,7 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **colorette@1.2.1**
      * Licenses: MIT
      * Repository: [https://github.com/jorgebucaran/colorette](https://github.com/jorgebucaran/colorette)
-1. **command-line-usage@6.1.0**
+1. **command-line-usage@6.1.1**
      * Licenses: MIT
      * Repository: [https://github.com/75lb/command-line-usage](https://github.com/75lb/command-line-usage)
 1. **commander@2.20.3**
@@ -1288,7 +1291,7 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **copy-descriptor@0.1.1**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/copy-descriptor](https://github.com/jonschlinkert/copy-descriptor)
-1. **core-js-compat@3.6.5**
+1. **core-js-compat@3.7.0**
      * Licenses: MIT
      * Repository: [https://github.com/zloirock/core-js](https://github.com/zloirock/core-js)
 1. **core-js@2.6.11**
@@ -1324,7 +1327,13 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **debug@3.2.6**
      * Licenses: MIT
      * Repository: [https://github.com/visionmedia/debug](https://github.com/visionmedia/debug)
+1. **debug@4.1.1**
+     * Licenses: MIT
+     * Repository: [https://github.com/visionmedia/debug](https://github.com/visionmedia/debug)
 1. **debug@4.2.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/visionmedia/debug](https://github.com/visionmedia/debug)
+1. **debug@4.3.1**
      * Licenses: MIT
      * Repository: [https://github.com/visionmedia/debug](https://github.com/visionmedia/debug)
 1. **debuglog@1.0.1**
@@ -1381,7 +1390,7 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **ecdsa-sig-formatter@1.0.11**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/Brightspace/node-ecdsa-sig-formatter](https://github.com/Brightspace/node-ecdsa-sig-formatter)
-1. **electron-to-chromium@1.3.588**
+1. **electron-to-chromium@1.3.603**
      * Licenses: ISC
      * Repository: [https://github.com/kilian/electron-to-chromium](https://github.com/kilian/electron-to-chromium)
 1. **elliptic@6.5.3**
@@ -1489,6 +1498,9 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **figgy-pudding@3.5.2**
      * Licenses: ISC
      * Repository: [https://github.com/npm/figgy-pudding](https://github.com/npm/figgy-pudding)
+1. **file-uri-to-path@1.0.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/TooTallNate/file-uri-to-path](https://github.com/TooTallNate/file-uri-to-path)
 1. **fill-range@4.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/fill-range](https://github.com/jonschlinkert/fill-range)
@@ -1534,7 +1546,7 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **from2@2.3.0**
      * Licenses: MIT
      * Repository: [https://github.com/hughsk/from2](https://github.com/hughsk/from2)
-1. **fromentries@1.3.2**
+1. **fromentries@1.2.0**
      * Licenses: MIT
      * Repository: [https://github.com/feross/fromentries](https://github.com/feross/fromentries)
 1. **fs-readdir-recursive@1.1.0**
@@ -1546,6 +1558,12 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **fs.realpath@1.0.0**
      * Licenses: ISC
      * Repository: [https://github.com/isaacs/fs.realpath](https://github.com/isaacs/fs.realpath)
+1. **fsevents@1.2.13**
+     * Licenses: MIT
+     * Repository: [https://github.com/strongloop/fsevents](https://github.com/strongloop/fsevents)
+1. **fsevents@2.1.3**
+     * Licenses: MIT
+     * Repository: [https://github.com/fsevents/fsevents](https://github.com/fsevents/fsevents)
 1. **function-bind@1.1.1**
      * Licenses: MIT
      * Repository: [https://github.com/Raynos/function-bind](https://github.com/Raynos/function-bind)
@@ -1594,13 +1612,13 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **google-p12-pem@3.0.3**
      * Licenses: MIT
      * Repository: [https://github.com/google/google-p12-pem](https://github.com/google/google-p12-pem)
-1. **graceful-fs@4.2.4**
+1. **graceful-fs@4.2.3**
      * Licenses: ISC
      * Repository: [https://github.com/isaacs/node-graceful-fs](https://github.com/isaacs/node-graceful-fs)
 1. **growl@1.10.5**
      * Licenses: MIT
      * Repository: [https://github.com/tj/node-growl](https://github.com/tj/node-growl)
-1. **gtoken@5.0.5**
+1. **gtoken@5.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/google/node-gtoken](https://github.com/google/node-gtoken)
 1. **has-ansi@2.0.0**
@@ -1636,7 +1654,7 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **hash.js@1.1.7**
      * Licenses: MIT
      * Repository: [https://github.com/indutny/hash.js](https://github.com/indutny/hash.js)
-1. **hasha@5.2.2**
+1. **hasha@5.2.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/hasha](https://github.com/sindresorhus/hasha)
 1. **he@1.2.0**
@@ -1726,9 +1744,6 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **is-buffer@1.1.6**
      * Licenses: MIT
      * Repository: [https://github.com/feross/is-buffer](https://github.com/feross/is-buffer)
-1. **is-core-module@2.1.0**
-     * Licenses: MIT
-     * Repository: [https://github.com/inspect-js/is-core-module](https://github.com/inspect-js/is-core-module)
 1. **is-data-descriptor@0.1.4**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/is-data-descriptor](https://github.com/jonschlinkert/is-data-descriptor)
@@ -1828,6 +1843,9 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **js-tokens@4.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/lydell/js-tokens](https://github.com/lydell/js-tokens)
+1. **js-yaml@3.13.1**
+     * Licenses: MIT
+     * Repository: [https://github.com/nodeca/js-yaml](https://github.com/nodeca/js-yaml)
 1. **js-yaml@3.14.0**
      * Licenses: MIT
      * Repository: [https://github.com/nodeca/js-yaml](https://github.com/nodeca/js-yaml)
@@ -1849,9 +1867,6 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **json-parse-better-errors@1.0.2**
      * Licenses: MIT
      * Repository: [https://github.com/zkat/json-parse-better-errors](https://github.com/zkat/json-parse-better-errors)
-1. **json-parse-even-better-errors@2.3.1**
-     * Licenses: MIT
-     * Repository: [https://github.com/npm/json-parse-even-better-errors](https://github.com/npm/json-parse-even-better-errors)
 1. **json-schema-traverse@0.4.1**
      * Licenses: MIT
      * Repository: [https://github.com/epoberezkin/json-schema-traverse](https://github.com/epoberezkin/json-schema-traverse)
@@ -1919,6 +1934,9 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
      * Licenses: MIT
      * Repository: [https://github.com/lodash/lodash](https://github.com/lodash/lodash)
 1. **lodash.get@4.4.2**
+     * Licenses: MIT
+     * Repository: [https://github.com/lodash/lodash](https://github.com/lodash/lodash)
+1. **lodash@4.17.15**
      * Licenses: MIT
      * Repository: [https://github.com/lodash/lodash](https://github.com/lodash/lodash)
 1. **lodash@4.17.20**
@@ -1996,6 +2014,9 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **minimatch@3.0.4**
      * Licenses: ISC
      * Repository: [https://github.com/isaacs/minimatch](https://github.com/isaacs/minimatch)
+1. **minimist@0.0.8**
+     * Licenses: MIT
+     * Repository: [https://github.com/substack/minimist](https://github.com/substack/minimist)
 1. **minimist@1.2.5**
      * Licenses: MIT
      * Repository: [https://github.com/substack/minimist](https://github.com/substack/minimist)
@@ -2005,6 +2026,9 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **mixin-deep@1.3.2**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/mixin-deep](https://github.com/jonschlinkert/mixin-deep)
+1. **mkdirp@0.5.1**
+     * Licenses: MIT
+     * Repository: [https://github.com/substack/node-mkdirp](https://github.com/substack/node-mkdirp)
 1. **mkdirp@0.5.5**
      * Licenses: MIT
      * Repository: [https://github.com/substack/node-mkdirp](https://github.com/substack/node-mkdirp)
@@ -2023,6 +2047,9 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **ms@2.1.2**
      * Licenses: MIT
      * Repository: [https://github.com/zeit/ms](https://github.com/zeit/ms)
+1. **nan@2.14.2**
+     * Licenses: MIT
+     * Repository: [https://github.com/nodejs/nan](https://github.com/nodejs/nan)
 1. **nanoid@3.1.12**
      * Licenses: MIT
      * Repository: [https://github.com/ai/nanoid](https://github.com/ai/nanoid)
@@ -2035,9 +2062,6 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **nise@4.0.4**
      * Licenses: BSD-3-Clause
      * Repository: [https://github.com/sinonjs/nise](https://github.com/sinonjs/nise)
-1. **node-fetch@2.6.1**
-     * Licenses: MIT
-     * Repository: [https://github.com/bitinn/node-fetch](https://github.com/bitinn/node-fetch)
 1. **node-forge@0.10.0**
      * Licenses: (BSD-3-Clause OR GPL-2.0)
      * Repository: [https://github.com/digitalbazaar/forge](https://github.com/digitalbazaar/forge)
@@ -2050,7 +2074,7 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **node-preload@0.2.1**
      * Licenses: MIT
      * Repository: [https://github.com/cfware/node-preload](https://github.com/cfware/node-preload)
-1. **node-releases@1.1.65**
+1. **node-releases@1.1.67**
      * Licenses: MIT
      * Repository: [https://github.com/chicoxyzzy/node-releases](https://github.com/chicoxyzzy/node-releases)
 1. **nopt@4.0.3**
@@ -2110,7 +2134,7 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **osenv@0.1.5**
      * Licenses: ISC
      * Repository: [https://github.com/npm/osenv](https://github.com/npm/osenv)
-1. **p-limit@2.3.0**
+1. **p-limit@2.2.2**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/p-limit](https://github.com/sindresorhus/p-limit)
 1. **p-limit@3.0.2**
@@ -2209,7 +2233,7 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **promise-polyfill@8.1.3**
      * Licenses: MIT
      * Repository: [https://github.com/taylorhakes/promise-polyfill](https://github.com/taylorhakes/promise-polyfill)
-1. **protobufjs@6.10.1**
+1. **protobufjs@6.10.2**
      * Licenses: BSD-3-Clause
      * Repository: [https://github.com/protobufjs/protobuf.js](https://github.com/protobufjs/protobuf.js)
 1. **prr@1.0.1**
@@ -2251,7 +2275,7 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **read-installed@4.0.3**
      * Licenses: ISC
      * Repository: [https://github.com/isaacs/read-installed](https://github.com/isaacs/read-installed)
-1. **read-package-json@2.1.2**
+1. **read-package-json@2.1.1**
      * Licenses: ISC
      * Repository: [https://github.com/npm/read-package-json](https://github.com/npm/read-package-json)
 1. **readable-stream@2.3.7**
@@ -2335,7 +2359,7 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **resolve-url@0.2.1**
      * Licenses: MIT
      * Repository: [https://github.com/lydell/resolve-url](https://github.com/lydell/resolve-url)
-1. **resolve@1.18.1**
+1. **resolve@1.15.1**
      * Licenses: MIT
      * Repository: [https://github.com/browserify/resolve](https://github.com/browserify/resolve)
 1. **ret@0.1.15**
@@ -2404,7 +2428,7 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **shebang-regex@3.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/shebang-regex](https://github.com/sindresorhus/shebang-regex)
-1. **signal-exit@3.0.3**
+1. **signal-exit@3.0.2**
      * Licenses: ISC
      * Repository: [https://github.com/tapjs/signal-exit](https://github.com/tapjs/signal-exit)
 1. **sinon@9.2.1**
@@ -2449,25 +2473,25 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **spdx-compare@1.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/kemitchell/spdx-compare.js](https://github.com/kemitchell/spdx-compare.js)
-1. **spdx-correct@3.1.1**
+1. **spdx-correct@3.1.0**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/jslicense/spdx-correct.js](https://github.com/jslicense/spdx-correct.js)
-1. **spdx-exceptions@2.3.0**
+1. **spdx-exceptions@2.2.0**
      * Licenses: CC-BY-3.0
      * Repository: [https://github.com/kemitchell/spdx-exceptions.json](https://github.com/kemitchell/spdx-exceptions.json)
-1. **spdx-expression-parse@3.0.1**
+1. **spdx-expression-parse@3.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/jslicense/spdx-expression-parse.js](https://github.com/jslicense/spdx-expression-parse.js)
-1. **spdx-license-ids@3.0.6**
+1. **spdx-license-ids@3.0.5**
      * Licenses: CC0-1.0
-     * Repository: [https://github.com/jslicense/spdx-license-ids](https://github.com/jslicense/spdx-license-ids)
+     * Repository: [https://github.com/shinnn/spdx-license-ids](https://github.com/shinnn/spdx-license-ids)
 1. **spdx-ranges@2.1.1**
      * Licenses: (MIT AND CC-BY-3.0)
      * Repository: [https://github.com/kemitchell/spdx-ranges.js](https://github.com/kemitchell/spdx-ranges.js)
 1. **spdx-satisfies@4.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/kemitchell/spdx-satisfies.js](https://github.com/kemitchell/spdx-satisfies.js)
-1. **spine-web@1.6.12**
+1. **spine-web@1.6.15**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/SpineEventEngine/web](https://github.com/SpineEventEngine/web)
 1. **split-string@3.1.0**
@@ -2537,6 +2561,9 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
      * Licenses: MIT
      * Repository: [https://github.com/chalk/supports-color](https://github.com/chalk/supports-color)
 1. **supports-color@5.5.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/chalk/supports-color](https://github.com/chalk/supports-color)
+1. **supports-color@7.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/chalk/supports-color](https://github.com/chalk/supports-color)
 1. **supports-color@7.2.0**
@@ -2683,10 +2710,10 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **vm-browserify@1.1.2**
      * Licenses: MIT
      * Repository: [https://github.com/substack/vm-browserify](https://github.com/substack/vm-browserify)
-1. **watchpack-chokidar2@2.0.0**
+1. **watchpack-chokidar2@2.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/webpack/watchpack](https://github.com/webpack/watchpack)
-1. **watchpack@1.7.4**
+1. **watchpack@1.7.5**
      * Licenses: MIT
      * Repository: [https://github.com/webpack/watchpack](https://github.com/webpack/watchpack)
 1. **webpack-cli@4.2.0**
@@ -2770,17 +2797,17 @@ This report was generated on **Fri Nov 20 18:47:20 EET 2020** using [Gradle-Lice
 1. **yargs@13.3.2**
      * Licenses: MIT
      * Repository: [https://github.com/yargs/yargs](https://github.com/yargs/yargs)
-1. **yargs@15.4.1**
+1. **yargs@15.3.1**
      * Licenses: MIT
      * Repository: [https://github.com/yargs/yargs](https://github.com/yargs/yargs)
 
 
-This report was generated on **Fri Nov 20 2020 18:47:23 GMT+0200 (Eastern European Standard Time)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
+This report was generated on **Mon Nov 23 2020 17:08:57 GMT+0200 (Eastern European Standard Time)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
 
 
 
     
-# Dependencies of `io.spine.gcloud:spine-firebase-web:1.6.12`
+# Dependencies of `io.spine.gcloud:spine-firebase-web:1.6.15`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson.core **Name:** jackson-annotations **Version:** 2.9.10
@@ -3587,12 +3614,12 @@ This report was generated on **Fri Nov 20 2020 18:47:23 GMT+0200 (Eastern Europe
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Nov 20 18:47:30 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 23 17:09:07 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-js-tests:1.6.12`
+# Dependencies of `io.spine:spine-js-tests:1.6.15`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -4002,12 +4029,12 @@ This report was generated on **Fri Nov 20 18:47:30 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Nov 20 18:48:15 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 23 17:09:22 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-test-app:1.6.12`
+# Dependencies of `io.spine:spine-test-app:1.6.15`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson.core **Name:** jackson-annotations **Version:** 2.9.10
@@ -5601,12 +5628,12 @@ This report was generated on **Fri Nov 20 18:48:15 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Nov 20 18:48:21 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 23 17:10:40 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-web:1.6.12`
+# Dependencies of `io.spine:spine-testutil-web:1.6.15`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -6085,12 +6112,12 @@ This report was generated on **Fri Nov 20 18:48:21 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Nov 20 18:48:22 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 23 17:10:40 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-web:1.6.12`
+# Dependencies of `io.spine:spine-web:1.6.15`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -6608,4 +6635,4 @@ This report was generated on **Fri Nov 20 18:48:22 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Nov 20 18:48:25 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 23 17:10:42 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-web</artifactId>
-<version>1.6.12</version>
+<version>1.6.15</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -70,7 +70,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-server</artifactId>
-    <version>1.6.13</version>
+    <version>1.6.15</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -94,13 +94,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testutil-client</artifactId>
-    <version>1.6.13</version>
+    <version>1.6.15</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mute-logging</artifactId>
-    <version>1.6.12</version>
+    <version>1.6.13</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -162,22 +162,22 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-client</artifactId>
-    <version>1.6.13</version>
+    <version>1.6.15</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-errorprone-checks</artifactId>
-    <version>1.6.12</version>
+    <version>1.6.13</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-javadoc-filter</artifactId>
-    <version>1.6.12</version>
+    <version>1.6.13</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-protoc-plugin</artifactId>
-    <version>1.6.12</version>
+    <version>1.6.13</version>
   </dependency>
   <dependency>
     <groupId>javax.servlet</groupId>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -18,10 +18,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val spineBaseVersion: String by extra("1.6.12")
-val spineTimeVersion: String by extra("1.6.11")
-val spineCoreVersion: String by extra("1.6.13")
+val spineBaseVersion: String by extra("1.6.13")
+val spineTimeVersion: String by extra("1.6.13")
+val spineCoreVersion: String by extra("1.6.15")
 val spineVersion: String by extra(spineCoreVersion)
 
-val versionToPublish: String by extra("1.6.12")
-val versionToPublishJs: String by extra("1.6.12")
+val versionToPublish: String by extra("1.6.15")
+val versionToPublishJs: String by extra("1.6.15")


### PR DESCRIPTION
In this PR we add a new GitHub Actions check which invokes the `checkVersionIncrement` Gradle task.

The check fails if the current version of the library is already published in order to avoid overriding existing versions.
The check runs on any `push`, but the task is only enabled for all branches except `master`. On `master`, the check will always pass.