### PR TITLE
[1.x] Improve subscription cancellation

### DIFF
--- a/client-js/main/client/client.js
+++ b/client-js/main/client/client.js
@@ -184,6 +184,16 @@ export class Client {
   }
 
   /**
+   * Immediately cancels all active subscriptions.
+   *
+   * This endpoint is handy to use when an end-user chooses to end her session
+   * with the web app. E.g. all subscriptions should be cancelled upon user sign-out.
+   */
+  cancelAllSubscriptions() {
+    throw new Error('Not implemented in abstract base.');
+  }
+
+  /**
    * Subscribes to the given `Topic` instance.
    *
    * The topic should have an entity type as target. Use {@link #subscribeToEvents} to subscribe to

--- a/client-js/main/client/composite-client.js
+++ b/client-js/main/client/composite-client.js
@@ -93,6 +93,13 @@ export class CompositeClient extends Client {
   /**
    * @override
    */
+  cancelAllSubscriptions() {
+    this._subscribing.cancelAllSubscriptions();
+  }
+
+  /**
+   * @override
+   */
   subscribeToEvent(eventType) {
     return this._subscribing.subscribeToEvent(eventType, this);
   }

--- a/client-js/main/client/firebase-client.js
+++ b/client-js/main/client/firebase-client.js
@@ -83,9 +83,9 @@ class SpineSubscription extends Subscription {
 class EntitySubscription extends SpineSubscription {
 
   /**
-   * @param {Function} unsubscribe the callbacks that allows to cancel the subscription
+   * @param {Function} unsubscribe the callback that allows to cancel the subscription
    * @param {{itemAdded: Observable, itemChanged: Observable, itemRemoved: Observable}} observables
-   *        the observables for entity changes
+   *        the observables for entity change
    * @param {SubscriptionObject} subscription the wrapped subscription object
    */
   constructor({

--- a/client-js/main/client/firebase-client.js
+++ b/client-js/main/client/firebase-client.js
@@ -269,6 +269,13 @@ class FirebaseSubscribingClient extends SubscribingClient {
   }
 
   /**
+   * @override
+   */
+  cancelAllSubscriptions() {
+    this._subscriptionService.cancelAllSubscriptions();
+  }
+
+  /**
    * Unsubscribes the provided Firebase subscriptions.
    *
    * @param {Array<Subscription>} subscriptions

--- a/client-js/main/client/firebase-client.js
+++ b/client-js/main/client/firebase-client.js
@@ -35,7 +35,6 @@ import {ActorRequestFactory} from './actor-request-factory';
 import {AbstractClientFactory} from './client-factory';
 import {CommandingClient} from "./commanding-client";
 import {CompositeClient} from "./composite-client";
-import {HttpClient} from './http-client';
 import {HttpEndpoint} from './http-endpoint';
 import {FirebaseDatabaseClient} from './firebase-database-client';
 import {FirebaseSubscriptionService} from './firebase-subscription-service';

--- a/client-js/main/client/firebase-client.js
+++ b/client-js/main/client/firebase-client.js
@@ -275,7 +275,7 @@ class FirebaseSubscribingClient extends SubscribingClient {
     return new EventSubscription({
       unsubscribedBy: () => {
         FirebaseSubscribingClient._unsubscribe([pathSubscription]);
-        return this._subscriptionService.cancelSubscription(subscription);
+        this._subscriptionService.cancelSubscription(subscription);
       },
       withObservable: ObjectToProto.map(itemAdded.asObservable(), EVENT_TYPE_URL),
       forInternal: subscription

--- a/client-js/main/client/firebase-client.js
+++ b/client-js/main/client/firebase-client.js
@@ -242,6 +242,15 @@ class FirebaseSubscribingClient extends SubscribingClient {
     return new EntitySubscription({
       unsubscribedBy: () => {
         FirebaseSubscribingClient._unsubscribe(pathSubscriptions);
+        // TODO:alex.tymchenko:2023-01-17: find out how to report `Promise` errors, and where.
+        this._subscriptionService.cancelSubscription(subscription)
+            .then(
+                (result) => {
+                  console.log("Subscription successfully cancelled: " + JSON.stringify(result))
+                },
+                () => console.warn("Error sending the subscription" +
+                    " cancellation request to the server-side.")
+            );
       },
       withObservables: {
         itemAdded: ObjectToProto.map(itemAdded.asObservable(), typeUrl),

--- a/client-js/main/client/firebase-subscription-service.js
+++ b/client-js/main/client/firebase-subscription-service.js
@@ -100,6 +100,17 @@ export class FirebaseSubscriptionService {
   }
 
   /**
+   * Immediately cancels the given subscription, including cancelling it on the server-side.
+   *
+   * @param {SubscriptionObject} subscription the subscription to cancel
+   * @return {Promise<Object>} a promise of a successful server response, rejected if
+   *                           an error occurs
+   */
+  cancelSubscription(subscription) {
+    return this._endpoint.cancelSubscription(subscription);
+  }
+
+  /**
    * Indicates whether this service is running keeping up subscriptions.
    *
    * @returns {boolean}

--- a/client-js/main/client/firebase-subscription-service.js
+++ b/client-js/main/client/firebase-subscription-service.js
@@ -38,8 +38,8 @@ import {Status} from '../proto/spine/core/response_pb';
 const DEFAULT_KEEP_UP_INTERVAL = new Duration({minutes: 2});
 
 /**
- * A service that manages the active subscriptions periodically sending requests to keep them
- * running.
+ * A service that manages the active subscriptions periodically sending requests
+ * to keep them running.
  */
 export class FirebaseSubscriptionService {
 
@@ -177,10 +177,22 @@ export class FirebaseSubscriptionService {
    * Removes the provided subscription from subscriptions list, which stops any attempts
    * to update it. In case no more subscriptions are left, stops this service.
    *
+   * In case the passed subscription is not known to this service, does nothing.
+   *
+   * @param subscription a subscription to cancel;
+   *                     this method accepts values of both `SpineSubscription`
+   *                     and Proto `Subscription` types,
+   *                     and operates based on the subscription ID
    * @private
    */
   _removeSubscription(subscription) {
-    const index = this._subscriptions.indexOf(subscription);
+    let id;
+    if (typeof subscription.id === 'function') {
+      id = subscription.id();
+    } else {
+      id = subscription.getId().getValue();
+    }
+    const index = this._subscriptions.findIndex(item => item.id() === id);
     this._subscriptions.splice(index, 1);
 
     if (this._subscriptions.length === 0) {

--- a/client-js/main/client/firebase-subscription-service.js
+++ b/client-js/main/client/firebase-subscription-service.js
@@ -103,11 +103,12 @@ export class FirebaseSubscriptionService {
    * Immediately cancels the given subscription, including cancelling it on the server-side.
    *
    * @param {SubscriptionObject} subscription the subscription to cancel
-   * @return {Promise<Object>} a promise of a successful server response, rejected if
-   *                           an error occurs
    */
   cancelSubscription(subscription) {
-    return this._endpoint.cancelSubscription(subscription);
+    this._endpoint.cancelSubscription(subscription)
+        .then(() => {
+          this._removeSubscription(subscription)
+        });
   }
 
   /**

--- a/client-js/main/client/firebase-subscription-service.js
+++ b/client-js/main/client/firebase-subscription-service.js
@@ -85,6 +85,21 @@ export class FirebaseSubscriptionService {
   }
 
   /**
+   * Immediately cancels all active subscriptions previously created through this service.
+   */
+  cancelAllSubscriptions() {
+    const activeSubscriptions = this._subscriptions.filter(s => !s.closed);
+    if (activeSubscriptions.length > 0) {
+      const subscriptionMessages = activeSubscriptions.map(s => s.internal())
+      this._endpoint.cancelAll(subscriptionMessages);
+      activeSubscriptions.forEach(s => {
+        s.unsubscribe() /* Calling RxJS's `unsubscribe` to stop propagating the updates. */
+        this._removeSubscription(s)
+      })
+    }
+  }
+
+  /**
    * Indicates whether this service is running keeping up subscriptions.
    *
    * @returns {boolean}

--- a/client-js/main/client/subscribing-client.js
+++ b/client-js/main/client/subscribing-client.js
@@ -86,6 +86,13 @@ export class SubscribingClient {
   }
 
   /**
+   * Cancels all subscriptions, which were created through this instance of subscribing client.
+   */
+  cancelAllSubscriptions() {
+    throw new Error('Not implemented in abstract base.');
+  }
+
+  /**
    * Returns a new topic factory instance which can be further used for the `Topic` creation.
    *
    * @return {TopicFactory}
@@ -121,6 +128,15 @@ export class NoOpSubscribingClient extends SubscribingClient {
    * @override
    */
   subscribeToEvents(topic) {
+    throw new Error(SUBSCRIPTIONS_NOT_SUPPORTED);
+  }
+
+  /**
+   * Always throws an error.
+   *
+   * @override
+   */
+  cancelAllSubscriptions() {
     throw new Error(SUBSCRIPTIONS_NOT_SUPPORTED);
   }
 }

--- a/client-js/package.json
+++ b/client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spine-web",
-  "version": "1.9.0-SNAPSHOT.9",
+  "version": "1.9.0-SNAPSHOT.10",
   "license": "Apache-2.0",
   "description": "A JS client for interacting with Spine applications.",
   "homepage": "https://spine.io",

--- a/firebase-web/src/main/java/io/spine/web/firebase/FirebaseCredentials.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/FirebaseCredentials.java
@@ -50,8 +50,7 @@ import static java.util.Arrays.asList;
  *
  * <p>See <a href="https://firebase.google.com/docs/database/rest/auth">Firebase REST docs</a>.
  */
-@SuppressWarnings("deprecation")
-// Use deprecated `GoogleCredential` to retain backward compatibility.
+@SuppressWarnings("deprecation" /*`GoogleCredential` is used to retain backward compatibility.*/)
 public final class FirebaseCredentials implements HttpRequestInitializer {
 
     private static final String AUTH_DATABASE = "https://www.googleapis.com/auth/firebase.database";

--- a/firebase-web/src/main/java/io/spine/web/firebase/subscription/FirebaseSubscriptionBridge.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/subscription/FirebaseSubscriptionBridge.java
@@ -209,13 +209,18 @@ public final class FirebaseSubscriptionBridge
         /**
          * Creates a new instance of {@code FirebaseQueryBridge}.
          *
+         * <p>Mandatory fields are {@link #setFirebaseClient(FirebaseClient) firebaseClient}
+         * and {@link #setSubscriptionService(SubscriptionServiceImplBase) subscriptionService}.
+         *
          * @return new instance of {@code FirebaseQueryBridge}
          */
         public FirebaseSubscriptionBridge build() {
             checkState(firebaseClient != null,
-                       "Firebase database client is not set to FirebaseSubscriptionBridge.");
+                       "Mandatory Firebase database client" +
+                               " is not specified for `FirebaseSubscriptionBridge`.");
             checkState(subscriptionService != null,
-                       "Subscription Service is not set to FirebaseSubscriptionBridge.");
+                       "Mandatory Subscription Service is not specified" +
+                               " for `FirebaseSubscriptionBridge`.");
             return new FirebaseSubscriptionBridge(this);
         }
     }

--- a/firebase-web/src/main/java/io/spine/web/firebase/subscription/HealthLog.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/subscription/HealthLog.java
@@ -47,7 +47,7 @@ import static java.util.Collections.synchronizedMap;
  * <p>To understand whether a client is still listening to the {@code Topic} updates, she
  * periodically sends a {@link FirebaseSubscriptionBridge#keepUp(Subscription) keepUp(Subscription)}
  * request. The server records the timestamps of these requests in this log and counts the client
- * alive, as long as the {@linkplain #withTimeout(Duration)} configured} timeout does not pass
+ * alive, as long as the {@linkplain #withTimeout(Duration) configured} timeout does not pass
  * since the last request.
  */
 final class HealthLog {

--- a/firebase-web/src/main/java/io/spine/web/firebase/subscription/HealthLog.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/subscription/HealthLog.java
@@ -113,4 +113,15 @@ final class HealthLog {
         Duration elapsed = between(lastUpdate, now);
         return compare(elapsed, expirationTimeout) > 0;
     }
+
+    /**
+     * Removes the given {@code Topic} from this health log.
+     *
+     * <p>In case this topic is not known to this registry, does nothing, allowing
+     * to safely clear the health log from stale topics potentially residing in storage
+     * on either client- or server-sides.
+     */
+    void remove(Topic topic) {
+        updateTimes.remove(topic.getId());
+    }
 }

--- a/firebase-web/src/main/java/io/spine/web/firebase/subscription/SubscriptionRepository.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/subscription/SubscriptionRepository.java
@@ -152,6 +152,7 @@ final class SubscriptionRepository {
         checkNotNull(topic);
         NodePath path = pathForSubscription(topic);
         firebase.delete(path);
+        healthLog.remove(topic);
     }
 
     private static NodePath pathForSubscription(Topic topic) {

--- a/firebase-web/src/main/java/io/spine/web/firebase/subscription/SubscriptionRepository.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/subscription/SubscriptionRepository.java
@@ -81,7 +81,7 @@ final class SubscriptionRepository {
     /**
      * Fetches all the existing subscriptions from the Firebase and activates them.
      *
-     * <p>After calling this method, all the new subscriptions are automatically activates on this
+     * <p>After calling this method, all the new subscriptions are automatically activated on this
      * server instance.
      */
     void subscribeToAll() {

--- a/firebase-web/src/main/java/io/spine/web/firebase/subscription/SubscriptionRepository.java
+++ b/firebase-web/src/main/java/io/spine/web/firebase/subscription/SubscriptionRepository.java
@@ -217,7 +217,12 @@ final class SubscriptionRepository {
 
         @Override
         public void onChildRemoved(DataSnapshot snapshot) {
-            // NOP.
+            String json = asJson(snapshot);
+            Topic topic = loadTopic(json);
+            HealthLog healthLog = repository.healthLog;
+            if (healthLog.isKnown(topic)) {
+                repository.delete(topic);
+            }
         }
 
         @Override

--- a/integration-tests/js-tests/package.json
+++ b/integration-tests/js-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-js-tests",
-  "version": "1.9.0-SNAPSHOT.9",
+  "version": "1.9.0-SNAPSHOT.10",
   "license": "Apache-2.0",
   "description": "Tests of a `spine-web` JS library against the Spine-based application.",
   "scripts": {

--- a/integration-tests/js-tests/test/firebase-client/subscribe-test.js
+++ b/integration-tests/js-tests/test/firebase-client/subscribe-test.js
@@ -539,15 +539,13 @@ describe('FirebaseClient subscription', function () {
       });
     });
 
-    it('and canceled on the next keep up interval if unsubscribed', done => {
+    it('and cancel subscription immediately if unsubscribed', done => {
       const cancelEndpoint = cancelEndpointSpy();
-
       subscribeToAllTasks().then(async ({itemAdded, itemChanged, itemRemoved, unsubscribe}) => {
         assert.ok(cancelEndpoint.notCalled);
         unsubscribe();
-        await nextInterval();
         assert.ok(cancelEndpoint.calledOnce);
-        const subscriptionMessage = cancelEndpoint.getCall(0).args[0][0];
+        const subscriptionMessage = cancelEndpoint.getCall(0).args[0];
         checkAllTasks(subscriptionMessage);
         done();
       });
@@ -564,10 +562,10 @@ describe('FirebaseClient subscription', function () {
         assert.ok(keepUpEndpoint.calledOnce);
         assert.ok(cancelEndpoint.notCalled);
         unsubscribe();
+        assert.ok(cancelEndpoint.calledOnce);
 
         await nextInterval();
         assert.ok(keepUpEndpoint.calledOnce);
-        assert.ok(cancelEndpoint.calledOnce);
 
         await nextInterval();
         assert.ok(keepUpEndpoint.calledOnce);
@@ -618,7 +616,7 @@ describe('FirebaseClient subscription', function () {
 
     function cancelEndpointSpy() {
       const httpEndpoint = client._subscribing._endpoint;
-      return sandbox.spy(httpEndpoint, 'cancelAll');
+      return sandbox.spy(httpEndpoint, 'cancelSubscription');
     }
 
     /**

--- a/integration-tests/js-tests/test/test-helpers.js
+++ b/integration-tests/js-tests/test/test-helpers.js
@@ -139,7 +139,7 @@ function arraysEqualDeep(arr1, arr2, compare) {
  * @param {EntitySubscriptionObject<T>} subscription a subscription to retrieve values
  * @param {(o1: T, o2: T) => boolean} compare a function that compares objects of `T` type;
  *      returns `true` if objects are considered equal, `false` otherwise
- * @return {Observable<T[]>} an observable that emits a list of values, composed from the given
+ * @return {Observable<T[]>} an observable that emits a list of values, composed of the given
  *      subscription object
  *
  * @template <T> a class of a subscription target entities

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client-js:1.9.0-SNAPSHOT.9`
+# Dependencies of `io.spine:spine-client-js:1.9.0-SNAPSHOT.10`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -368,10 +368,10 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Jan 12 13:42:53 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 13 13:41:27 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
-#NPM dependencies of `spine-web@1.9.0-SNAPSHOT.9`
+#NPM dependencies of `spine-web@1.9.0-SNAPSHOT.10`
 
 ## `Production` dependencies:
 
@@ -405,7 +405,7 @@ This report was generated on **Thu Jan 12 13:42:53 WET 2023** using [Gradle-Lice
 1. **rxjs@6.5.5**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/reactivex/rxjs](https://github.com/reactivex/rxjs)
-1. **spine-web@1.9.0-SNAPSHOT.9**
+1. **spine-web@1.9.0-SNAPSHOT.10**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/SpineEventEngine/web](https://github.com/SpineEventEngine/web)
 1. **tr46@0.0.3**
@@ -1958,7 +1958,7 @@ This report was generated on **Thu Jan 12 13:42:53 WET 2023** using [Gradle-Lice
 1. **spdx-satisfies@4.0.1**
      * Licenses: MIT
      * Repository: [https://github.com/kemitchell/spdx-satisfies.js](https://github.com/kemitchell/spdx-satisfies.js)
-1. **spine-web@1.9.0-SNAPSHOT.9**
+1. **spine-web@1.9.0-SNAPSHOT.10**
      * Licenses: Apache-2.0
      * Repository: [https://github.com/SpineEventEngine/web](https://github.com/SpineEventEngine/web)
 1. **sprintf-js@1.0.3**
@@ -2140,12 +2140,12 @@ This report was generated on **Thu Jan 12 13:42:53 WET 2023** using [Gradle-Lice
      * Repository: [https://github.com/sindresorhus/yocto-queue](https://github.com/sindresorhus/yocto-queue)
 
 
-This report was generated on **Thu Jan 12 2023 13:42:54 GMT+0000 (Western European Standard Time)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
+This report was generated on **Fri Jan 13 2023 13:41:28 GMT+0000 (Western European Standard Time)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
 
 
 
     
-# Dependencies of `io.spine.gcloud:spine-firebase-web:1.9.0-SNAPSHOT.9`
+# Dependencies of `io.spine.gcloud:spine-firebase-web:1.9.0-SNAPSHOT.10`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson.core **Name:** jackson-annotations **Version:** 2.9.10
@@ -2932,12 +2932,12 @@ This report was generated on **Thu Jan 12 2023 13:42:54 GMT+0000 (Western Europe
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Jan 12 13:42:59 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 13 13:41:35 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-js-tests:1.9.0-SNAPSHOT.9`
+# Dependencies of `io.spine:spine-js-tests:1.9.0-SNAPSHOT.10`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -3327,12 +3327,12 @@ This report was generated on **Thu Jan 12 13:42:59 WET 2023** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Jan 12 13:43:04 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 13 13:41:40 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-test-app:1.9.0-SNAPSHOT.9`
+# Dependencies of `io.spine:spine-test-app:1.9.0-SNAPSHOT.10`
 
 ## Runtime
 1. **Group:** com.fasterxml.jackson.core **Name:** jackson-annotations **Version:** 2.9.10
@@ -4906,12 +4906,12 @@ This report was generated on **Thu Jan 12 13:43:04 WET 2023** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Jan 12 13:43:06 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 13 13:41:43 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-web:1.9.0-SNAPSHOT.9`
+# Dependencies of `io.spine:spine-testutil-web:1.9.0-SNAPSHOT.10`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -5370,12 +5370,12 @@ This report was generated on **Thu Jan 12 13:43:06 WET 2023** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Jan 12 13:43:08 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 13 13:41:45 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-web:1.9.0-SNAPSHOT.9`
+# Dependencies of `io.spine:spine-web:1.9.0-SNAPSHOT.10`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -5873,4 +5873,4 @@ This report was generated on **Thu Jan 12 13:43:08 WET 2023** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Jan 12 13:43:11 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 13 13:41:48 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -368,7 +368,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jan 13 13:41:27 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 27 17:43:52 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 #NPM dependencies of `spine-web@1.9.0-SNAPSHOT.10`
@@ -2140,7 +2140,7 @@ This report was generated on **Fri Jan 13 13:41:27 WET 2023** using [Gradle-Lice
      * Repository: [https://github.com/sindresorhus/yocto-queue](https://github.com/sindresorhus/yocto-queue)
 
 
-This report was generated on **Fri Jan 13 2023 13:41:28 GMT+0000 (Western European Standard Time)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
+This report was generated on **Fri Jan 27 2023 17:43:53 GMT+0000 (Western European Standard Time)** using [NPM License Checker](https://github.com/davglass/license-checker) library.
 
 
 
@@ -2932,7 +2932,7 @@ This report was generated on **Fri Jan 13 2023 13:41:28 GMT+0000 (Western Europe
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jan 13 13:41:35 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 27 17:43:59 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3327,7 +3327,7 @@ This report was generated on **Fri Jan 13 13:41:35 WET 2023** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jan 13 13:41:40 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 27 17:44:03 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4906,7 +4906,7 @@ This report was generated on **Fri Jan 13 13:41:40 WET 2023** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jan 13 13:41:43 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 27 17:44:05 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5370,7 +5370,7 @@ This report was generated on **Fri Jan 13 13:41:43 WET 2023** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jan 13 13:41:45 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 27 17:44:07 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5873,4 +5873,4 @@ This report was generated on **Fri Jan 13 13:41:45 WET 2023** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jan 13 13:41:48 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jan 27 17:44:10 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-web</artifactId>
-<version>1.9.0-SNAPSHOT.9</version>
+<version>1.9.0-SNAPSHOT.10</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,5 +29,5 @@ val spineTimeVersion: String by extra("1.9.0-SNAPSHOT.5")
 val spineCoreVersion: String by extra("1.9.0-SNAPSHOT.6")
 val spineVersion: String by extra(spineCoreVersion)
 
-val versionToPublish: String by extra("1.9.0-SNAPSHOT.9")
+val versionToPublish: String by extra("1.9.0-SNAPSHOT.10")
 val versionToPublishJs: String by extra(versionToPublish)

--- a/web/src/main/java/io/spine/web/subscription/BlockingSubscriptionService.java
+++ b/web/src/main/java/io/spine/web/subscription/BlockingSubscriptionService.java
@@ -94,8 +94,8 @@ public final class BlockingSubscriptionService {
             throw illegalStateWithCauseOf(error);
         } else {
             checkState(observer.isCompleted(),
-                       "Provided SubscriptionService implementation (`%s`) must complete `%s`" +
-                               " procedure at once.",
+                       "Provided `SubscriptionService` implementation (`%s`)" +
+                               " must complete `%s` procedure at once.",
                        subscriptionService,
                        SUBSCRIBE_METHOD_NAME);
         }


### PR DESCRIPTION
This PR addresses #188.

In particular, the following changes were made to the behaviour:

* Calling `unsubscribe` for any subscription now leads to an immediate cancellation on both client- and server-side. Previously, all such cancellations were only processed during the next "keep-up" propagation.

* `Client` now allows cancelling all known subscription via `cancelAllSubscriptions()` no-args call. Its invocation leads to sending the bulk cancellation request to server-side, as well as shutting down the client-level subscriptions.  Such an API is useful in case end-users choose to log out from the application.

Also, this PR aims to improve the server-side memory consumption. 

In particular, server-side holds a couple of internal registries to track active subscriptions. Previously, upon cancellation of a subscription, some of these registries were not affected, thus producing a memory leak. Now, each cancelled subscription is removed from all in-memory caches.

In future PRs there will be more updates to this repository, addressing the library updates available for both Java and client-side code.

The library version is set to `1.9.0-SNAPSHOT.10`.