### PR TITLE
Allow using Firebase RDB emulator with Firebase client

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
@@ -102,7 +102,7 @@ object Versions {
     val javaPoet         = "1.13.0"
     val autoService      = "1.0-rc7"
     val autoCommon       = "0.10"
-    val jackson          = "2.9.10.5"
+    val jackson          = "2.9.10.8"
     val animalSniffer    = "1.19"
     val apiguardian      = "1.1.0"
     val javaxAnnotation  = "1.3.2"

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spine-web",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "license": "Apache-2.0",
   "description": "A JS client for interacting with Spine applications.",
   "homepage": "https://spine.io",

--- a/firebase-web/src/main/java/io/spine/web/firebase/DatabaseUrls.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/DatabaseUrls.java
@@ -28,7 +28,7 @@ package io.spine.web.firebase;
 
 import io.spine.net.Urls;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static io.spine.util.Preconditions2.checkNotEmptyOrBlank;
 
 /**
  * Utilities and static factories dealing with {@link DatabaseUrl}.
@@ -50,7 +50,7 @@ public final class DatabaseUrls {
      * @see com.google.firebase.database.util.EmulatorHelper
      */
     public static DatabaseUrl from(String dbUrl) {
-        checkNotNull(dbUrl);
+        checkNotEmptyOrBlank(dbUrl);
         String namespace = "";
         String url = dbUrl;
         String namespaceQuery = "?ns=";

--- a/firebase-web/src/main/java/io/spine/web/firebase/DatabaseUrls.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/DatabaseUrls.java
@@ -35,22 +35,34 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public final class DatabaseUrls {
 
-    /** Prevents instantiation of this utility class. */
+    /**
+     * Prevents instantiation of this utility class.
+     */
     private DatabaseUrls() {
     }
 
     /**
-     * Creates a {@code DatabaseUrls} instance from the given string.
+     * Creates a {@code DatabaseUrl} instance from the given string.
      *
-     * @param url
+     * @param dbUrl
      *         a {@code String} containing database URL
-     * @return a new instance of {@code DatabaseUrls}
+     * @return a new instance of {@code DatabaseUrl}
+     * @see com.google.firebase.database.util.EmulatorHelper
      */
-    public static DatabaseUrl from(String url) {
-        checkNotNull(url);
+    public static DatabaseUrl from(String dbUrl) {
+        checkNotNull(dbUrl);
+        String namespace = "";
+        String url = dbUrl;
+        String namespaceQuery = "?ns=";
+        int queryIndex = dbUrl.indexOf(namespaceQuery);
+        if (queryIndex > 0) {
+            namespace = dbUrl.substring(queryIndex + namespaceQuery.length());
+            url = dbUrl.substring(0, queryIndex);
+        }
         return DatabaseUrl
                 .newBuilder()
                 .setUrl(Urls.create(url))
+                .setNamespace(namespace)
                 .vBuild();
     }
 }

--- a/firebase-web/src/main/java/io/spine/web/firebase/rest/RestNodeUrls.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/rest/RestNodeUrls.java
@@ -27,11 +27,13 @@
 package io.spine.web.firebase.rest;
 
 import com.google.api.client.http.GenericUrl;
+import com.google.common.base.Preconditions;
 import io.spine.net.Url;
 import io.spine.net.Urls;
 import io.spine.web.firebase.DatabaseUrl;
 import io.spine.web.firebase.NodePath;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
 
 /**
@@ -42,7 +44,11 @@ final class RestNodeUrls {
 
     private final String template;
 
+    /**
+     * Creates a new factory for the specified database {@code url}.
+     */
     RestNodeUrls(DatabaseUrl url) {
+        checkNotNull(url);
         this.template = Urls.toString(url.getUrl()) + "/%s.json";
     }
 
@@ -50,6 +56,7 @@ final class RestNodeUrls {
      * Creates a new {@link RestNodeUrl} for a node at the specified {@link NodePath path}.
      */
     RestNodeUrl with(NodePath path) {
+        checkNotNull(path);
         Url url = Urls.create(format(template, path.getValue()));
         RestNodeUrl node = RestNodeUrl
                 .newBuilder()
@@ -58,7 +65,11 @@ final class RestNodeUrls {
         return node;
     }
 
+    /**
+     * Converts supplied {@code node} into a {@code GenericUrl}.
+     */
     static GenericUrl asGenericUrl(RestNodeUrl node) {
+        checkNotNull(node);
         GenericUrl url = new GenericUrl(Urls.toString(node.getUrl()));
         return url;
     }

--- a/firebase-web/src/main/java/io/spine/web/firebase/rest/RestNodeUrls.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/rest/RestNodeUrls.java
@@ -56,7 +56,7 @@ final class RestNodeUrls {
      */
     RestNodeUrl with(NodePath path) {
         checkNotNull(path);
-        Url url = withDatabase(path);
+        Url url = withinDatabase(path);
         RestNodeUrl node = RestNodeUrl
                 .newBuilder()
                 .setUrl(url)
@@ -64,7 +64,7 @@ final class RestNodeUrls {
         return node;
     }
 
-    private Url withDatabase(NodePath path) {
+    private Url withinDatabase(NodePath path) {
         Url dbUrl = database.getUrl();
         String result;
         if (isNullOrEmpty(database.getNamespace())) {

--- a/firebase-web/src/main/proto/spine/web/firebase/client.proto
+++ b/firebase-web/src/main/proto/spine/web/firebase/client.proto
@@ -38,8 +38,20 @@ import "spine/net/url.proto";
 
 // A Firebase database URL.
 //
+// The Firebase endpoint URL may be of two formats.
+// The first one is a URL to connect to a remote database which must be specified as
+// `https://<project-id>.firebaseio.com` or `https://<database-alias>.firebaseio.com`.
+// The second one is a URL to connect to an emulator database that has the following format:
+// `http://<local-ip>:<local-port>?ns=<database-alias>`. The `ns` stands for a `namespace`
+// and by default is set to the project ID.
+//
 message DatabaseUrl {
+
+    // The Firebase RDB endpoint.
     spine.net.Url url = 1 [(required) = true];
+
+    // The namespace to connect to.
+    string namespace = 2;
 }
 
 // A path in a Firebase Realtime Database.

--- a/firebase-web/src/test/java/io/spine/web/firebase/DatabaseUrlsTest.java
+++ b/firebase-web/src/test/java/io/spine/web/firebase/DatabaseUrlsTest.java
@@ -31,22 +31,35 @@ import io.spine.testing.UtilityClassTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.extensions.proto.ProtoTruth.assertThat;
 
 @DisplayName("`DatabaseUrls` should")
 class DatabaseUrlsTest extends UtilityClassTest<DatabaseUrls> {
-
-    private static final String VALID_URL = "https://spine-dev.appspot.com/";
 
     DatabaseUrlsTest() {
         super(DatabaseUrls.class);
     }
 
     @Test
-    @DisplayName("be successfully created from valid URL")
+    @DisplayName("be successfully created from a valid URL")
     void acceptValidUrl() {
-        DatabaseUrl url = DatabaseUrls.from(VALID_URL);
+        String dbUrl = "https://spine-dev.firebaseio.com";
+        DatabaseUrl url = DatabaseUrls.from(dbUrl);
         assertThat(url.getUrl())
-                .isEqualTo(Urls.create(VALID_URL));
+                .isEqualTo(Urls.create(dbUrl));
+        assertThat(url.getNamespace())
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("parse a namespace if any is specified in the query")
+    void parseNamespace() {
+        String dbUrl = "http://localhost:5000?ns=spine-dev";
+        DatabaseUrl url = DatabaseUrls.from(dbUrl);
+        assertThat(url.getUrl())
+                .isEqualTo(Urls.create("http://localhost:5000"));
+        assertThat(url.getNamespace())
+                .isEqualTo("spine-dev");
     }
 }

--- a/firebase-web/src/test/java/io/spine/web/firebase/DatabaseUrlsTest.java
+++ b/firebase-web/src/test/java/io/spine/web/firebase/DatabaseUrlsTest.java
@@ -42,8 +42,8 @@ class DatabaseUrlsTest extends UtilityClassTest<DatabaseUrls> {
     }
 
     @Test
-    @DisplayName("be successfully created from a valid URL")
-    void acceptValidUrl() {
+    @DisplayName("be created from a remote RDB URL")
+    void acceptRemoteRdb() {
         String dbUrl = "https://spine-dev.firebaseio.com";
         DatabaseUrl url = DatabaseUrls.from(dbUrl);
         assertThat(url.getUrl())
@@ -53,8 +53,8 @@ class DatabaseUrlsTest extends UtilityClassTest<DatabaseUrls> {
     }
 
     @Test
-    @DisplayName("parse a namespace if any is specified in the query")
-    void parseNamespace() {
+    @DisplayName("be created from a local emulator URL")
+    void acceptLocalEmulator() {
         String dbUrl = "http://localhost:5000?ns=spine-dev";
         DatabaseUrl url = DatabaseUrls.from(dbUrl);
         assertThat(url.getUrl())

--- a/firebase-web/src/test/java/io/spine/web/firebase/rest/RestNodeUrlsTest.java
+++ b/firebase-web/src/test/java/io/spine/web/firebase/rest/RestNodeUrlsTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.web.firebase.rest;
+
+import com.google.common.testing.NullPointerTester;
+import com.google.common.testing.NullPointerTester.Visibility;
+import io.spine.net.Urls;
+import io.spine.web.firebase.DatabaseUrl;
+import io.spine.web.firebase.DatabaseUrls;
+import io.spine.web.firebase.NodePaths;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.google.common.truth.extensions.proto.ProtoTruth.assertThat;
+
+@DisplayName("`RestNodeUrls` should")
+final class RestNodeUrlsTest {
+
+    @Test
+    @DisplayName("not accept `null`s")
+    void notAcceptNulls() {
+        NullPointerTester tester = new NullPointerTester();
+        tester.testConstructors(RestNodeUrls.class, Visibility.PACKAGE);
+        tester.testAllPublicInstanceMethods(new RestNodeUrls(DatabaseUrl.getDefaultInstance()));
+    }
+
+    @Test
+    @DisplayName("create a `RestNodeUrl` for the specified `NodePath` and remote RDB")
+    void createRemoteDbUrl() {
+        String dbUrl = "https://spine-dev.firebaseio.com";
+        RestNodeUrls factory = new RestNodeUrls(DatabaseUrls.from(dbUrl));
+        String node = "subscriptions/111";
+        RestNodeUrl result = factory.with(NodePaths.of(node));
+        assertThat(result.getUrl())
+                .isEqualTo(Urls.create(dbUrl + '/' + node + ".json"));
+    }
+
+    @Test
+    @DisplayName("create a `RestNodeUrl` for the specified `NodePath` and local emulator")
+    void createEmulatorUrl() {
+        String dbUrl = "http://localhost:5000?ns=spine-dev";
+        RestNodeUrls factory = new RestNodeUrls(DatabaseUrls.from(dbUrl));
+        String node = "query/currentYear";
+        RestNodeUrl result = factory.with(NodePaths.of(node));
+        assertThat(result.getUrl())
+                .isEqualTo(Urls.create("http://localhost:5000/" + node + ".json?ns=spine-dev"));
+    }
+}

--- a/integration-tests/js-tests/package.json
+++ b/integration-tests/js-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-js-tests",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "license": "Apache-2.0",
   "description": "Tests of a `spine-web` JS library against the Spine-based application.",
   "scripts": {

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client-js:1.7.1`
+# Dependencies of `io.spine:spine-client-js:1.7.2`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -286,7 +286,6 @@
 1. **Group:** org.jacoco **Name:** org.jacoco.report **Version:** 0.8.5
      * **POM License: Eclipse Public License 2.0** - [https://www.eclipse.org/legal/epl-2.0/](https://www.eclipse.org/legal/epl-2.0/)
 
-1. **Group:** org.junit **Name:** junit-bom **Version:** 5.7.0 **No license information found**
 1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.7.0
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
@@ -368,17 +367,17 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 29 23:10:29 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
-#NPM dependencies of `spine-web@1.7.1`
+#NPM dependencies of `spine-web@1.7.2`
 
 ## `Production` dependencies:
 
 1. **base64-js@1.5.1**
      * Licenses: MIT
      * Repository: [https://github.com/beatgammit/base64-js](https://github.com/beatgammit/base64-js)
-1. **google-protobuf@3.14.0**
+1. **google-protobuf@3.13.0**
      * Licenses: BSD-3-Clause
      * Repository: [https://github.com/protocolbuffers/protobuf/tree/master/js](https://github.com/protocolbuffers/protobuf/tree/master/js)
 1. **isomorphic-fetch@3.0.0**
@@ -390,7 +389,7 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **rxjs@6.5.5**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/reactivex/rxjs](https://github.com/reactivex/rxjs)
-1. **spine-web@1.7.1**
+1. **spine-web@1.7.2**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/SpineEventEngine/web](https://github.com/SpineEventEngine/web)
 1. **tslib@1.14.1**
@@ -399,7 +398,7 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **uuid@8.3.2**
      * Licenses: MIT
      * Repository: [https://github.com/uuidjs/uuid](https://github.com/uuidjs/uuid)
-1. **whatwg-fetch@3.5.0**
+1. **whatwg-fetch@3.4.1**
      * Licenses: MIT
      * Repository: [https://github.com/github/fetch](https://github.com/github/fetch)
 
@@ -410,7 +409,7 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **@babel/cli@7.12.10**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/code-frame@7.12.11**
+1. **@babel/code-frame@7.10.4**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
 1. **@babel/compat-data@7.12.7**
@@ -419,7 +418,7 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **@babel/core@7.12.10**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/generator@7.12.11**
+1. **@babel/generator@7.12.10**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
 1. **@babel/helper-annotate-as-pure@7.12.10**
@@ -443,7 +442,7 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **@babel/helper-explode-assignable-expression@7.12.1**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/helper-function-name@7.12.11**
+1. **@babel/helper-function-name@7.10.4**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
 1. **@babel/helper-get-function-arity@7.12.10**
@@ -470,7 +469,7 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **@babel/helper-remap-async-to-generator@7.12.1**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/helper-replace-supers@7.12.11**
+1. **@babel/helper-replace-supers@7.12.5**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
 1. **@babel/helper-simple-access@7.12.1**
@@ -479,13 +478,13 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **@babel/helper-skip-transparent-expression-wrappers@7.12.1**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/helper-split-export-declaration@7.12.11**
+1. **@babel/helper-split-export-declaration@7.11.0**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/helper-validator-identifier@7.12.11**
+1. **@babel/helper-validator-identifier@7.10.4**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/helper-validator-option@7.12.11**
+1. **@babel/helper-validator-option@7.12.1**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
 1. **@babel/helper-wrap-function@7.12.3**
@@ -497,13 +496,13 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **@babel/highlight@7.10.4**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/parser@7.12.11**
+1. **@babel/parser@7.12.10**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/parser@7.12.7**
+1. **@babel/parser@7.12.5**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-proposal-async-generator-functions@7.12.12**
+1. **@babel/plugin-proposal-async-generator-functions@7.12.1**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
 1. **@babel/plugin-proposal-class-properties@7.12.1**
@@ -587,7 +586,7 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **@babel/plugin-transform-block-scoped-functions@7.12.1**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/plugin-transform-block-scoping@7.12.12**
+1. **@babel/plugin-transform-block-scoping@7.12.1**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
 1. **@babel/plugin-transform-classes@7.12.1**
@@ -674,7 +673,7 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **@babel/plugin-transform-unicode-regex@7.12.1**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/preset-env@7.12.11**
+1. **@babel/preset-env@7.12.10**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
 1. **@babel/preset-modules@0.1.4**
@@ -689,10 +688,10 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **@babel/template@7.12.7**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/traverse@7.12.12**
+1. **@babel/traverse@7.12.10**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
-1. **@babel/types@7.12.12**
+1. **@babel/types@7.12.10**
      * Licenses: MIT
      * Repository: [https://github.com/babel/babel](https://github.com/babel/babel)
 1. **@firebase/analytics-types@0.4.0**
@@ -779,10 +778,13 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **@firebase/webchannel-wrapper@0.4.0**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/firebase/firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)
-1. **@grpc/grpc-js@1.2.1**
+1. **@grpc/grpc-js@1.1.8**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/grpc/grpc-node/tree/master/packages/grpc-js](https://github.com/grpc/grpc-node/tree/master/packages/grpc-js)
 1. **@grpc/proto-loader@0.5.5**
+     * Licenses: Apache-2.0
+     * Repository: [https://github.com/grpc/grpc-node](https://github.com/grpc/grpc-node)
+1. **@grpc/proto-loader@0.6.0-pre9**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/grpc/grpc-node](https://github.com/grpc/grpc-node)
 1. **@istanbuljs/load-nyc-config@1.1.0**
@@ -830,6 +832,9 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **@sinonjs/fake-timers@6.0.1**
      * Licenses: BSD-3-Clause
      * Repository: [https://github.com/sinonjs/fake-timers](https://github.com/sinonjs/fake-timers)
+1. **@sinonjs/formatio@5.0.1**
+     * Licenses: BSD-3-Clause
+     * Repository: [https://github.com/sinonjs/formatio](https://github.com/sinonjs/formatio)
 1. **@sinonjs/samsam@5.3.0**
      * Licenses: BSD-3-Clause
      * Repository: [https://github.com/sinonjs/samsam](https://github.com/sinonjs/samsam)
@@ -839,19 +844,16 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **@tootallnate/once@1.1.2**
      * Licenses: MIT
      * Repository: [https://github.com/TooTallNate/once](https://github.com/TooTallNate/once)
-1. **@types/color-name@1.1.1**
-     * Licenses: MIT
-     * Repository: [https://github.com/DefinitelyTyped/DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped)
 1. **@types/json-schema@7.0.6**
      * Licenses: MIT
      * Repository: [https://github.com/DefinitelyTyped/DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped)
 1. **@types/long@4.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/DefinitelyTyped/DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped)
-1. **@types/node@12.19.6**
+1. **@types/node@12.19.3**
      * Licenses: MIT
      * Repository: [https://github.com/DefinitelyTyped/DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped)
-1. **@types/node@13.13.32**
+1. **@types/node@13.13.30**
      * Licenses: MIT
      * Repository: [https://github.com/DefinitelyTyped/DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped)
 1. **@ungap/promise-all-settled@1.1.2**
@@ -938,7 +940,7 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **agent-base@6.0.2**
      * Licenses: MIT
      * Repository: [https://github.com/TooTallNate/node-agent-base](https://github.com/TooTallNate/node-agent-base)
-1. **aggregate-error@3.0.1**
+1. **aggregate-error@3.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/aggregate-error](https://github.com/sindresorhus/aggregate-error)
 1. **ajv-errors@1.0.1**
@@ -969,9 +971,6 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
      * Licenses: MIT
      * Repository: [https://github.com/chalk/ansi-styles](https://github.com/chalk/ansi-styles)
 1. **ansi-styles@3.2.1**
-     * Licenses: MIT
-     * Repository: [https://github.com/chalk/ansi-styles](https://github.com/chalk/ansi-styles)
-1. **ansi-styles@4.2.1**
      * Licenses: MIT
      * Repository: [https://github.com/chalk/ansi-styles](https://github.com/chalk/ansi-styles)
 1. **ansi-styles@4.3.0**
@@ -1088,9 +1087,6 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **binary-extensions@2.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/binary-extensions](https://github.com/sindresorhus/binary-extensions)
-1. **bindings@1.5.0**
-     * Licenses: MIT
-     * Repository: [https://github.com/TooTallNate/node-bindings](https://github.com/TooTallNate/node-bindings)
 1. **bluebird@3.7.2**
      * Licenses: MIT
      * Repository: [https://github.com/petkaantonov/bluebird](https://github.com/petkaantonov/bluebird)
@@ -1124,7 +1120,7 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **browserify-des@1.0.2**
      * Licenses: MIT
      * Repository: [https://github.com/crypto-browserify/browserify-des](https://github.com/crypto-browserify/browserify-des)
-1. **browserify-rsa@4.1.0**
+1. **browserify-rsa@4.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/crypto-browserify/browserify-rsa](https://github.com/crypto-browserify/browserify-rsa)
 1. **browserify-sign@4.2.1**
@@ -1133,7 +1129,7 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **browserify-zlib@0.2.0**
      * Licenses: MIT
      * Repository: [https://github.com/devongovett/browserify-zlib](https://github.com/devongovett/browserify-zlib)
-1. **browserslist@4.16.1**
+1. **browserslist@4.16.0**
      * Licenses: MIT
      * Repository: [https://github.com/browserslist/browserslist](https://github.com/browserslist/browserslist)
 1. **buffer-equal-constant-time@1.0.1**
@@ -1169,7 +1165,7 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **camelcase@6.2.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/camelcase](https://github.com/sindresorhus/camelcase)
-1. **caniuse-lite@1.0.30001173**
+1. **caniuse-lite@1.0.30001166**
      * Licenses: CC-BY-4.0
      * Repository: [https://github.com/ben-eb/caniuse-lite](https://github.com/ben-eb/caniuse-lite)
 1. **catharsis@0.8.11**
@@ -1232,7 +1228,7 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **colorette@1.2.1**
      * Licenses: MIT
      * Repository: [https://github.com/jorgebucaran/colorette](https://github.com/jorgebucaran/colorette)
-1. **command-line-usage@6.1.1**
+1. **command-line-usage@6.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/75lb/command-line-usage](https://github.com/75lb/command-line-usage)
 1. **commander@2.20.3**
@@ -1271,7 +1267,7 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **copy-descriptor@0.1.1**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/copy-descriptor](https://github.com/jonschlinkert/copy-descriptor)
-1. **core-js-compat@3.8.2**
+1. **core-js-compat@3.8.1**
      * Licenses: MIT
      * Repository: [https://github.com/zloirock/core-js](https://github.com/zloirock/core-js)
 1. **core-js@2.6.11**
@@ -1305,9 +1301,6 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
      * Licenses: MIT
      * Repository: [https://github.com/visionmedia/debug](https://github.com/visionmedia/debug)
 1. **debug@3.2.6**
-     * Licenses: MIT
-     * Repository: [https://github.com/visionmedia/debug](https://github.com/visionmedia/debug)
-1. **debug@4.1.1**
      * Licenses: MIT
      * Repository: [https://github.com/visionmedia/debug](https://github.com/visionmedia/debug)
 1. **debug@4.2.0**
@@ -1370,7 +1363,7 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **ecdsa-sig-formatter@1.0.11**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/Brightspace/node-ecdsa-sig-formatter](https://github.com/Brightspace/node-ecdsa-sig-formatter)
-1. **electron-to-chromium@1.3.634**
+1. **electron-to-chromium@1.3.626**
      * Licenses: ISC
      * Repository: [https://github.com/kilian/electron-to-chromium](https://github.com/kilian/electron-to-chromium)
 1. **elliptic@6.5.3**
@@ -1478,9 +1471,6 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **figgy-pudding@3.5.2**
      * Licenses: ISC
      * Repository: [https://github.com/npm/figgy-pudding](https://github.com/npm/figgy-pudding)
-1. **file-uri-to-path@1.0.0**
-     * Licenses: MIT
-     * Repository: [https://github.com/TooTallNate/file-uri-to-path](https://github.com/TooTallNate/file-uri-to-path)
 1. **fill-range@4.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/fill-range](https://github.com/jonschlinkert/fill-range)
@@ -1526,7 +1516,7 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **from2@2.3.0**
      * Licenses: MIT
      * Repository: [https://github.com/hughsk/from2](https://github.com/hughsk/from2)
-1. **fromentries@1.2.0**
+1. **fromentries@1.3.2**
      * Licenses: MIT
      * Repository: [https://github.com/feross/fromentries](https://github.com/feross/fromentries)
 1. **fs-readdir-recursive@1.1.0**
@@ -1538,12 +1528,6 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **fs.realpath@1.0.0**
      * Licenses: ISC
      * Repository: [https://github.com/isaacs/fs.realpath](https://github.com/isaacs/fs.realpath)
-1. **fsevents@1.2.13**
-     * Licenses: MIT
-     * Repository: [https://github.com/strongloop/fsevents](https://github.com/strongloop/fsevents)
-1. **fsevents@2.1.3**
-     * Licenses: MIT
-     * Repository: [https://github.com/fsevents/fsevents](https://github.com/fsevents/fsevents)
 1. **function-bind@1.1.1**
      * Licenses: MIT
      * Repository: [https://github.com/Raynos/function-bind](https://github.com/Raynos/function-bind)
@@ -1559,7 +1543,7 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **get-caller-file@2.0.5**
      * Licenses: ISC
      * Repository: [https://github.com/stefanpenner/get-caller-file](https://github.com/stefanpenner/get-caller-file)
-1. **get-intrinsic@1.0.2**
+1. **get-intrinsic@1.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/ljharb/get-intrinsic](https://github.com/ljharb/get-intrinsic)
 1. **get-package-type@0.1.0**
@@ -1592,13 +1576,13 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **google-p12-pem@3.0.3**
      * Licenses: MIT
      * Repository: [https://github.com/google/google-p12-pem](https://github.com/google/google-p12-pem)
-1. **graceful-fs@4.2.3**
+1. **graceful-fs@4.2.4**
      * Licenses: ISC
      * Repository: [https://github.com/isaacs/node-graceful-fs](https://github.com/isaacs/node-graceful-fs)
 1. **growl@1.10.5**
      * Licenses: MIT
      * Repository: [https://github.com/tj/node-growl](https://github.com/tj/node-growl)
-1. **gtoken@5.1.0**
+1. **gtoken@5.0.5**
      * Licenses: MIT
      * Repository: [https://github.com/google/node-gtoken](https://github.com/google/node-gtoken)
 1. **has-ansi@2.0.0**
@@ -1634,7 +1618,7 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **hash.js@1.1.7**
      * Licenses: MIT
      * Repository: [https://github.com/indutny/hash.js](https://github.com/indutny/hash.js)
-1. **hasha@5.2.0**
+1. **hasha@5.2.2**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/hasha](https://github.com/sindresorhus/hasha)
 1. **he@1.2.0**
@@ -1724,6 +1708,9 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **is-buffer@1.1.6**
      * Licenses: MIT
      * Repository: [https://github.com/feross/is-buffer](https://github.com/feross/is-buffer)
+1. **is-core-module@2.1.0**
+     * Licenses: MIT
+     * Repository: [https://github.com/inspect-js/is-core-module](https://github.com/inspect-js/is-core-module)
 1. **is-data-descriptor@0.1.4**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/is-data-descriptor](https://github.com/jonschlinkert/is-data-descriptor)
@@ -1823,9 +1810,6 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **js-tokens@4.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/lydell/js-tokens](https://github.com/lydell/js-tokens)
-1. **js-yaml@3.13.1**
-     * Licenses: MIT
-     * Repository: [https://github.com/nodeca/js-yaml](https://github.com/nodeca/js-yaml)
 1. **js-yaml@3.14.0**
      * Licenses: MIT
      * Repository: [https://github.com/nodeca/js-yaml](https://github.com/nodeca/js-yaml)
@@ -1847,6 +1831,9 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **json-parse-better-errors@1.0.2**
      * Licenses: MIT
      * Repository: [https://github.com/zkat/json-parse-better-errors](https://github.com/zkat/json-parse-better-errors)
+1. **json-parse-even-better-errors@2.3.1**
+     * Licenses: MIT
+     * Repository: [https://github.com/npm/json-parse-even-better-errors](https://github.com/npm/json-parse-even-better-errors)
 1. **json-schema-traverse@0.4.1**
      * Licenses: MIT
      * Repository: [https://github.com/epoberezkin/json-schema-traverse](https://github.com/epoberezkin/json-schema-traverse)
@@ -1914,9 +1901,6 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
      * Licenses: MIT
      * Repository: [https://github.com/lodash/lodash](https://github.com/lodash/lodash)
 1. **lodash.get@4.4.2**
-     * Licenses: MIT
-     * Repository: [https://github.com/lodash/lodash](https://github.com/lodash/lodash)
-1. **lodash@4.17.15**
      * Licenses: MIT
      * Repository: [https://github.com/lodash/lodash](https://github.com/lodash/lodash)
 1. **lodash@4.17.20**
@@ -1994,9 +1978,6 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **minimatch@3.0.4**
      * Licenses: ISC
      * Repository: [https://github.com/isaacs/minimatch](https://github.com/isaacs/minimatch)
-1. **minimist@0.0.8**
-     * Licenses: MIT
-     * Repository: [https://github.com/substack/minimist](https://github.com/substack/minimist)
 1. **minimist@1.2.5**
      * Licenses: MIT
      * Repository: [https://github.com/substack/minimist](https://github.com/substack/minimist)
@@ -2006,9 +1987,6 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **mixin-deep@1.3.2**
      * Licenses: MIT
      * Repository: [https://github.com/jonschlinkert/mixin-deep](https://github.com/jonschlinkert/mixin-deep)
-1. **mkdirp@0.5.1**
-     * Licenses: MIT
-     * Repository: [https://github.com/substack/node-mkdirp](https://github.com/substack/node-mkdirp)
 1. **mkdirp@0.5.5**
      * Licenses: MIT
      * Repository: [https://github.com/substack/node-mkdirp](https://github.com/substack/node-mkdirp)
@@ -2027,9 +2005,6 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **ms@2.1.2**
      * Licenses: MIT
      * Repository: [https://github.com/zeit/ms](https://github.com/zeit/ms)
-1. **nan@2.14.2**
-     * Licenses: MIT
-     * Repository: [https://github.com/nodejs/nan](https://github.com/nodejs/nan)
 1. **nanoid@3.1.12**
      * Licenses: MIT
      * Repository: [https://github.com/ai/nanoid](https://github.com/ai/nanoid)
@@ -2042,6 +2017,9 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **nise@4.0.4**
      * Licenses: BSD-3-Clause
      * Repository: [https://github.com/sinonjs/nise](https://github.com/sinonjs/nise)
+1. **node-fetch@2.6.1**
+     * Licenses: MIT
+     * Repository: [https://github.com/bitinn/node-fetch](https://github.com/bitinn/node-fetch)
 1. **node-forge@0.10.0**
      * Licenses: (BSD-3-Clause OR GPL-2.0)
      * Repository: [https://github.com/digitalbazaar/forge](https://github.com/digitalbazaar/forge)
@@ -2054,7 +2032,7 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **node-preload@0.2.1**
      * Licenses: MIT
      * Repository: [https://github.com/cfware/node-preload](https://github.com/cfware/node-preload)
-1. **node-releases@1.1.69**
+1. **node-releases@1.1.67**
      * Licenses: MIT
      * Repository: [https://github.com/chicoxyzzy/node-releases](https://github.com/chicoxyzzy/node-releases)
 1. **nopt@4.0.3**
@@ -2114,7 +2092,7 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **osenv@0.1.5**
      * Licenses: ISC
      * Repository: [https://github.com/npm/osenv](https://github.com/npm/osenv)
-1. **p-limit@2.2.2**
+1. **p-limit@2.3.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/p-limit](https://github.com/sindresorhus/p-limit)
 1. **p-limit@3.0.2**
@@ -2213,7 +2191,7 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **promise-polyfill@8.1.3**
      * Licenses: MIT
      * Repository: [https://github.com/taylorhakes/promise-polyfill](https://github.com/taylorhakes/promise-polyfill)
-1. **protobufjs@6.10.2**
+1. **protobufjs@6.10.1**
      * Licenses: BSD-3-Clause
      * Repository: [https://github.com/protobufjs/protobuf.js](https://github.com/protobufjs/protobuf.js)
 1. **prr@1.0.1**
@@ -2255,7 +2233,7 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **read-installed@4.0.3**
      * Licenses: ISC
      * Repository: [https://github.com/isaacs/read-installed](https://github.com/isaacs/read-installed)
-1. **read-package-json@2.1.1**
+1. **read-package-json@2.1.2**
      * Licenses: ISC
      * Repository: [https://github.com/npm/read-package-json](https://github.com/npm/read-package-json)
 1. **readable-stream@2.3.7**
@@ -2339,7 +2317,7 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **resolve-url@0.2.1**
      * Licenses: MIT
      * Repository: [https://github.com/lydell/resolve-url](https://github.com/lydell/resolve-url)
-1. **resolve@1.15.1**
+1. **resolve@1.18.1**
      * Licenses: MIT
      * Repository: [https://github.com/browserify/resolve](https://github.com/browserify/resolve)
 1. **ret@0.1.15**
@@ -2408,10 +2386,10 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **shebang-regex@3.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/sindresorhus/shebang-regex](https://github.com/sindresorhus/shebang-regex)
-1. **signal-exit@3.0.2**
+1. **signal-exit@3.0.3**
      * Licenses: ISC
      * Repository: [https://github.com/tapjs/signal-exit](https://github.com/tapjs/signal-exit)
-1. **sinon@9.2.3**
+1. **sinon@9.2.2**
      * Licenses: BSD-3-Clause
      * Repository: [https://github.com/sinonjs/sinon](https://github.com/sinonjs/sinon)
 1. **slash@2.0.0**
@@ -2453,25 +2431,25 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **spdx-compare@1.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/kemitchell/spdx-compare.js](https://github.com/kemitchell/spdx-compare.js)
-1. **spdx-correct@3.1.0**
+1. **spdx-correct@3.1.1**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/jslicense/spdx-correct.js](https://github.com/jslicense/spdx-correct.js)
-1. **spdx-exceptions@2.2.0**
+1. **spdx-exceptions@2.3.0**
      * Licenses: CC-BY-3.0
      * Repository: [https://github.com/kemitchell/spdx-exceptions.json](https://github.com/kemitchell/spdx-exceptions.json)
-1. **spdx-expression-parse@3.0.0**
+1. **spdx-expression-parse@3.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/jslicense/spdx-expression-parse.js](https://github.com/jslicense/spdx-expression-parse.js)
-1. **spdx-license-ids@3.0.5**
+1. **spdx-license-ids@3.0.6**
      * Licenses: CC0-1.0
-     * Repository: [https://github.com/shinnn/spdx-license-ids](https://github.com/shinnn/spdx-license-ids)
+     * Repository: [https://github.com/jslicense/spdx-license-ids](https://github.com/jslicense/spdx-license-ids)
 1. **spdx-ranges@2.1.1**
      * Licenses: (MIT AND CC-BY-3.0)
      * Repository: [https://github.com/kemitchell/spdx-ranges.js](https://github.com/kemitchell/spdx-ranges.js)
 1. **spdx-satisfies@4.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/kemitchell/spdx-satisfies.js](https://github.com/kemitchell/spdx-satisfies.js)
-1. **spine-web@1.7.1**
+1. **spine-web@1.7.2**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/SpineEventEngine/web](https://github.com/SpineEventEngine/web)
 1. **split-string@3.1.0**
@@ -2541,9 +2519,6 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
      * Licenses: MIT
      * Repository: [https://github.com/chalk/supports-color](https://github.com/chalk/supports-color)
 1. **supports-color@5.5.0**
-     * Licenses: MIT
-     * Repository: [https://github.com/chalk/supports-color](https://github.com/chalk/supports-color)
-1. **supports-color@7.1.0**
      * Licenses: MIT
      * Repository: [https://github.com/chalk/supports-color](https://github.com/chalk/supports-color)
 1. **supports-color@7.2.0**
@@ -2690,10 +2665,10 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **vm-browserify@1.1.2**
      * Licenses: MIT
      * Repository: [https://github.com/substack/vm-browserify](https://github.com/substack/vm-browserify)
-1. **watchpack-chokidar2@2.0.1**
+1. **watchpack-chokidar2@2.0.0**
      * Licenses: MIT
      * Repository: [https://github.com/webpack/watchpack](https://github.com/webpack/watchpack)
-1. **watchpack@1.7.5**
+1. **watchpack@1.7.4**
      * Licenses: MIT
      * Repository: [https://github.com/webpack/watchpack](https://github.com/webpack/watchpack)
 1. **webpack-cli@4.2.0**
@@ -2777,17 +2752,17 @@ This report was generated on **Fri Jan 08 18:05:44 EET 2021** using [Gradle-Lice
 1. **yargs@13.3.2**
      * Licenses: MIT
      * Repository: [https://github.com/yargs/yargs](https://github.com/yargs/yargs)
-1. **yargs@15.3.1**
+1. **yargs@15.4.1**
      * Licenses: MIT
      * Repository: [https://github.com/yargs/yargs](https://github.com/yargs/yargs)
 
 
-This report was generated on **Fri Jan 08 2021 18:05:46 GMT+0200 (Eastern European Standard Time)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
+This report was generated on **Fri Jan 29 2021 23:10:32 GMT+0200 (Eastern European Standard Time)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
 
 
 
     
-# Dependencies of `io.spine.gcloud:spine-firebase-web:1.7.1`
+# Dependencies of `io.spine.gcloud:spine-firebase-web:1.7.2`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson.core **Name:** jackson-annotations **Version:** 2.9.10
@@ -2798,7 +2773,7 @@ This report was generated on **Fri Jan 08 2021 18:05:46 GMT+0200 (Eastern Europe
      * **Project URL:** [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.fasterxml.jackson.core **Name:** jackson-databind **Version:** 2.9.10.5
+1. **Group:** com.fasterxml.jackson.core **Name:** jackson-databind **Version:** 2.9.10.8
      * **Project URL:** [http://github.com/FasterXML/jackson](http://github.com/FasterXML/jackson)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -3078,7 +3053,7 @@ This report was generated on **Fri Jan 08 2021 18:05:46 GMT+0200 (Eastern Europe
      * **Project URL:** [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.fasterxml.jackson.core **Name:** jackson-databind **Version:** 2.9.10.5
+1. **Group:** com.fasterxml.jackson.core **Name:** jackson-databind **Version:** 2.9.10.8
      * **Project URL:** [http://github.com/FasterXML/jackson](http://github.com/FasterXML/jackson)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -3479,7 +3454,6 @@ This report was generated on **Fri Jan 08 2021 18:05:46 GMT+0200 (Eastern Europe
 1. **Group:** org.jacoco **Name:** org.jacoco.report **Version:** 0.8.5
      * **POM License: Eclipse Public License 2.0** - [https://www.eclipse.org/legal/epl-2.0/](https://www.eclipse.org/legal/epl-2.0/)
 
-1. **Group:** org.junit **Name:** junit-bom **Version:** 5.7.0 **No license information found**
 1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.7.0
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
@@ -3574,12 +3548,12 @@ This report was generated on **Fri Jan 08 2021 18:05:46 GMT+0200 (Eastern Europe
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jan 08 18:05:54 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 29 22:17:16 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-js-tests:1.7.1`
+# Dependencies of `io.spine:spine-js-tests:1.7.2`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -3622,7 +3596,7 @@ This report was generated on **Fri Jan 08 18:05:54 EET 2021** using [Gradle-Lice
      * **Project URL:** [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.fasterxml.jackson.core **Name:** jackson-databind **Version:** 2.9.10.5
+1. **Group:** com.fasterxml.jackson.core **Name:** jackson-databind **Version:** 2.9.10.8
      * **Project URL:** [http://github.com/FasterXML/jackson](http://github.com/FasterXML/jackson)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -3879,7 +3853,6 @@ This report was generated on **Fri Jan 08 18:05:54 EET 2021** using [Gradle-Lice
 1. **Group:** org.jacoco **Name:** org.jacoco.report **Version:** 0.8.5
      * **POM License: Eclipse Public License 2.0** - [https://www.eclipse.org/legal/epl-2.0/](https://www.eclipse.org/legal/epl-2.0/)
 
-1. **Group:** org.junit **Name:** junit-bom **Version:** 5.7.0 **No license information found**
 1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.7.0
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
@@ -3969,12 +3942,12 @@ This report was generated on **Fri Jan 08 18:05:54 EET 2021** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jan 08 18:06:05 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 29 22:17:28 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-test-app:1.7.1`
+# Dependencies of `io.spine:spine-test-app:1.7.2`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson.core **Name:** jackson-annotations **Version:** 2.9.10
@@ -3985,7 +3958,7 @@ This report was generated on **Fri Jan 08 18:06:05 EET 2021** using [Gradle-Lice
      * **Project URL:** [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.fasterxml.jackson.core **Name:** jackson-databind **Version:** 2.9.10.5
+1. **Group:** com.fasterxml.jackson.core **Name:** jackson-databind **Version:** 2.9.10.8
      * **Project URL:** [http://github.com/FasterXML/jackson](http://github.com/FasterXML/jackson)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -4282,7 +4255,7 @@ This report was generated on **Fri Jan 08 18:06:05 EET 2021** using [Gradle-Lice
      * **Project URL:** [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.fasterxml.jackson.core **Name:** jackson-databind **Version:** 2.9.10.5
+1. **Group:** com.fasterxml.jackson.core **Name:** jackson-databind **Version:** 2.9.10.8
      * **Project URL:** [http://github.com/FasterXML/jackson](http://github.com/FasterXML/jackson)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -5362,7 +5335,6 @@ This report was generated on **Fri Jan 08 18:06:05 EET 2021** using [Gradle-Lice
 1. **Group:** org.jacoco **Name:** org.jacoco.report **Version:** 0.8.5
      * **POM License: Eclipse Public License 2.0** - [https://www.eclipse.org/legal/epl-2.0/](https://www.eclipse.org/legal/epl-2.0/)
 
-1. **Group:** org.junit **Name:** junit-bom **Version:** 5.7.0 **No license information found**
 1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.7.0
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
@@ -5548,12 +5520,12 @@ This report was generated on **Fri Jan 08 18:06:05 EET 2021** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jan 08 18:07:51 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 29 22:17:32 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-web:1.7.1`
+# Dependencies of `io.spine:spine-testutil-web:1.7.2`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -5930,7 +5902,6 @@ This report was generated on **Fri Jan 08 18:07:51 EET 2021** using [Gradle-Lice
 1. **Group:** org.jacoco **Name:** org.jacoco.report **Version:** 0.8.5
      * **POM License: Eclipse Public License 2.0** - [https://www.eclipse.org/legal/epl-2.0/](https://www.eclipse.org/legal/epl-2.0/)
 
-1. **Group:** org.junit **Name:** junit-bom **Version:** 5.7.0 **No license information found**
 1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.7.0
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
@@ -6012,12 +5983,12 @@ This report was generated on **Fri Jan 08 18:07:51 EET 2021** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jan 08 18:07:52 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 29 22:17:33 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-web:1.7.1`
+# Dependencies of `io.spine:spine-web:1.7.2`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -6433,7 +6404,6 @@ This report was generated on **Fri Jan 08 18:07:52 EET 2021** using [Gradle-Lice
 1. **Group:** org.jacoco **Name:** org.jacoco.report **Version:** 0.8.5
      * **POM License: Eclipse Public License 2.0** - [https://www.eclipse.org/legal/epl-2.0/](https://www.eclipse.org/legal/epl-2.0/)
 
-1. **Group:** org.junit **Name:** junit-bom **Version:** 5.7.0 **No license information found**
 1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.7.0
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
@@ -6515,4 +6485,4 @@ This report was generated on **Fri Jan 08 18:07:52 EET 2021** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jan 08 18:07:53 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 29 22:17:38 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -134,7 +134,7 @@
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1. **Group:** com.google.protobuf **Name:** protoc **Version:** 3.11.4
+1. **Group:** com.google.protobuf **Name:** protoc **Version:** 3.13.0
      * **POM Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -367,7 +367,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jan 29 23:10:29 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Feb 01 17:22:46 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 #NPM dependencies of `spine-web@1.7.2`
@@ -2757,7 +2757,7 @@ This report was generated on **Fri Jan 29 23:10:29 EET 2021** using [Gradle-Lice
      * Repository: [https://github.com/yargs/yargs](https://github.com/yargs/yargs)
 
 
-This report was generated on **Fri Jan 29 2021 23:10:32 GMT+0200 (Eastern European Standard Time)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
+This report was generated on **Mon Feb 01 2021 17:22:49 GMT+0200 (Eastern European Standard Time)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
 
 
 
@@ -3548,7 +3548,7 @@ This report was generated on **Fri Jan 29 2021 23:10:32 GMT+0200 (Eastern Europe
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jan 29 22:17:16 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Feb 01 17:22:57 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3942,7 +3942,7 @@ This report was generated on **Fri Jan 29 22:17:16 EET 2021** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jan 29 22:17:28 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Feb 01 17:23:04 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5520,7 +5520,7 @@ This report was generated on **Fri Jan 29 22:17:28 EET 2021** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jan 29 22:17:32 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Feb 01 17:23:08 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5983,7 +5983,7 @@ This report was generated on **Fri Jan 29 22:17:32 EET 2021** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jan 29 22:17:33 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Feb 01 17:23:09 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6485,4 +6485,4 @@ This report was generated on **Fri Jan 29 22:17:33 EET 2021** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jan 29 22:17:38 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Feb 01 17:23:12 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-web</artifactId>
-<version>1.7.1</version>
+<version>1.7.2</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -28,7 +28,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>com.fasterxml.jackson.core</groupId>
     <artifactId>jackson-databind</artifactId>
-    <version>2.9.10.5</version>
+    <version>2.9.10.8</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -128,9 +128,27 @@ all modules and does not describe the project structure per-subproject.
     <scope>test</scope>
   </dependency>
   <dependency>
+    <groupId>com.google.code.findbugs</groupId>
+    <artifactId>jsr305</artifactId>
+    <version>3.0.2</version>
+    <scope>provided</scope>
+  </dependency>
+  <dependency>
+    <groupId>com.google.errorprone</groupId>
+    <artifactId>error_prone_annotations</artifactId>
+    <version>2.4.0</version>
+    <scope>provided</scope>
+  </dependency>
+  <dependency>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_core</artifactId>
     <version>2.4.0</version>
+  </dependency>
+  <dependency>
+    <groupId>com.google.errorprone</groupId>
+    <artifactId>error_prone_type_annotations</artifactId>
+    <version>2.4.0</version>
+    <scope>provided</scope>
   </dependency>
   <dependency>
     <groupId>com.google.errorprone</groupId>
@@ -151,6 +169,12 @@ all modules and does not describe the project structure per-subproject.
     <groupId>io.spine</groupId>
     <artifactId>spine-client</artifactId>
     <version>1.7.1</version>
+  </dependency>
+  <dependency>
+    <groupId>io.spine.tools</groupId>
+    <artifactId>spine-errorprone-checks</artifactId>
+    <version>1.7.4</version>
+    <scope>provided</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
@@ -175,7 +199,18 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>
     <artifactId>pmd-java</artifactId>
+    <version>6.24.0</version>
+  </dependency>
+  <dependency>
+    <groupId>net.sourceforge.pmd</groupId>
+    <artifactId>pmd-java</artifactId>
     <version>6.26.0</version>
+  </dependency>
+  <dependency>
+    <groupId>org.checkerframework</groupId>
+    <artifactId>checker-qual</artifactId>
+    <version>3.7.1</version>
+    <scope>provided</scope>
   </dependency>
   <dependency>
     <groupId>org.gretty</groupId>

--- a/scripts/js.gradle
+++ b/scripts/js.gradle
@@ -189,7 +189,7 @@ protoJs {
 protobuf {
     generatedFilesBaseDir = genProtoBaseDir
     protoc {
-        artifact = deps.build.protoc
+        artifact = io.spine.gradle.internal.Deps.build.protoc
     }
     generateProtoTasks {
         all().each { final task ->

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,5 +29,5 @@ val spineTimeVersion: String by extra("1.7.1")
 val spineCoreVersion: String by extra("1.7.1")
 val spineVersion: String by extra(spineCoreVersion)
 
-val versionToPublish: String by extra("1.7.1")
+val versionToPublish: String by extra("1.7.2")
 val versionToPublishJs: String by extra(versionToPublish)


### PR DESCRIPTION
This PR fixes the handling of the Firebase RDB emulator endpoint. The DB URL may be of two formats:
* the `https://<database-alias>.firebaseio.com` DB URL points to a remote Firebase RDB;
* the `http://<local-ip>:<local-port>?ns=<database-alias>` points to a local Firebase RDB emulator.

For the latter, the `ns` part stands for `namespace` and is effectively used by the emulator as a way to determine the local database instance to be used. Prior to the improvement, such a query in the URL was not handled properly and it was not possible to connect to a specific database thus one should have to just guess which database would be used (from what I understood, if `127.0.0.1` IP address is used, the DB name would be `127`, for `localhost` I was not able to determine which one is used).

The PR also bumps the Jackson version to address [security vulnerability](https://github.com/advisories/GHSA-5949-rw7g-wx7w).