### PR TITLE
[1.x] Improve `Subscription` cancellation

### DIFF
--- a/.github/workflows/publish-v1.yml
+++ b/.github/workflows/publish-v1.yml
@@ -70,7 +70,7 @@ jobs:
         # updated with the contents of 2.x branch. So this operation should be performed
         # manually, if really needed.
         # See https://github.com/SpineEventEngine/config/tree/master/scripts/publish-documentation.
-        run: ./gradlew publish -x test -x updateGitHubPages --stacktrace
+        run: ./gradlew publish -x test -x updateGitHubPages -x publishJs --stacktrace
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FORMAL_GIT_HUB_PAGES_AUTHOR: developers@spine.io


### PR DESCRIPTION
This changeset is meant to address a production-discovered issue related to `Subscription` cancellation.

See #202 for more details.

In this PR the way of `Subscription` cancellation was updated, so that all locally-known data about the cancelled-somewhere-else subscription is removed altogether.

Once this PR is merged, the codebase will still have the same `1.9.0` version. That is an intentional action, because we want to replace the existing 1.9.0 release version for end-user convenience — rather than advance every library of the framework to something like 1.9.1 and keep consistency.