### PR TITLE
Fix JS publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,3 +50,4 @@ jobs:
           # https://docs.github.com/en/actions/reference/environment-variables
           REPO_SLUG: $GITHUB_REPOSITORY    # e.g. SpineEventEngine/core-java
           GOOGLE_APPLICATION_CREDENTIALS: ./maven-publisher.json
+          NPM_TOKEN: ${{ secrets.NPM_SECRET }}

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -25,22 +25,13 @@
  */
 
 /**
- * This script uses three declarations of the constant [licenseReportVersion] because
+ * This script uses two declarations of the constant [licenseReportVersion] because
  * currently there is no way to define a constant _before_ a build script of `buildSrc`.
  * We cannot use imports or do something else before the `buildscript` or `plugin` clauses.
  *
  * Therefore, when a version of [io.spine.internal.dependency.LicenseReport] changes, it should be
- * changed in the Kotlin object _and_ in this file below thrice.
+ * changed in the Kotlin object _and_ in this file below twice.
  */
-buildscript {
-    repositories {
-        gradlePluginPortal()
-    }
-    val licenseReportVersion = "1.16"
-    dependencies {
-        classpath("com.github.jk1:gradle-license-report:${licenseReportVersion}")
-    }
-}
 
 plugins {
     java

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Scripts.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Scripts.kt
@@ -53,7 +53,6 @@ object Scripts {
 
     fun checkstyle(p: Project)             = p.script("checkstyle.gradle")
     fun runBuild(p: Project)               = p.script("run-build.gradle")
-    fun modelCompiler(p: Project)          = p.script("model-compiler.gradle")
     fun licenseReportCommon(p: Project)    = p.script("license-report-common.gradle")
     fun projectLicenseReport(p: Project)   = p.script("license-report-project.gradle")
     fun repoLicenseReport(p: Project)      = p.script("license-report-repo.gradle")

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spine-web",
-  "version": "2.0.0-SNAPSHOT.65",
+  "version": "2.0.0-SNAPSHOT.67",
   "license": "Apache-2.0",
   "description": "A JS client for interacting with Spine applications.",
   "homepage": "https://spine.io",

--- a/integration-tests/js-tests/package.json
+++ b/integration-tests/js-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-js-tests",
-  "version": "2.0.0-SNAPSHOT.65",
+  "version": "2.0.0-SNAPSHOT.67",
   "license": "Apache-2.0",
   "description": "Tests of a `spine-web` JS library against the Spine-based application.",
   "scripts": {

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:client-js:2.0.0-SNAPSHOT.65`
+# Dependencies of `io.spine:client-js:2.0.0-SNAPSHOT.67`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -461,12 +461,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Oct 01 20:53:14 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 04 18:28:30 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.gcloud:firebase-web:2.0.0-SNAPSHOT.65`
+# Dependencies of `io.spine.gcloud:firebase-web:2.0.0-SNAPSHOT.67`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson **Name:** jackson-bom **Version:** 2.12.4 **No license information found**
@@ -1324,12 +1324,12 @@ This report was generated on **Fri Oct 01 20:53:14 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Oct 01 20:53:17 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 04 18:28:53 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:js-tests:2.0.0-SNAPSHOT.65`
+# Dependencies of `io.spine:js-tests:2.0.0-SNAPSHOT.67`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -1816,12 +1816,12 @@ This report was generated on **Fri Oct 01 20:53:17 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Oct 01 20:53:25 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 04 18:29:15 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:test-app:2.0.0-SNAPSHOT.65`
+# Dependencies of `io.spine:test-app:2.0.0-SNAPSHOT.67`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson **Name:** jackson-bom **Version:** 2.12.4 **No license information found**
@@ -3459,12 +3459,12 @@ This report was generated on **Fri Oct 01 20:53:25 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Oct 01 20:53:27 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 04 18:33:23 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:testutil-web:2.0.0-SNAPSHOT.65`
+# Dependencies of `io.spine:testutil-web:2.0.0-SNAPSHOT.67`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -4060,12 +4060,12 @@ This report was generated on **Fri Oct 01 20:53:27 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Oct 01 20:53:28 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 04 18:33:25 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:web:2.0.0-SNAPSHOT.65`
+# Dependencies of `io.spine:web:2.0.0-SNAPSHOT.67`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -4635,4 +4635,4 @@ This report was generated on **Fri Oct 01 20:53:28 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Oct 01 20:53:30 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 04 18:33:27 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-web</artifactId>
-<version>2.0.0-SNAPSHOT.65</version>
+<version>2.0.0-SNAPSHOT.67</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -124,7 +124,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.65</version>
+    <version>2.0.0-SNAPSHOT.67</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -167,13 +167,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-checks</artifactId>
-    <version>2.0.0-SNAPSHOT.65</version>
+    <version>2.0.0-SNAPSHOT.67</version>
     <scope>provided</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-protoc</artifactId>
-    <version>2.0.0-SNAPSHOT.65</version>
+    <version>2.0.0-SNAPSHOT.67</version>
   </dependency>
   <dependency>
     <groupId>javax.servlet</groupId>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,11 +24,11 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val spineBaseVersion: String by extra("2.0.0-SNAPSHOT.65")
+val spineBaseVersion: String by extra("2.0.0-SNAPSHOT.67")
 val spineBaseTypesVersion: String by extra("2.0.0-SNAPSHOT.64")
 val spineTimeVersion: String by extra("2.0.0-SNAPSHOT.64")
 val spineCoreVersion: String by extra("2.0.0-SNAPSHOT.61")
 val spineVersion: String by extra(spineCoreVersion)
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.65")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.67")
 val versionToPublishJs: String by extra(versionToPublish)


### PR DESCRIPTION
This PR updates the GitHub Actions workflow in order to include `NPM_TOKEN` environment variable.

With it, the publishing of the JS artifact to the npm registry should work better.

Additionally, the fresh `base` version has been used. And the latest `config` contents are now used as well.