### PR TITLE
Publish `spine-testutils-web`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,7 +68,7 @@ plugins {
 }
 
 extra["credentialsPropertyFile"] = PublishingRepos.cloudRepo.credentials
-extra["projectsToPublish"] = listOf("web", "firebase-web")
+extra["projectsToPublish"] = listOf("web", "firebase-web", "testutil-web")
 
 allprojects {
     apply {

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spine-web",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "license": "Apache-2.0",
   "description": "A JS client for interacting with Spine applications.",
   "homepage": "https://spine.io",

--- a/integration-tests/js-tests/package.json
+++ b/integration-tests/js-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-js-tests",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "license": "Apache-2.0",
   "description": "Tests of a `spine-web` JS library against the Spine-based application.",
   "scripts": {

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client-js:1.7.2`
+# Dependencies of `io.spine:spine-client-js:1.7.3`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -367,10 +367,10 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Feb 01 17:22:46 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 04 13:36:38 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
-#NPM dependencies of `spine-web@1.7.2`
+#NPM dependencies of `spine-web@1.7.3`
 
 ## `Production` dependencies:
 
@@ -389,7 +389,7 @@ This report was generated on **Mon Feb 01 17:22:46 EET 2021** using [Gradle-Lice
 1. **rxjs@6.5.5**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/reactivex/rxjs](https://github.com/reactivex/rxjs)
-1. **spine-web@1.7.2**
+1. **spine-web@1.7.3**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/SpineEventEngine/web](https://github.com/SpineEventEngine/web)
 1. **tslib@1.14.1**
@@ -2449,7 +2449,7 @@ This report was generated on **Mon Feb 01 17:22:46 EET 2021** using [Gradle-Lice
 1. **spdx-satisfies@4.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/kemitchell/spdx-satisfies.js](https://github.com/kemitchell/spdx-satisfies.js)
-1. **spine-web@1.7.2**
+1. **spine-web@1.7.3**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/SpineEventEngine/web](https://github.com/SpineEventEngine/web)
 1. **split-string@3.1.0**
@@ -2757,12 +2757,12 @@ This report was generated on **Mon Feb 01 17:22:46 EET 2021** using [Gradle-Lice
      * Repository: [https://github.com/yargs/yargs](https://github.com/yargs/yargs)
 
 
-This report was generated on **Mon Feb 01 2021 17:22:49 GMT+0200 (Eastern European Standard Time)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
+This report was generated on **Thu Mar 04 2021 13:36:42 GMT+0200 (Eastern European Standard Time)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
 
 
 
     
-# Dependencies of `io.spine.gcloud:spine-firebase-web:1.7.2`
+# Dependencies of `io.spine.gcloud:spine-firebase-web:1.7.3`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson.core **Name:** jackson-annotations **Version:** 2.9.10
@@ -3548,12 +3548,12 @@ This report was generated on **Mon Feb 01 2021 17:22:49 GMT+0200 (Eastern Europe
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Feb 01 17:22:57 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 04 13:36:50 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-js-tests:1.7.2`
+# Dependencies of `io.spine:spine-js-tests:1.7.3`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -3942,12 +3942,12 @@ This report was generated on **Mon Feb 01 17:22:57 EET 2021** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Feb 01 17:23:04 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 04 13:37:42 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-test-app:1.7.2`
+# Dependencies of `io.spine:spine-test-app:1.7.3`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson.core **Name:** jackson-annotations **Version:** 2.9.10
@@ -5520,12 +5520,12 @@ This report was generated on **Mon Feb 01 17:23:04 EET 2021** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Feb 01 17:23:08 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 04 13:37:48 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-web:1.7.2`
+# Dependencies of `io.spine:spine-testutil-web:1.7.3`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -5983,12 +5983,12 @@ This report was generated on **Mon Feb 01 17:23:08 EET 2021** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Feb 01 17:23:09 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 04 13:37:52 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-web:1.7.2`
+# Dependencies of `io.spine:spine-web:1.7.3`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -6485,4 +6485,4 @@ This report was generated on **Mon Feb 01 17:23:09 EET 2021** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Feb 01 17:23:12 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 04 13:37:58 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-web</artifactId>
-<version>1.7.2</version>
+<version>1.7.3</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/testutil-web/src/main/java/io/spine/web/given/KnownRequest.java
+++ b/testutil-web/src/main/java/io/spine/web/given/KnownRequest.java
@@ -29,6 +29,7 @@ package io.spine.web.given;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.net.MediaType;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.io.BufferedReader;
@@ -151,7 +152,7 @@ public final class KnownRequest implements MockedRequest {
     }
 
     @Override
-    public @Nullable String getContentType() {
+    public @NonNull String getContentType() {
         return type.toString();
     }
 
@@ -162,6 +163,11 @@ public final class KnownRequest implements MockedRequest {
                         new ByteArrayInputStream(content), StandardCharsets.UTF_8
                 )
         );
+    }
+
+    @Override
+    public @NonNull String getRequestURI() {
+        return uri;
     }
 
     /**

--- a/testutil-web/src/main/java/io/spine/web/given/KnownRequest.java
+++ b/testutil-web/src/main/java/io/spine/web/given/KnownRequest.java
@@ -84,36 +84,10 @@ public final class KnownRequest implements MockedRequest {
     public static KnownRequest create(String content, MediaType type) {
         checkNotNull(content);
         checkNotNull(type);
-        return create(content, type, contentTypeHeader(type));
-    }
-
-    /**
-     * Creates a new mocked request with specified {@code content}, {@code type}
-     * and {@code headers}.
-     */
-    public static KnownRequest create(String content,
-                                      MediaType type,
-                                      ImmutableMap<String, String> headers) {
-        checkNotNull(content);
-        checkNotNull(type);
-        checkNotNull(headers);
-        return create(content.getBytes(StandardCharsets.UTF_8), type, headers);
-    }
-
-    /**
-     * Creates a new mocked request with specified {@code content}, {@code type}
-     * and {@code headers}.
-     */
-    public static KnownRequest create(byte[] content,
-                                      MediaType type,
-                                      ImmutableMap<String, String> headers) {
-        checkNotNull(content);
-        checkNotNull(type);
-        checkNotNull(headers);
         return newBuilder()
-                .withBinaryContent(content)
+                .withContent(content)
                 .withType(type)
-                .withHeaders(headers)
+                .withHeaders(contentTypeHeader(type))
                 .build();
     }
 

--- a/testutil-web/src/main/java/io/spine/web/given/KnownRequest.java
+++ b/testutil-web/src/main/java/io/spine/web/given/KnownRequest.java
@@ -159,7 +159,7 @@ public final class KnownRequest implements MockedRequest {
     }
 
     /**
-     * The request builder.
+     * A builder for producing {@code KnownRequest} instances.
      */
     public static class Builder {
 

--- a/testutil-web/src/main/java/io/spine/web/given/KnownRequest.java
+++ b/testutil-web/src/main/java/io/spine/web/given/KnownRequest.java
@@ -45,7 +45,7 @@ import static com.google.common.collect.Iterators.singletonIterator;
 import static java.util.Collections.emptyIterator;
 
 /**
- * A mocked servlet request with pre-defined {@code content}, {@code type} and {@code headers}.
+ * A mocked servlet request with pre-defined content.
  *
  * @implNote The request is effectively immutable and does not pay attention to any
  *         modification attempts. Such a mocked implementation may be used for tests where

--- a/testutil-web/src/main/java/io/spine/web/given/KnownRequest.java
+++ b/testutil-web/src/main/java/io/spine/web/given/KnownRequest.java
@@ -70,6 +70,20 @@ public final class KnownRequest implements MockedRequest {
     }
 
     /**
+     * Creates an empty request.
+     */
+    public static KnownRequest empty() {
+        return newBuilder().build();
+    }
+
+    /**
+     * Creates a new request builder.
+     */
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    /**
      * Creates a new mocked request with specified {@code content} and default
      * {@linkplain MediaType#ANY_TYPE any} type.
      */
@@ -142,20 +156,6 @@ public final class KnownRequest implements MockedRequest {
     @Override
     public @NonNull String getRequestURI() {
         return uri;
-    }
-
-    /**
-     * Creates an empty request.
-     */
-    public static KnownRequest empty() {
-        return newBuilder().build();
-    }
-
-    /**
-     * Creates a new request builder.
-     */
-    public static Builder newBuilder() {
-        return new Builder();
     }
 
     /**

--- a/testutil-web/src/test/java/io/spine/web/given/KnownRequestTest.java
+++ b/testutil-web/src/test/java/io/spine/web/given/KnownRequestTest.java
@@ -55,7 +55,12 @@ class KnownRequestTest {
         String headerName = "custom";
         String headerValue = "header";
         ImmutableMap<String, String> headers = ImmutableMap.of(headerName, headerValue);
-        KnownRequest request = KnownRequest.create(text, type, headers);
+        KnownRequest request = KnownRequest
+                .newBuilder()
+                .withContent(text)
+                .withType(type)
+                .withHeaders(headers)
+                .build();
         assertThat(request.getContentLength())
                 .isEqualTo(text.length());
         assertThat(request.getContentLengthLong())

--- a/testutil-web/src/test/java/io/spine/web/given/KnownRequestTest.java
+++ b/testutil-web/src/test/java/io/spine/web/given/KnownRequestTest.java
@@ -27,6 +27,7 @@
 package io.spine.web.given;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.io.CharStreams;
 import com.google.common.net.MediaType;
 import com.google.common.testing.NullPointerTester;
 import org.junit.jupiter.api.DisplayName;
@@ -49,9 +50,11 @@ final class KnownRequestTest {
 
     @Test
     @DisplayName("return set values")
-    @SuppressWarnings("JdkObsolete") // we're force to follow the contract
+    @SuppressWarnings("JdkObsolete")
+        // we're force to follow the contract
     void returnSetValues() throws IOException {
         String text = "some text";
+        String uri = "/perform/action";
         MediaType type = MediaType.PLAIN_TEXT_UTF_8;
         String headerName = "custom";
         String headerValue = "header";
@@ -61,6 +64,7 @@ final class KnownRequestTest {
                 .withContent(text)
                 .withType(type)
                 .withHeaders(headers)
+                .withUri(uri)
                 .build();
         assertThat(request.getContentLength())
                 .isEqualTo(text.length());
@@ -79,6 +83,22 @@ final class KnownRequestTest {
         assertThat(request.getReader()
                           .readLine())
                 .isEqualTo(text);
+        assertThat(request.getRequestURI())
+                .isEqualTo(uri);
+    }
+
+    @Test
+    @DisplayName("create empty request")
+    void empty() throws IOException {
+        KnownRequest request = KnownRequest.empty();
+        assertThat(request.getContentLength())
+                .isEqualTo(0);
+        assertThat(request.getContentLengthLong())
+                .isEqualTo(0);
+        assertThat(request.getContentType())
+                .isEqualTo(MediaType.ANY_TYPE.toString());
+        assertThat(CharStreams.toString(request.getReader()))
+                .isEmpty();
         assertThat(request.getRequestURI())
                 .isEmpty();
     }

--- a/testutil-web/src/test/java/io/spine/web/given/KnownRequestTest.java
+++ b/testutil-web/src/test/java/io/spine/web/given/KnownRequestTest.java
@@ -73,5 +73,7 @@ class KnownRequestTest {
         assertThat(request.getReader()
                           .readLine())
                 .isEqualTo(text);
+        assertThat(request.getRequestURI())
+                .isEmpty();
     }
 }

--- a/testutil-web/src/test/java/io/spine/web/given/KnownRequestTest.java
+++ b/testutil-web/src/test/java/io/spine/web/given/KnownRequestTest.java
@@ -37,13 +37,14 @@ import java.io.IOException;
 import static com.google.common.truth.Truth.assertThat;
 
 @DisplayName("`KnownRequest` should")
-class KnownRequestTest {
+final class KnownRequestTest {
 
     @Test
     @DisplayName("not tolerate `null`s")
     void notTolerateNull() {
         NullPointerTester tester = new NullPointerTester();
         tester.testAllPublicStaticMethods(KnownRequest.class);
+        tester.testAllPublicInstanceMethods(KnownRequest.newBuilder());
     }
 
     @Test

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,5 +29,5 @@ val spineTimeVersion: String by extra("1.7.1")
 val spineCoreVersion: String by extra("1.7.1")
 val spineVersion: String by extra(spineCoreVersion)
 
-val versionToPublish: String by extra("1.7.2")
+val versionToPublish: String by extra("1.7.3")
 val versionToPublishJs: String by extra(versionToPublish)


### PR DESCRIPTION
In this PR I configured publishing of the `spine-testutils-web` module.

As part of the PR, I have also refined the `KnownRequest` public API and added a respective `Builder`.